### PR TITLE
fix(sonamu): typo error in build command

### DIFF
--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -11,7 +11,7 @@
   "exports": "./dist/index.js",
   "scripts": {
     "dev": "nodemon exec",
-    "build": "tsc --noEmit && swc src --config-file .swcrc -d dist --strip-leading-path"
+    "build": "tsc --noEmit && swc src --config-file .swcrc -d dist --strip-leading-paths"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
 - swc의 해당 옵션은 `--strip-leading-paths` 입니다. [[Reference]](https://swc.rs/docs/usage/cli#--strip-leading-paths)

## 이후 TODO

> 해당 내용은 제가 실행해보려고 하면서 찾은 문제들을 적어뒀습니다. 확인 부탁드릴게요.

1. `./example/miomock/api/start.sh`에서는 `yarn dev:start` 로 하는데 해당 커맨드가 없습니다. (`yarn dev:serve`로 실행하고 있습니다.)
2. `./example/miomock/api/`에서 `yarn build`를 실행하면 `build:aliases` 커맨드가 없어서 빌드가 안됩니다.