### PR TITLE
chore(miomock:web): zod v3으로 고정

### DIFF
--- a/examples/miomock/web/package.json
+++ b/examples/miomock/web/package.json
@@ -24,7 +24,7 @@
     "semantic-ui-css": "^2.5.0",
     "semantic-ui-react": "^2.1.5",
     "swr": "^2.3.6",
-    "zod": "^4.1.8"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.12",


### PR DESCRIPTION
`sonamu`와 `./examples/miomock/api`가 zod v3을 쓰고 있고, v4와는 호환되지 않는 부분이 있어서 zod v3으로 고정했습니다. zod v4에서는 `ZodArray`의 타입 파라미터에 Cardinality가 없어졌습니다.

## Reference
[zod v3](https://github.com/colinhacks/zod/blob/62bf4e439e287e55c843245b49f8d34b1ad024ee/packages/zod/src/v3/types.ts#L2236), [zod v4](https://github.com/colinhacks/zod/blob/2bed4b39760d8e4d678203b5c8fcaf24c182fc9f/packages/zod/src/v4/classic/schemas.ts#L1068)