### PR TITLE
[sonamu] syncer 트랜스파일 후 소스맵 주석 덧붙일 때 append 모드로 동작하도록 변경

### DIFF
--- a/modules/sonamu/src/syncer/syncer.ts
+++ b/modules/sonamu/src/syncer/syncer.ts
@@ -401,9 +401,8 @@ export class Syncer {
             mkdirSync(path.dirname(mapPath), { recursive: true });
             writeFileSync(mapPath, map);
 
-            const codeWithSourceMap =
-              code + "\n//# sourceMappingURL=" + path.basename(mapPath);
-            writeFileSync(jsPath, codeWithSourceMap);
+            const sourceMapComment = "\n//# sourceMappingURL=" + path.basename(mapPath);
+            writeFileSync(jsPath, sourceMapComment, { flag: "a"/*파일 끝에 붙이기만 해요*/ });
           }
 
           console.log(


### PR DESCRIPTION
## 개요

- **as-is**: `synced`에서 트랜스파일이 끝난 `code`를 `jsPath`에 작성하고, 이후에 `map`이 존재할 경우 `code`에다가 그 `map`의 존재를 알리는 source mapping URL 주석을 더한(`string` 덧셈) 페이로드를 다시 `jsPath`에 작성하고 있는데,
- **to-be**: 이때 전체 페이로드(`code` + source mapping URL 주석)를 다시 `jsPath`에 쓰지 않고, source mapping URL 주석 부분만 파일 끝에 덧붙이도록(`'a'`) 하였습니다.

## 왜?

최소한의 수정으로 아주 약간의 퍼포먼스 향상을 노려볼 수 있습니다.

## 예상되는 위험성

이 경우에는 딱히 떠오르지 않습니다.