### PR TITLE
fix(puri): Column 타입에 대한 개선

### DIFF
--- a/modules/sonamu/src/database/puri.ts
+++ b/modules/sonamu/src/database/puri.ts
@@ -9,6 +9,7 @@ import {
   ExtractColumnType,
   Expand,
   FulltextColumns,
+  FullColumnNames,
 } from "./puri.types";
 import chalk from "chalk";
 
@@ -291,10 +292,14 @@ export class Puri<
   }
 
   // Join
-  join<TJoinTable extends keyof TSchema>(
+  join<
+    TJoinTable extends keyof TSchema,
+    TLColumn extends FullColumnNames<TSchema, TTable>,
+    TRColumn extends FullColumnNames<TSchema, TJoinTable>,
+  >(
     table: TJoinTable,
-    left: string,
-    right: string
+    left: TLColumn,
+    right: TRColumn,
   ): Puri<
     TSchema,
     TTable,
@@ -349,10 +354,14 @@ export class Puri<
     return this as any;
   }
 
-  leftJoin<TJoinTable extends keyof TSchema>(
+  leftJoin<
+    TJoinTable extends keyof TSchema,
+    TLColumn extends FullColumnNames<TJoinTable, TSchema[TJoinTable]>,
+    TRColumn extends FullColumnNames<TTable, TResult>,
+  >(
     table: TJoinTable,
-    left: string,
-    right: string
+    left: TLColumn,
+    right: TRColumn,
   ): Puri<
     TSchema,
     TTable,


### PR DESCRIPTION
- `Puri#select(aliases: TSelect)`로 가져올 때 `TSelect`에서는 혼선을 방지하기 위해 Join 되었을 경우엔 alias 대상 컬럼에 무조건 `{table_name}.{column_name}`을 쓰도록 함.
- `Puri#join(table, left, right)`와 `Puri#leftJoin(table, left, right)`에서 컬럼(`left`, `right`) 이름을 추론할 수 있도록 개선함.
- `TJoined`의 타입이 기본적으로 `null`이어야 `TJoined extends Record` 등으로 타입 체크를 할 때, 바로 예외 처리가 가능해짐.

## Examples

```ts
    // Join 유무와 상관 없이 {table_name}.{column_name}
    const joinColumn: FullColumnNames<DatabaseSchemaExtend, "employees", {
      "departments": DatabaseSchemaExtend["departments"]
    }> = "departments.id";

    // Join이 있으면 무조건 {table_name}.{column_name} format만 가능하지만 Join이 없으면 {column_name} format을 쓸 수 있음.
    const test: AvailableColumns<DatabaseSchemaExtend, "employees", DatabaseSchemaExtend["employees"], {
      "departments": DatabaseSchemaExtend["departments"],
    }> = "employees.id";
    const testWithoutJoin: AvailableColumns<DatabaseSchemaExtend, "employees", DatabaseSchemaExtend["employees"]> = "id";

    // .select() 할 때 쓰는 SelectValue<...>에서도 마찬가지로 적용됨.
    const select: SelectValue<DatabaseSchemaExtend, "employees", DatabaseSchemaExtend["employees"], {
      "departments": DatabaseSchemaExtend["departments"],
    }> = "employees.id";
```