### PR TITLE
Fix/puri type

### DIFF
--- a/modules/sonamu/src/database/puri.ts
+++ b/modules/sonamu/src/database/puri.ts
@@ -7,6 +7,7 @@ import type {
   ExtractColumnType,
   FulltextColumns,
   InsertData,
+  MergeJoined,
   ParseSelectObject,
   ResultAvailableColumns,
   SelectObject,
@@ -303,7 +304,7 @@ export class Puri<
     TSchema,
     TTable,
     TResult,
-    TJoined & Record<TJoinTable, TSchema[TJoinTable]>
+    MergeJoined<TJoined, Record<TJoinTable, TSchema[TJoinTable]>>
   >;
   join<TJoinTable extends keyof TSchema>(
     table: TJoinTable,
@@ -314,7 +315,7 @@ export class Puri<
     TSchema,
     TTable,
     TResult,
-    TJoined & Record<TJoinTable, TSchema[TJoinTable]>
+    MergeJoined<TJoined, Record<TJoinTable, TSchema[TJoinTable]>>
   >;
   join<TSubResult, TAlias extends string>(
     subquery: Puri<TSchema, any, TSubResult, any>,

--- a/modules/sonamu/src/database/puri.types.ts
+++ b/modules/sonamu/src/database/puri.types.ts
@@ -3,7 +3,13 @@ export type Expand<T> = T extends any[]
   ? { [K in keyof T[0]]: T[0][K] }[] // 배열이면 첫 번째 요소를 Expand하고 배열로 감쌈
   : T extends object
     ? { [K in keyof T]: T[K] } & Record<string, never>
-    : T;
+  : T;
+    
+// EmptyRecord가 남아있으면 AvailableColumns 추론이 제대로 되지 않음 (EmptyRecord를 {}로 변경하면 정상 동작함)
+export type MergeJoined<TExisting, TNew> = 
+  TExisting extends EmptyRecord 
+    ? TNew  // 첫 join: EmptyRecord 제거하고 대체
+    : TExisting & TNew;  // 이후 join: 누적
 
 type DeepEqual<T, U> = [T] extends [U] ? [U] extends [T] ? true : false : false;
 type Extends<T, U> = DeepEqual<T, Record<string, never>> extends true ? false : (T extends U ? true : false);


### PR DESCRIPTION
### 1. having 컬럼 타입추론 오류 수정
column을 string으로 받는 시그니처 삭제

### 2. 조인이 존재하는 경우 조인테이블 컬럼 타입추론 동작하지 않는 이슈 수정
<img width="1326" height="536" alt="image" src="https://github.com/user-attachments/assets/c846308f-d779-4fa6-9c72-8876cb30954b" />
<img width="1406" height="520" alt="image" src="https://github.com/user-attachments/assets/e6d46147-a8ec-43ed-b068-3ea0abe49d26" />

조인 테이블 타입의 기본값인 `EmptyRecord`가 `{}`에서 `Record<string, never>`로 변경된 후에 조인테이블 타입이 제대로 추론되지 않음

조인을 수행하고 나면 TJoined는 `TJoined & Record<TJoinTable, TSchema[TJoinTable]>`로 설정됨
=> 첫 조인을 수행하면 `TJoined = EmptyRecord & Record<TJoinTable, TSchema[TJoinTable]>`

```ts
type TJoined = Record<string, never> & Record<"employees", {...}> // 
// 이것이 Record<string, any>를 extends 하는가?
// - Record<string, never>는 [key: string]: never
// - Record<"employees", ...>는 employees: {...}
// - 교집합: 두 조건을 모두 만족?
//   → employees는 never & {...} = ???

// 따라서 아래 구문이 제대로 평가되지 않아, `AvailableColumns`의 타입추론이 망가짐
Extends<TJoined, Record<string, any>> extends false
```

`EmptyRecord`를 `{}`로 되돌리면 간단하게 정상동작하나, `MergeJoined` 헬퍼 타입을 추가하여 조인테이블 타입이 `기본값 & TJoined` 처럼 기본값과의 교집합으로 표현되지 않도록 수정함