### PR TITLE
[sonamu] Puri - pluck 메서드 추가

### DIFF
--- a/examples/miomock/api/src/practices/p1-puri-example.ts
+++ b/examples/miomock/api/src/practices/p1-puri-example.ts
@@ -182,6 +182,50 @@ async function examples() {
 
   console.log(`Found ${specificUsers.length} users with specific roles`);
 
+  console.log("\n=== Example 7.5: Using pluck ===");
+  // 기본 컬럼 pluck - 특정 컬럼의 값들만 배열로 반환
+  const userIds = await db.table("users").where("role", "admin").pluck("id");
+
+  console.log(`Found ${userIds.length} admin user IDs:`, userIds);
+  assert(Array.isArray(userIds));
+  if (userIds.length > 0) {
+    assert(typeof userIds[0] === "number");
+    console.log("First user ID:", userIds[0]);
+  }
+
+  // 조인된 테이블 컬럼 pluck
+  const departmentNames = await db
+    .table("users")
+    .join("employees", "users.id", "employees.user_id")
+    .leftJoin("departments", "employees.department_id", "departments.id")
+    .where("users.role", "admin")
+    .pluck("departments.name");
+
+  console.log(
+    `Found ${departmentNames.length} department names:`,
+    departmentNames
+  );
+  assert(Array.isArray(departmentNames));
+  if (departmentNames.length > 0 && departmentNames[0] !== null) {
+    assert(typeof departmentNames[0] === "string");
+  }
+
+  // select로 선택된 컬럼 pluck
+  const usernames = await db
+    .table("users")
+    .select({
+      userId: "id",
+      userName: "username",
+    })
+    .where("role", "admin")
+    .pluck("userName");
+
+  console.log(`Found ${usernames.length} usernames:`, usernames);
+  assert(Array.isArray(usernames));
+  if (usernames.length > 0) {
+    assert(typeof usernames[0] === "string");
+  }
+
   console.log("\n=== Example 8: Transaction Example ===");
   await db.transaction(async (trx) => {
     // 트랜잭션 내에서 쿼리 실행

--- a/modules/sonamu/src/database/puri.ts
+++ b/modules/sonamu/src/database/puri.ts
@@ -559,6 +559,31 @@ export class Puri<
     return result;
   }
 
+  // Pluck
+  async pluck<
+    TColumn extends ResultAvailableColumns<
+      TSchema,
+      TTable,
+      TOriginal,
+      TResult,
+      TJoined
+    >,
+  >(
+    column: TColumn
+  ): Promise<
+    ExtractColumnType<TSchema, TTable, TColumn & string, TOriginal, TJoined>[]
+  > {
+    type Result = ExtractColumnType<
+      TSchema,
+      TTable,
+      TColumn & string,
+      TOriginal,
+      TJoined
+    >[];
+
+    return this.knexQuery.pluck(column) as Promise<Result>;
+  }
+
   // Insert/Update/Delete
   // TODO(Haze, 251030): InsertData<T>에서 nullable type을 제대로 처리하지 못하는 것 같음.
   async insert(


### PR DESCRIPTION
### 작업 내용

odb 프로젝트를 만들면서 knex.pluck 메서드를 사용하게 되었고, puri에는 해당 기능이 없어서 한번 작업해보았습니다.
(단일 컬럼 대상이어서 자주 사용될까 확실하지 않아서 연습삼아 한번 해보았는데, 급한건은 아니어서 천천히 확인해주셔도 괜찮습니다:))

**pluck(column) 란?**
 쿼리 결과에서 지정한 단일 컬럼의 값들만 뽑아서 배열로 반환하는 메서드 
- [knex 링크](https://knexjs.org/guide/query-builder.html#pluck)
- [knex 구현 방법 링크](https://github.dev/knex/knex)
```
.select('id') → [ { id:1 }, { id:2 } ]
.pluck('id') → [1, 2]
```


**사용 시 주의사항 및 팁** 
- 컬럼명은 타입 시스템으로 보호되어 TypeScript를 사용하면 존재하지 않는 컬럼을 컴파일 타임에 감지할 수 있음
- 다만 타입 단언(`as any`)을 사용하거나 동적으로 컬럼명을 생성하는 경우에는 주의가 필요
- `.pluck()` 는 단일 컬럼 대상. 두 개 이상 컬럼을 뽑고 싶다면 `.select()` 또는 `.map()` 등을 사용해야함
- `.pluck()` 는 쿼리를 실행하는 메서드이므로, 호출 후에는 Promise<배열>이 반환되어 `.pluck()` 이후에 `.select()` 나 다른 쿼리 빌더 메서드를 체이닝하는 것 불가능
- 반환된 배열에 행이 없으면 빈 배열이 됨

**miomock - practice 테스트 결과**
테스트 코드를 `p1-puri-example.ts` 에 넣었는데 따로 파일로 분리하는게 적절할까요?
<img width="320" height="87" alt="image" src="https://github.com/user-attachments/assets/08954109-b095-43ed-84f1-6bc1adcaa44d" />


- [x] merge 전 빌드 성공 확인