### PR TITLE
[miomock] fix: migrator의 트랜잭션 롤백 테스트에 약간의 개선을 추가해보았어요

### DIFF
--- a/examples/miomock/api/src/sonamu-test/__snapshots__/migrator.test.ts.snap
+++ b/examples/miomock/api/src/sonamu-test/__snapshots__/migrator.test.ts.snap
@@ -259,3 +259,27 @@ exports[`Migrator test > runAction > apply > 단일(test)DB에 마이그레이�
   },
 ]
 `;
+
+exports[`Migrator test > runAction() > rollback > 마지막 배치 롤백 1`] = `
+[
+  {
+    "applied": [
+      "20251124233609_foreign__project_tags__project_id_tag_id.ts",
+      "20251124233608_foreign__projects__employees__employee_id_project_id.ts",
+      "20251124233607_foreign__employees__user_id_department_id.ts",
+      "20251124233606_foreign__departments__company_id_parent_id.ts",
+      "20251124233605_create__project_tags.ts",
+      "20251124233604_create__projects__employees.ts",
+      "20251124233603_create__users.ts",
+      "20251124233602_create__tags.ts",
+      "20251124233601_create__projects.ts",
+      "20251124233600_create__files.ts",
+      "20251124233559_create__employees.ts",
+      "20251124233558_create__departments.ts",
+      "20251124233557_create__companies.ts",
+    ],
+    "batchNo": 1,
+    "connKey": "test",
+  },
+]
+`;

--- a/examples/miomock/api/src/sonamu-test/migrator.test.ts
+++ b/examples/miomock/api/src/sonamu-test/migrator.test.ts
@@ -1,4 +1,4 @@
-import { type EntityJson, EntityManager, Migrator, Naite, Sonamu } from "sonamu";
+import { type EntityJson, EntityManager, FixtureManager, Migrator, Naite, Sonamu } from "sonamu";
 import { afterEach, beforeAll, describe, expect, vi } from "vitest";
 import { bootstrap, test } from "../testing/bootstrap";
 
@@ -314,10 +314,54 @@ describe.skip("Migrator test", () => {
         // apply 전 runShadowTest 호출됨
       });
     });
-  });
 
-  // @TODO: DDL Transaction 이슈로 skip
-  describe.skip("rollback", () => {});
+    describe.only("rollback", () => {
+      afterEach(async () => {
+        // 테스트가 끝나고 나면 수습을 해줍니다.
+        // 테스트 suite가 롤백을 포함하다 보니, 테스트가 끝나면 데이터와 스키마가 모두 증발해버립니다.
+        // 따라서 테스트를 이어가기 위해서는 스키마부터 다시 건설해주어야 합니다.
+        // 그런 다음에 준비된 스키마 위에 fixture 데이터를 올려야 합니다.
+        await migrator.runAction("apply", ["test"]);
+        FixtureManager.init(); // 여러 번 호출해도 돼요.
+        await FixtureManager.sync();
+      });
+
+      test("마지막 배치 롤백", async () => {
+        // given: 롤백 전 상태
+        const statusBefore = await migrator.getStatus();
+        const testConnBefore = statusBefore.conns.find((c) => c.connKey === "test");
+        const pendingBefore = testConnBefore?.pending.length ?? 0;
+
+        // when: 롤백 실행
+        const result = await migrator.runAction("rollback", ["test"]);
+        Naite.expect("runAction:action").toBe("rollback");
+        Naite.expect("runAction:targets").toEqual(["test"]);
+        Naite.expect("runAction:result").toMatchSnapshot(); // 롤백 결과의 "applied" 배열에는 이번 롤백으로 인해 "down"된 마이그레이션의 이름들이 들어갑니다. 따라서 모두 롤백했다면 모든 (그동안 적용되었던) 마이그레이션의 이름들이 들어갑니다.
+
+        // then: 결과 검증
+        expect(result).toHaveLength(1);
+        expect(result[0]?.connKey).toBe("test");
+        expect(result[0]?.batchNo).toBeGreaterThanOrEqual(0);
+        expect(result[0]?.applied).toBeInstanceOf(Array);
+
+        // after: 롤백 후 상태
+        const statusAfter = await migrator.getStatus();
+        const testConnAfter = statusAfter.conns.find((c) => c.connKey === "test");
+        const pendingAfter = testConnAfter?.pending.length ?? 0;
+
+        // 롤백된 파일이 있으면 pending이 증가해야 함
+        if (result[0]?.applied && result[0].applied.length > 0) {
+          expect(testConnAfter?.pending.length).toBeGreaterThan(pendingBefore);
+        }
+
+        expect(pendingAfter).toBeGreaterThan(pendingBefore);
+      });
+
+      test("Shadow 테스트 미실행", async () => {
+        // rollback 시 runShadowTest 호출 안 됨
+      });
+    });
+  });
 
   describe.skip("delCodes", () => {
     test("pending 파일 삭제 성공", async () => {


### PR DESCRIPTION
롤백을 하면 다음 테스트에서 필요로 하는 스키마와 데이터가 사라지기 때문에 이를 해결하기 위해 `afterEach`를 두어 fixture를 sync하도록 했어요.

롤백을 테스트 대상에 넣으려면... 현재로서는 이 방법이 가장 먼저 떠올라서 제안드려봅니다.