### PR TITLE
[Nightly 2026-04-10] 문서 코드 예제의 this.db()/getPuri() 시그니처 오류 및 서버 시작 메시지 현행화 수정 (ko/en 24파일)

### DIFF
--- a/modules/docs/en/advanced-features/vector-search/chunking.mdx
+++ b/modules/docs/en/advanced-features/vector-search/chunking.mdx
@@ -296,7 +296,7 @@ async searchDocs(query: string, limit: number = 5) {
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
   // Search chunks
-  const chunks = await this.getPuri().raw(`
+  const chunks = await this.getPuri("r").raw(`
     SELECT
       c.id, c.parent_id, c.content, c.chunk_index,
       d.title,

--- a/modules/docs/en/advanced-features/vector-search/embeddings.mdx
+++ b/modules/docs/en/advanced-features/vector-search/embeddings.mdx
@@ -201,7 +201,7 @@ async search(query: string) {
   );
 
   // 2. Vector search (see vector-search.mdx)
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     SELECT title, content,
       1 - (embedding <=> ?) AS similarity
     FROM documents
@@ -370,7 +370,7 @@ async searchSimilar(query: string) {
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
   // Search similar documents
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     SELECT id, title, content,
       1 - (embedding <=> ?) AS similarity
     FROM knowledge_base

--- a/modules/docs/en/advanced-features/vector-search/hybrid-search.mdx
+++ b/modules/docs/en/advanced-features/vector-search/hybrid-search.mdx
@@ -12,7 +12,7 @@ You've built a product search API with Sonamu:
 async searchProducts(query: string) {
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     SELECT name, description,
       1 - (embedding <=> ?) AS similarity
     FROM products
@@ -150,7 +150,7 @@ class ProductModelClass extends BaseModelClass {
     const embedding = await Embedding.embedOne(query, "voyage", "query");
 
     // 2. Hybrid search SQL
-    const results = await this.getPuri().raw(
+    const results = await this.getPuri("r").raw(
       `
       WITH vector_results AS (
         SELECT
@@ -400,7 +400,7 @@ async searchProducts(
 
   params.push(limit);
 
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     WITH vector_results AS (
       SELECT
         id,

--- a/modules/docs/en/advanced-features/vector-search/pgvector-setup.mdx
+++ b/modules/docs/en/advanced-features/vector-search/pgvector-setup.mdx
@@ -78,7 +78,7 @@ class DocumentModelClass extends BaseModelClass {
   @api({ httpMethod: "POST" })
   async search(query: string) {
     // Write vector search SQL with Puri
-    const results = await this.getPuri().raw(`...`);
+    const results = await this.getPuri("r").raw(`...`);
     return results.rows;
   }
 }
@@ -428,7 +428,7 @@ class KnowledgeBaseModelClass extends BaseModelClass {
   @api({ httpMethod: "POST" })
   async search(query: string) {
     // See vector-search.mdx
-    const results = await this.getPuri().raw(`...`);
+    const results = await this.getPuri("r").raw(`...`);
     return results.rows;
   }
 }

--- a/modules/docs/en/advanced-features/vector-search/vector-search.mdx
+++ b/modules/docs/en/advanced-features/vector-search/vector-search.mdx
@@ -66,7 +66,7 @@ class DocumentModelClass extends BaseModelClass {
     );
 
     // 2. Write vector search SQL with Puri
-    const results = await this.getPuri().raw(
+    const results = await this.getPuri("r").raw(
       `
       SELECT
         id,
@@ -106,7 +106,7 @@ await this.findMany({
 });
 
 // Write SQL directly with Puri.raw()
-await this.getPuri().raw(`
+await this.getPuri("r").raw(`
   SELECT * FROM docs
   WHERE embedding <=> ? < 0.5
 `);
@@ -178,7 +178,7 @@ ORDER BY embedding <#> ?;
 
 ```typescript
 // Recommended: Cosine similarity
-const results = await this.getPuri().raw(
+const results = await this.getPuri("r").raw(
   `
   SELECT
     id, title, content,
@@ -205,7 +205,7 @@ async searchWithThreshold(
 ) {
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     SELECT
       id, title, content,
       1 - (embedding <=> ?) AS similarity
@@ -247,7 +247,7 @@ class KnowledgeBaseModelClass extends BaseModelClass {
     // Category filter (optional)
     const categoryFilter = category ? `AND category = '${category}'` : "";
 
-    const results = await this.getPuri().raw(
+    const results = await this.getPuri("r").raw(
       `
       SELECT
         id, title, content, category,
@@ -301,7 +301,7 @@ class ProductModelClass extends BaseModelClass {
     }
 
     // Search similar products (exclude self)
-    const results = await this.getPuri().raw(
+    const results = await this.getPuri("r").raw(
       `
       SELECT
         id, name, description, price,
@@ -390,7 +390,7 @@ async advancedSearch(
 
   params.push(limit);
 
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     SELECT
       id, title, content, category,
       1 - (embedding <=> ?) AS similarity,
@@ -418,7 +418,7 @@ async searchDocumentChunks(
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
   // Search by chunk (fetch more)
-  const chunks = await this.getPuri().raw(`
+  const chunks = await this.getPuri("r").raw(`
     SELECT
       id, parent_id, title, content, chunk_index,
       1 - (embedding <=> ?) AS similarity
@@ -486,7 +486,7 @@ USING hnsw (embedding vector_cosine_ops);
 ### Verify with EXPLAIN ANALYZE
 
 ```typescript
-const explain = await this.getPuri().raw(
+const explain = await this.getPuri("r").raw(
   `
   EXPLAIN ANALYZE
   SELECT id, title, 1 - (embedding <=> ?) AS similarity
@@ -521,8 +521,8 @@ SET LOCAL hnsw.ef_search = 100;  -- default: 40
 In Sonamu:
 
 ```typescript
-await this.getPuri().raw("SET LOCAL hnsw.ef_search = 100");
-const results = await this.getPuri().raw(`SELECT ...`);
+await this.getPuri("r").raw("SET LOCAL hnsw.ef_search = 100");
+const results = await this.getPuri("r").raw(`SELECT ...`);
 ```
 
 ## Benchmarks
@@ -577,7 +577,7 @@ const results = await this.getPuri().raw(`SELECT ...`);
 5. **Use Puri.raw()**: Cannot use Knex's wq
 
    ```typescript
-   await this.getPuri().raw(`SELECT ...`);
+   await this.getPuri("r").raw(`SELECT ...`);
    ```
 
 6. **Index creation timing**: After data

--- a/modules/docs/en/core-concepts/how-sonamu-works.mdx
+++ b/modules/docs/en/core-concepts/how-sonamu-works.mdx
@@ -165,14 +165,14 @@ class UserModelClass extends BaseModelClass<
   // CRUD API
   @api({ httpMethod: "GET", clients: ["axios", "tanstack-query"] })
   async findById<T extends UserSubsetKey>(subset: T, id: number): Promise<UserSubsetMapping[T]> {
-    const user = await this.db().where("id", id).first();
+    const user = await this.getPuri("r").where("id", id).first();
     return user;
   }
 
   // Custom business logic
   @api({ httpMethod: "POST", clients: ["axios"] })
   async changePassword(userId: number, newPassword: string): Promise<void> {
-    await this.db()
+    await this.getPuri("w")
       .where("id", userId)
       .update({ password: await this.hashPassword(newPassword) });
   }
@@ -315,7 +315,7 @@ Let's see how Sonamu works during actual development:
 ```typescript
 @api({ httpMethod: "GET" })
 async findById(id: number): Promise<Post> {
-  return await this.db().where("id", id).first();
+  return await this.getPuri("r").where("id", id).first();
 }
 ```
 **Auto-generated on save:**
@@ -438,7 +438,7 @@ type User = {
 
 // 3. Model method (type-safe)
 async findByEmail(email: string): Promise<User> {
-  return await this.db().where("email", email).first();
+  return await this.getPuri("r").where("email", email).first();
 }
 
 ↓

--- a/modules/docs/en/database/transactions/transactional-decorator.mdx
+++ b/modules/docs/en/database/transactions/transactional-decorator.mdx
@@ -446,7 +446,7 @@ async createUserComplex(data: UserSaveParams): Promise<number> {
 ## Important Notes
 
 <Warning>
-  **Must Follow**: 1. Method must be `async` function 2. Access DB with `this.getPuri()` 3.
+  **Must Follow**: 1. Method must be `async` function 2. Access DB with `this.getPuri("r" or "w")` 3.
   Propagate errors with throw (auto rollback) 4. Nested transactions share same context
 </Warning>
 

--- a/modules/docs/en/getting-started/development-workflow.mdx
+++ b/modules/docs/en/getting-started/development-workflow.mdx
@@ -225,7 +225,7 @@ class UserModelClass extends BaseModelClass<
     // Password change logic
     const hashedPassword = await this.hashPassword(newPassword);
 
-    await this.db().where("id", userId).update({ password: hashedPassword });
+    await this.getPuri("w").where("id", userId).update({ password: hashedPassword });
   }
 
   private async hashPassword(password: string): Promise<string> {
@@ -488,7 +488,7 @@ Add `like_count` field to Post entity
 ```typescript
 @api({ httpMethod: "POST", clients: ["axios"] })
 async addLike(postId: number): Promise<Post> {
-  await this.db()
+  await this.getPuri("w")
     .where("id", postId)
     .increment("like_count", 1);
   

--- a/modules/docs/en/getting-started/quick-start.mdx
+++ b/modules/docs/en/getting-started/quick-start.mdx
@@ -75,7 +75,12 @@ pnpm dev
 When the server starts successfully, you'll see the following message:
 
 ```
-🌲 Server listening on http://localhost:34900
+🌲 Sonamu v1.x.x
+
+✓ Config loaded (...)
+✓ DB
+  ▸ development_master @ localhost:5432/myapp
+✓ Sonamu ready (...)
 ```
 
 This single command runs everything:

--- a/modules/docs/en/troubleshooting/performance/caching-strategies.mdx
+++ b/modules/docs/en/troubleshooting/performance/caching-strategies.mdx
@@ -99,7 +99,7 @@ class UserModelClass extends BaseModelClass {
   // Cache for 5 minutes
   @cache({ ttl: "5m" })
   async getActiveUsersCount(): Promise<number> {
-    const result = await this.getPuri().select({ count: Puri.count() }).where({ status: "active" });
+    const result = await this.getPuri("r").select({ count: Puri.count() }).where({ status: "active" });
     return result[0].count;
   }
 }
@@ -112,19 +112,19 @@ class ProductModelClass extends BaseModelClass {
   // Cache for 1 hour
   @cache({ ttl: "1h" })
   async getFeaturedProducts() {
-    return this.getPuri().select("*").where({ featured: true });
+    return this.getPuri("r").select("*").where({ featured: true });
   }
 
   // Cache for 1 day
   @cache({ ttl: "1d" })
   async getCategoryCounts() {
-    return this.getPuri().select("category", knex.raw("COUNT(*) as count")).groupBy("category");
+    return this.getPuri("r").select("category", knex.raw("COUNT(*) as count")).groupBy("category");
   }
 
   // Permanent cache (requires manual invalidation)
   @cache({ ttl: 0 })
   async getProductCategories() {
-    return this.getPuri().select("DISTINCT category");
+    return this.getPuri("r").select("DISTINCT category");
   }
 }
 ```
@@ -144,7 +144,7 @@ class UserModelClass extends BaseModelClass {
   // Creates different cache entries per parameter
   @cache({ ttl: "5m" })
   async getUsersByStatus(status: string) {
-    return this.getPuri().select("id", "name", "email").where({ status });
+    return this.getPuri("r").select("id", "name", "email").where({ status });
   }
 }
 
@@ -162,7 +162,7 @@ class PostModelClass extends BaseModelClass {
     key: (userId: number, page: number) => `posts:user:${userId}:page:${page}`,
   })
   async getUserPosts(userId: number, page: number = 1) {
-    return this.getPuri()
+    return this.getPuri("r")
       .select("*")
       .where({ user_id: userId })
       .offset((page - 1) * 20)
@@ -330,7 +330,7 @@ class ProductModelClass extends BaseModelClass {
 class ProductModelClass extends BaseModelClass {
   // Warm popular products cache on server start
   async warmPopularProducts() {
-    const popularProducts = await this.getPuri()
+    const popularProducts = await this.getPuri("r")
       .select("*")
       .where({ featured: true })
       .orWhere("view_count", ">", 1000);
@@ -354,7 +354,7 @@ class PostModelClass extends BaseModelClass {
   @cache({ ttl: "10m" })
   @api({ httpMethod: "GET" })
   async listPosts(page: number = 1) {
-    return this.getPuri()
+    return this.getPuri("r")
       .select("id", "title", "author_id", "created_at")
       .orderBy("created_at", "desc")
       .offset((page - 1) * 20)
@@ -465,7 +465,7 @@ class AuthService {
 // Simplest - auto-expire with TTL
 @cache({ ttl: '5m' })  // Auto-expire after 5 minutes
 async getData() {
-  return this.getPuri();
+  return this.getPuri("r");
 }
 ```
 

--- a/modules/docs/en/troubleshooting/performance/n-plus-one-problems.mdx
+++ b/modules/docs/en/troubleshooting/performance/n-plus-one-problems.mdx
@@ -288,7 +288,7 @@ Use the DataLoader pattern when repeated queries are needed:
 class OrderModelClass extends BaseModelClass {
   // Orders loader by user
   private userOrdersLoader = new DataLoader(async (userIds: number[]) => {
-    const orders = await this.getPuri().select("*").whereIn("user_id", userIds);
+    const orders = await this.getPuri("r").select("*").whereIn("user_id", userIds);
 
     // Group by user_id
     const grouped = userIds.map((userId) => orders.filter((o) => o.user_id === userId));
@@ -324,7 +324,7 @@ class PostModelClass extends BaseModelClass {
   // N+1 occurring
   @api({ httpMethod: "GET" })
   async listPostsSlow() {
-    const posts = await this.getPuri().select("id", "title", "content");
+    const posts = await this.getPuri("r").select("id", "title", "content");
 
     // N+1 occurring!
     for (const post of posts) {

--- a/modules/docs/en/troubleshooting/performance/query-optimization.mdx
+++ b/modules/docs/en/troubleshooting/performance/query-optimization.mdx
@@ -311,7 +311,7 @@ import { cache } from "sonamu";
 class UserModelClass extends BaseModelClass {
   @cache({ ttl: "5m" }) // 5 minute cache
   async getActiveUsersCount(): Promise<number> {
-    const result = await this.getPuri().select({ count: Puri.count() }).where({ status: "active" });
+    const result = await this.getPuri("r").select({ count: Puri.count() }).where({ status: "active" });
     return result[0].count;
   }
 }
@@ -386,7 +386,7 @@ class UserModelClass extends BaseModelClass {
   async findActiveUsers() {
     const start = Date.now();
 
-    const users = await this.getPuri().select("*").where({ status: "active" });
+    const users = await this.getPuri("r").select("*").where({ status: "active" });
 
     const duration = Date.now() - start;
 

--- a/modules/docs/ko/advanced-features/vector-search/chunking.mdx
+++ b/modules/docs/ko/advanced-features/vector-search/chunking.mdx
@@ -296,7 +296,7 @@ async searchDocs(query: string, limit: number = 5) {
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
   // 청크 검색
-  const chunks = await this.getPuri().raw(`
+  const chunks = await this.getPuri("r").raw(`
     SELECT
       c.id, c.parent_id, c.content, c.chunk_index,
       d.title,

--- a/modules/docs/ko/advanced-features/vector-search/embeddings.mdx
+++ b/modules/docs/ko/advanced-features/vector-search/embeddings.mdx
@@ -201,7 +201,7 @@ async search(query: string) {
   );
 
   // 2. 벡터 검색 (vector-search.mdx 참고)
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     SELECT title, content,
       1 - (embedding <=> ?) AS similarity
     FROM documents
@@ -370,7 +370,7 @@ async searchSimilar(query: string) {
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
   // 유사 문서 검색
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     SELECT id, title, content,
       1 - (embedding <=> ?) AS similarity
     FROM knowledge_base

--- a/modules/docs/ko/advanced-features/vector-search/hybrid-search.mdx
+++ b/modules/docs/ko/advanced-features/vector-search/hybrid-search.mdx
@@ -12,7 +12,7 @@ Sonamu로 상품 검색 API를 만들었습니다:
 async searchProducts(query: string) {
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     SELECT name, description,
       1 - (embedding <=> ?) AS similarity
     FROM products
@@ -150,7 +150,7 @@ class ProductModelClass extends BaseModelClass {
     const embedding = await Embedding.embedOne(query, "voyage", "query");
 
     // 2. 하이브리드 검색 SQL
-    const results = await this.getPuri().raw(
+    const results = await this.getPuri("r").raw(
       `
       WITH vector_results AS (
         SELECT 
@@ -400,7 +400,7 @@ async searchProducts(
 
   params.push(limit);
 
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     WITH vector_results AS (
       SELECT
         id,

--- a/modules/docs/ko/advanced-features/vector-search/pgvector-setup.mdx
+++ b/modules/docs/ko/advanced-features/vector-search/pgvector-setup.mdx
@@ -78,7 +78,7 @@ class DocumentModelClass extends BaseModelClass {
   @api({ httpMethod: "POST" })
   async search(query: string) {
     // Puri로 벡터 검색 SQL 작성
-    const results = await this.getPuri().raw(`...`);
+    const results = await this.getPuri("r").raw(`...`);
     return results.rows;
   }
 }
@@ -392,7 +392,7 @@ class KnowledgeBaseModelClass extends BaseModelClass {
   @api({ httpMethod: "POST" })
   async search(query: string) {
     // vector-search.mdx 참고
-    const results = await this.getPuri().raw(`...`);
+    const results = await this.getPuri("r").raw(`...`);
     return results.rows;
   }
 }

--- a/modules/docs/ko/advanced-features/vector-search/vector-search.mdx
+++ b/modules/docs/ko/advanced-features/vector-search/vector-search.mdx
@@ -66,7 +66,7 @@ class DocumentModelClass extends BaseModelClass {
     );
 
     // 2. Puri로 벡터 검색 SQL 작성
-    const results = await this.getPuri().raw(
+    const results = await this.getPuri("r").raw(
       `
       SELECT 
         id,
@@ -106,7 +106,7 @@ await this.findMany({
 });
 
 // ✅ Puri.raw()로 SQL 직접 작성
-await this.getPuri().raw(`
+await this.getPuri("r").raw(`
   SELECT * FROM docs
   WHERE embedding <=> ? < 0.5
 `);
@@ -178,7 +178,7 @@ ORDER BY embedding <#> ?;
 
 ```typescript
 // ✅ 권장: 코사인 유사도
-const results = await this.getPuri().raw(
+const results = await this.getPuri("r").raw(
   `
   SELECT 
     id, title, content,
@@ -205,7 +205,7 @@ async searchWithThreshold(
 ) {
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     SELECT
       id, title, content,
       1 - (embedding <=> ?) AS similarity
@@ -247,7 +247,7 @@ class KnowledgeBaseModelClass extends BaseModelClass {
     // 카테고리 필터 (선택)
     const categoryFilter = category ? `AND category = '${category}'` : "";
 
-    const results = await this.getPuri().raw(
+    const results = await this.getPuri("r").raw(
       `
       SELECT 
         id, title, content, category,
@@ -301,7 +301,7 @@ class ProductModelClass extends BaseModelClass {
     }
 
     // 유사 상품 검색 (자기 자신 제외)
-    const results = await this.getPuri().raw(
+    const results = await this.getPuri("r").raw(
       `
       SELECT 
         id, name, description, price,
@@ -390,7 +390,7 @@ async advancedSearch(
 
   params.push(limit);
 
-  const results = await this.getPuri().raw(`
+  const results = await this.getPuri("r").raw(`
     SELECT
       id, title, content, category,
       1 - (embedding <=> ?) AS similarity,
@@ -418,7 +418,7 @@ async searchDocumentChunks(
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
   // 청크별 검색 (더 많이 가져옴)
-  const chunks = await this.getPuri().raw(`
+  const chunks = await this.getPuri("r").raw(`
     SELECT
       id, parent_id, title, content, chunk_index,
       1 - (embedding <=> ?) AS similarity
@@ -486,7 +486,7 @@ USING hnsw (embedding vector_cosine_ops);
 ### EXPLAIN ANALYZE로 확인
 
 ```typescript
-const explain = await this.getPuri().raw(
+const explain = await this.getPuri("r").raw(
   `
   EXPLAIN ANALYZE
   SELECT id, title, 1 - (embedding <=> ?) AS similarity
@@ -521,8 +521,8 @@ SET LOCAL hnsw.ef_search = 100;  -- 기본: 40
 Sonamu에서:
 
 ```typescript
-await this.getPuri().raw("SET LOCAL hnsw.ef_search = 100");
-const results = await this.getPuri().raw(`SELECT ...`);
+await this.getPuri("r").raw("SET LOCAL hnsw.ef_search = 100");
+const results = await this.getPuri("r").raw(`SELECT ...`);
 ```
 
 ## 벤치마크
@@ -577,7 +577,7 @@ const results = await this.getPuri().raw(`SELECT ...`);
 5. **Puri.raw() 사용**: Knex의 wq로는 안 됨
 
    ```typescript
-   await this.getPuri().raw(`SELECT ...`);
+   await this.getPuri("r").raw(`SELECT ...`);
    ```
 
 6. **인덱스 생성 시점**: 데이터 후

--- a/modules/docs/ko/core-concepts/how-sonamu-works.mdx
+++ b/modules/docs/ko/core-concepts/how-sonamu-works.mdx
@@ -164,14 +164,14 @@ class UserModelClass extends BaseModelClass<
   // CRUD API
   @api({ httpMethod: "GET", clients: ["axios", "tanstack-query"] })
   async findById<T extends UserSubsetKey>(subset: T, id: number): Promise<UserSubsetMapping[T]> {
-    const user = await this.db().where("id", id).first();
+    const user = await this.getPuri("r").where("id", id).first();
     return user;
   }
 
   // 커스텀 비즈니스 로직
   @api({ httpMethod: "POST", clients: ["axios"] })
   async changePassword(userId: number, newPassword: string): Promise<void> {
-    await this.db()
+    await this.getPuri("w")
       .where("id", userId)
       .update({ password: await this.hashPassword(newPassword) });
   }
@@ -354,7 +354,7 @@ export class UserService {
 ```typescript
 @api({ httpMethod: "GET" })
 async findById(id: number): Promise<Post> {
-  return await this.db().where("id", id).first();
+  return await this.getPuri("r").where("id", id).first();
 }
 ```
 **저장 시 자동 생성:**
@@ -497,7 +497,7 @@ type User = {
 
 // 3. Model 메서드 (타입 안전)
 async findByEmail(email: string): Promise<User> {
-  return await this.db().where("email", email).first();
+  return await this.getPuri("r").where("email", email).first();
 }
 
 ↓

--- a/modules/docs/ko/database/transactions/transactional-decorator.mdx
+++ b/modules/docs/ko/database/transactions/transactional-decorator.mdx
@@ -662,7 +662,7 @@ async createUserComplex(data: UserSaveParams): Promise<number> {
 ## 주의사항
 
 <Warning>
-  **반드시 지켜야 할 사항**: 1. 메서드는 `async` 함수여야 함 2. `this.getPuri()`로 DB 접근 3. 에러는
+  **반드시 지켜야 할 사항**: 1. 메서드는 `async` 함수여야 함 2. `this.getPuri("r"/"w")`로 DB 접근 3. 에러는
   throw로 전파 (자동 롤백) 4. 중첩 트랜잭션은 같은 컨텍스트 공유
 </Warning>
 

--- a/modules/docs/ko/getting-started/development-workflow.mdx
+++ b/modules/docs/ko/getting-started/development-workflow.mdx
@@ -242,7 +242,7 @@ class UserModelClass extends BaseModelClass<
     // 비밀번호 변경 로직
     const hashedPassword = await this.hashPassword(newPassword);
 
-    await this.db().where("id", userId).update({ password: hashedPassword });
+    await this.getPuri("w").where("id", userId).update({ password: hashedPassword });
   }
 
   private async hashPassword(password: string): Promise<string> {
@@ -523,7 +523,7 @@ Post 엔티티에 `like_count` 필드 추가
 ```typescript
 @api({ httpMethod: "POST", clients: ["axios"] })
 async addLike(postId: number): Promise<Post> {
-  await this.db()
+  await this.getPuri("w")
     .where("id", postId)
     .increment("like_count", 1);
   

--- a/modules/docs/ko/getting-started/quick-start.mdx
+++ b/modules/docs/ko/getting-started/quick-start.mdx
@@ -75,7 +75,12 @@ pnpm dev
 서버가 성공적으로 시작되면 다음과 같은 메시지가 표시됩니다:
 
 ```
-🌲 Server listening on http://localhost:34900
+🌲 Sonamu v1.x.x
+
+✓ Config loaded (...)
+✓ DB
+  ▸ development_master @ localhost:5432/myapp
+✓ Sonamu ready (...)
 ```
 
 이 명령어 하나로 다음이 모두 실행됩니다:

--- a/modules/docs/ko/troubleshooting/performance/caching-strategies.mdx
+++ b/modules/docs/ko/troubleshooting/performance/caching-strategies.mdx
@@ -99,7 +99,7 @@ class UserModelClass extends BaseModelClass {
   // 5분간 캐싱
   @cache({ ttl: "5m" })
   async getActiveUsersCount(): Promise<number> {
-    const result = await this.getPuri().select({ count: Puri.count() }).where({ status: "active" });
+    const result = await this.getPuri("r").select({ count: Puri.count() }).where({ status: "active" });
     return result[0].count;
   }
 }
@@ -112,19 +112,19 @@ class ProductModelClass extends BaseModelClass {
   // 1시간 캐싱
   @cache({ ttl: "1h" })
   async getFeaturedProducts() {
-    return this.getPuri().select("*").where({ featured: true });
+    return this.getPuri("r").select("*").where({ featured: true });
   }
 
   // 1일 캐싱
   @cache({ ttl: "1d" })
   async getCategoryCounts() {
-    return this.getPuri().select("category", knex.raw("COUNT(*) as count")).groupBy("category");
+    return this.getPuri("r").select("category", knex.raw("COUNT(*) as count")).groupBy("category");
   }
 
   // 영구 캐싱 (수동 무효화 필요)
   @cache({ ttl: 0 })
   async getProductCategories() {
-    return this.getPuri().select("DISTINCT category");
+    return this.getPuri("r").select("DISTINCT category");
   }
 }
 ```
@@ -144,7 +144,7 @@ class UserModelClass extends BaseModelClass {
   // 파라미터별로 다른 캐시 생성
   @cache({ ttl: "5m" })
   async getUsersByStatus(status: string) {
-    return this.getPuri().select("id", "name", "email").where({ status });
+    return this.getPuri("r").select("id", "name", "email").where({ status });
   }
 }
 
@@ -162,7 +162,7 @@ class PostModelClass extends BaseModelClass {
     key: (userId: number, page: number) => `posts:user:${userId}:page:${page}`,
   })
   async getUserPosts(userId: number, page: number = 1) {
-    return this.getPuri()
+    return this.getPuri("r")
       .select("*")
       .where({ user_id: userId })
       .offset((page - 1) * 20)
@@ -330,7 +330,7 @@ class ProductModelClass extends BaseModelClass {
 class ProductModelClass extends BaseModelClass {
   // 서버 시작 시 인기 상품 캐시 워밍
   async warmPopularProducts() {
-    const popularProducts = await this.getPuri()
+    const popularProducts = await this.getPuri("r")
       .select("*")
       .where({ featured: true })
       .orWhere("view_count", ">", 1000);
@@ -354,7 +354,7 @@ class PostModelClass extends BaseModelClass {
   @cache({ ttl: "10m" })
   @api({ httpMethod: "GET" })
   async listPosts(page: number = 1) {
-    return this.getPuri()
+    return this.getPuri("r")
       .select("id", "title", "author_id", "created_at")
       .orderBy("created_at", "desc")
       .offset((page - 1) * 20)
@@ -465,7 +465,7 @@ class AuthService {
 // 가장 간단 - TTL로 자동 만료
 @cache({ ttl: '5m' })  // 5분 후 자동 만료
 async getData() {
-  return this.getPuri();
+  return this.getPuri("r");
 }
 ```
 

--- a/modules/docs/ko/troubleshooting/performance/n-plus-one-problems.mdx
+++ b/modules/docs/ko/troubleshooting/performance/n-plus-one-problems.mdx
@@ -288,7 +288,7 @@ async function getUsersWithOrders() {
 class OrderModelClass extends BaseModelClass {
   // 사용자별 주문 로더
   private userOrdersLoader = new DataLoader(async (userIds: number[]) => {
-    const orders = await this.getPuri().select("*").whereIn("user_id", userIds);
+    const orders = await this.getPuri("r").select("*").whereIn("user_id", userIds);
 
     // user_id별로 그룹화
     const grouped = userIds.map((userId) => orders.filter((o) => o.user_id === userId));
@@ -324,7 +324,7 @@ class PostModelClass extends BaseModelClass {
   // ❌ N+1 발생
   @api({ httpMethod: "GET" })
   async listPostsSlow() {
-    const posts = await this.getPuri().select("id", "title", "content");
+    const posts = await this.getPuri("r").select("id", "title", "content");
 
     // N+1 발생!
     for (const post of posts) {

--- a/modules/docs/ko/troubleshooting/performance/query-optimization.mdx
+++ b/modules/docs/ko/troubleshooting/performance/query-optimization.mdx
@@ -311,7 +311,7 @@ import { cache } from "sonamu";
 class UserModelClass extends BaseModelClass {
   @cache({ ttl: "5m" }) // 5분 캐싱
   async getActiveUsersCount(): Promise<number> {
-    const result = await this.getPuri().select({ count: Puri.count() }).where({ status: "active" });
+    const result = await this.getPuri("r").select({ count: Puri.count() }).where({ status: "active" });
     return result[0].count;
   }
 }
@@ -386,7 +386,7 @@ class UserModelClass extends BaseModelClass {
   async findActiveUsers() {
     const start = Date.now();
 
-    const users = await this.getPuri().select("*").where({ status: "active" });
+    const users = await this.getPuri("r").select("*").where({ status: "active" });
 
     const duration = Date.now() - start;
 


### PR DESCRIPTION
이 PR은 AI(Claude Code)에 의해 자동 생성된 Nightly PR입니다.
코드베이스의 ownership은 전적으로 maintainer에게 있으며, 이 PR은 검토 후 판단을 돕기 위한 제안입니다.

## 어떤 issue를 참조했으며, 왜 이 작업을 선정했나요?

[#44 - 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44)을 참조했습니다.

Issue #44의 범위 중:
> 문서와 주석이 코드와 어긋나는 경우 -> 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다.

기존 Nightly PR들(#124~#146)의 description과 comment를 모두 확인하였으며, 이 건들은 이전에 조치되거나 보류된 적이 없는 문제입니다.

## 무엇이 문제인가요?

### 1. `this.db()` 메서드 호출 오류 (ko 2파일 + en 2파일, 12곳)

`BaseModelClass`에는 `this.db()`라는 메서드가 존재하지 않습니다. 실제 API는 다음과 같습니다:

- `this.getPuri(which: DBPreset)` — PuriWrapper 반환 (일반적 사용)
- `this.getDB(which: DBPreset)` — 원시 Knex 반환

그러나 아래 문서들에서 존재하지 않는 `this.db()`를 사용하여, 문서를 따라 코드를 작성하면 컴파일 에러가 발생합니다:

- `ko/core-concepts/how-sonamu-works.mdx` — 4곳 오류
- `en/core-concepts/how-sonamu-works.mdx` — 4곳 오류
- `ko/getting-started/development-workflow.mdx` — 2곳 오류
- `en/getting-started/development-workflow.mdx` — 2곳 오류

### 2. `getPuri()` 필수 파라미터 누락 오류 (ko 10파일 + en 10파일, ~60곳)

`getPuri(which: DBPreset)`의 `which` 파라미터는 필수(`"r"` 또는 `"w"`)이지만, 아래 문서들에서 파라미터 없이 `this.getPuri()`로 호출하고 있었습니다:

**벡터 검색 문서 (ko/en 각 5파일):**
- `vector-search/vector-search.mdx` — ko 12곳, en 12곳
- `vector-search/hybrid-search.mdx` — ko 3곳, en 3곳
- `vector-search/pgvector-setup.mdx` — ko 2곳, en 2곳
- `vector-search/embeddings.mdx` — ko 2곳, en 2곳
- `vector-search/chunking.mdx` — ko 1곳, en 1곳

**성능 최적화 문서 (ko/en 각 3파일):**
- `troubleshooting/performance/caching-strategies.mdx` — ko 9곳, en 9곳
- `troubleshooting/performance/n-plus-one-problems.mdx` — ko 2곳, en 2곳
- `troubleshooting/performance/query-optimization.mdx` — ko 2곳, en 2곳

**트랜잭션 문서 (ko/en 각 1파일, prose 언급):**
- `database/transactions/transactional-decorator.mdx` — ko 1곳, en 1곳

참고: `ko/api-reference/base-model/get-puri.mdx`의 getPuri() API 문서는 파라미터를 정확히 기술하고 있었으나, 나머지 튜토리얼 문서들은 파라미터가 빠져 있었습니다.

### 3. `quick-start.mdx` 서버 시작 메시지 outdated (ko 1파일 + en 1파일)

최근 커밋(8b2f5ecc, e6ff513d)에서 서버 시작 로그가 `printStartupSummary()`로 통합 정리되었으나, quick-start.mdx의 출력 예시가 이전 형식 그대로 남아 있었습니다:

- 이전: `🌲 Server listening on http://localhost:34900`
- 현재: `🌲 Sonamu v{version}` 배너 + Config/DB/Auth/Timezone/Ready 요약 출력

## 어떤 접근 방식을 왜 채택했나요?

실제 소스 코드의 시그니처를 기준으로 문서를 수정했습니다:

- `getPuri()`: `modules/sonamu/src/database/base-model.ts:58` — `getPuri(which: DBPreset)`
- 읽기 작업(SELECT, raw query 등)은 `this.getPuri("r")`, 쓰기 작업(UPDATE, INSERT 등)은 `this.getPuri("w")` 사용
- `this.db()` → 읽기 맥락에서는 `this.getPuri("r")`, 쓰기 맥락에서는 `this.getPuri("w")`로 변경
- 서버 시작 메시지는 `cli.ts`의 `dev_all()`과 `sonamu.ts`의 `printStartupSummary()` 구현을 기반으로 수정

## 이렇게 하지 않으면 어떤 점이 안 좋은지

- `this.db()` 예제를 따라 코드를 작성하면 `TypeError: this.db is not a function` 런타임 에러 발생
- `this.getPuri()` 예제를 따라 코드를 작성하면 `Expected 1 arguments, but got 0` TypeScript 컴파일 에러 발생
- 특히 벡터 검색 문서는 pgvector 도입을 시도하는 개발자가 가장 먼저 참조하는 문서로, 모든 코드 예제가 컴파일되지 않으면 도입 경험에 큰 차질이 생김

## 이 변경이 어떤 기능에 영향을 미치는지

문서만 변경했으며 소스 코드 변경은 없습니다. 기능에 영향 없음.

## 이 변경이 미치는 영향을 바로 확인하는 구체적인 방법

1. 변경된 `.mdx` 파일의 코드 블록을 `this.getPuri("r")`로 검색하여 파라미터가 올바르게 포함되어 있는지 확인
2. `this.db()`와 파라미터 없는 `this.getPuri()`가 문서 전체에서 더 이상 나타나지 않는지 grep 확인
3. `pnpm check` 통과 확인 (0 에러, 260 기존 경고)
4. `pnpm build` 성공 확인

## 검토 필요 사항

- `quick-start.mdx`의 서버 시작 출력 예시를 일반화된 형태(`v1.x.x`, `(...)`)로 작성했습니다. 실제 서버를 구동하여 출력 형식이 정확히 일치하는지 확인이 필요할 수 있습니다.
- 트랜잭션 문서의 prose 언급(`this.getPuri("r"/"w")`로 DB 접근)은 간략한 가이드라인 형태인데, 이 표현이 맥락에 적합한지 검토가 필요합니다.