### PR TITLE
[Nightly 2026-04-13] 문서 코드 예제의 this.puri() 및 .many() 미존재 API 호출 오류 수정 (ko/en 18파일, 46개소)

### DIFF
--- a/modules/docs/en/core-concepts/auto-generation/customizing-generated-code.mdx
+++ b/modules/docs/en/core-concepts/auto-generation/customizing-generated-code.mdx
@@ -295,7 +295,7 @@ class UserModelClass extends BaseModelClass {
   // ✅ Add custom methods (safe)
   @api({ httpMethod: "POST", clients: ["axios", "tanstack-mutation"] })
   async login(params: UserLoginParams): Promise<{ user: User; token: string }> {
-    const user = await this.puri().where("email", params.email).first();
+    const user = await this.getPuri("r").from("users").where("email", params.email).first();
 
     if (!user) {
       throw new UnauthorizedException("Email or password does not match");
@@ -320,7 +320,7 @@ class UserModelClass extends BaseModelClass {
 
   // Internal helper method (no @api)
   async findByEmail(email: string): Promise<User | null> {
-    return this.puri().where("email", email).first();
+    return this.getPuri("r").from("users").where("email", email).first();
   }
 }
 ```

--- a/modules/docs/en/core-concepts/entity/defining-entities.mdx
+++ b/modules/docs/en/core-concepts/entity/defining-entities.mdx
@@ -173,10 +173,12 @@ Defines field combinations for API responses.
 
 <CodeGroup>
 ```typescript title="Usage in Model"
-async findAll(): Promise<UserSubsetA[]> {
-  return this.puri()
-    .select<UserSubsetA>("A")
-    .many();
+async findMany<T extends UserSubsetKey>(
+  subset: T,
+  params: UserListParams,
+): Promise<ListResult<UserSubsetMapping[T]>> {
+  const { qb } = this.getSubsetQueries(subset);
+  return this.executeSubsetQuery({ subset, qb, params });
 }
 ```
 

--- a/modules/docs/en/core-concepts/entity/enums.mdx
+++ b/modules/docs/en/core-concepts/entity/enums.mdx
@@ -183,10 +183,10 @@ export class UserModel extends BaseModelClass {
   @api({ httpMethod: "POST" })
   async updateRole(userId: number, role: UserRole) {
     // role is type-safe
-    await this.puri()
+    await this.getPuri("w").from("users")
       .where("id", userId)
       .update({ role });
-      
+
     return { success: true };
   }
 }
@@ -253,9 +253,8 @@ Define sorting options.
 ```typescript
 async findAll(orderBy: UserOrderBy = "id-desc") {
   const [field, direction] = orderBy.split("-");
-  return this.puri()
-    .orderBy(field, direction as "asc" | "desc")
-    .many();
+  return this.getPuri("r").from("users")
+    .orderBy(field, direction as "asc" | "desc");
 }
 ```
 
@@ -279,9 +278,8 @@ Define searchable fields.
 
 ```typescript
 async search(field: UserSearchField, keyword: string) {
-  return this.puri()
-    .whereLike(field, `%${keyword}%`)
-    .many();
+  return this.getPuri("r").from("users")
+    .whereLike(field, `%${keyword}%`);
 }
 ```
 
@@ -306,7 +304,7 @@ Define statuses.
 
 ```typescript
 async publish(postId: number) {
-  await this.puri()
+  await this.getPuri("w").from("posts")
     .where("id", postId)
     .update({ status: "published" });
 }
@@ -380,10 +378,10 @@ function hasPermission(user: User, permission: Permission): boolean {
 async grantPermission(userId: number, permission: Permission) {
   const user = await this.findById(userId);
   if (!user.permissions.includes(permission)) {
-    await this.puri()
+    await this.getPuri("w").from("users")
       .where("id", userId)
       .update({
-        permissions: [...user.permissions, permission]
+        permissions: [...user.permissions, permission],
       });
   }
 }

--- a/modules/docs/en/core-concepts/entity/field-types.mdx
+++ b/modules/docs/en/core-concepts/entity/field-types.mdx
@@ -652,14 +652,11 @@ Virtual fields not stored in the database.
     Calculated with SQL using Puri query's appendSelect.
     
     ```typescript
-    // {entity}.model.ts
-    async findAll() {
-      return this.puri()
-        .appendSelect({
-          full_name: this.puri().knex.raw("first_name || ' ' || last_name")
-        })
-        .many();
-    }
+    // Used in {entity}.model.ts subset queries
+    const { qb } = this.getSubsetQueries(subset);
+    qb.appendSelect({
+      full_name: this.getPuri("r").raw("first_name || ' ' || last_name"),
+    });
     ```
     
     **Pros**: Database-level calculation, can filter/sort
@@ -719,11 +716,14 @@ Type for storing vector embeddings. Requires pgvector extension.
 ```typescript
 // Search by cosine similarity
 async searchSimilar(queryEmbedding: number[]) {
-  return this.puri()
-    .whereRaw("embedding <=> ?", [JSON.stringify(queryEmbedding)])
-    .orderByRaw("embedding <=> ?", [JSON.stringify(queryEmbedding)])
-    .limit(10)
-    .many();
+  const results = await this.getPuri("r").raw(`
+    SELECT id, content,
+      1 - (embedding <=> ?) AS similarity
+    FROM documents
+    ORDER BY embedding <=> ?
+    LIMIT 10
+  `, [JSON.stringify(queryEmbedding), JSON.stringify(queryEmbedding)]);
+  return results.rows;
 }
 ```
 

--- a/modules/docs/en/core-concepts/entity/relations.mdx
+++ b/modules/docs/en/core-concepts/entity/relations.mdx
@@ -108,13 +108,11 @@ Sonamu supports 4 Relation types:
 <CodeGroup>
 ```typescript title="Query"
 // Include relation in Subset
-const posts = await this.puri()
-  .select<PostSubsetA>("A")
-  .many();
+const { qb } = this.getSubsetQueries("A");
+const result = await this.executeSubsetQuery({ subset: "A", qb, params });
 
-// Can access posts[0].user.username
-
-````
+// Can access result.rows[0].user.username
+```
 
 ```typescript title="Type (auto-generated)"
 type PostSubsetA = {
@@ -321,10 +319,11 @@ type UserSubsetA = {
 ```
 
 ```typescript title="Query"
-const users = await this.puri().select<UserSubsetA>("A").many();
+const { qb } = this.getSubsetQueries("A");
+const result = await this.executeSubsetQuery({ subset: "A", qb, params });
 
-// users[0].posts is an array
-console.log(users[0].posts.length);
+// result.rows[0].posts is an array
+console.log(result.rows[0].posts.length);
 ```
 
 </CodeGroup>
@@ -440,10 +439,11 @@ type PostSubsetA = {
 ```
 
 ```typescript title="Query"
-const posts = await this.puri().select<PostSubsetA>("A").many();
+const { qb } = this.getSubsetQueries("A");
+const result = await this.executeSubsetQuery({ subset: "A", qb, params });
 
-// posts[0].tags is an array
-posts[0].tags.forEach((tag) => {
+// result.rows[0].tags is an array
+result.rows[0].tags.forEach((tag) => {
   console.log(tag.name);
 });
 ```
@@ -508,19 +508,18 @@ LEFT JOIN departments ON employees.department_id = departments.id
 
 <CodeGroup>
 ```typescript title="BelongsToOne Filter"
-const posts = await this.puri()
-  .where("user.role", "admin")
-  .many();
+const { qb } = this.getSubsetQueries("A");
+qb.where("user.role", "admin");
+const result = await this.executeSubsetQuery({ subset: "A", qb, params });
 ```
 
 ```typescript title="HasMany Filter"
 // HasMany included in Subset cannot be filtered
 // Use separate query instead
 const user = await UserModel.findById(userId);
-const activePosts = await PostModel.puri()
+const activePosts = await PostModel.getPuri("r").from("posts")
   .where("user_id", userId)
-  .where("status", "active")
-  .many();
+  .where("status", "active");
 ```
 
 </CodeGroup>
@@ -528,7 +527,9 @@ const activePosts = await PostModel.puri()
 ### 4. Sorting by Relations
 
 ```typescript
-const posts = await this.puri().orderBy("user.username", "asc").many();
+const { qb } = this.getSubsetQueries("A");
+qb.orderBy("user.username", "asc");
+const result = await this.executeSubsetQuery({ subset: "A", qb, params });
 ```
 
 ## Relation Design Guide

--- a/modules/docs/en/core-concepts/model/basemodel-methods.mdx
+++ b/modules/docs/en/core-concepts/model/basemodel-methods.mdx
@@ -91,8 +91,7 @@ async findActive(): Promise<User[]> {
   return rdb
     .table("users")
     .where("is_active", true)
-    .orderBy("created_at", "desc")
-    .many();
+    .orderBy("created_at", "desc");
 }
 ```
 

--- a/modules/docs/en/core-concepts/model/business-logic.mdx
+++ b/modules/docs/en/core-concepts/model/business-logic.mdx
@@ -40,7 +40,7 @@ class UserModelClass extends BaseModelClass {
         throw new BadRequestException("Users under 18 cannot register");
       }
       
-      const existing = await this.puri()
+      const existing = await this.getPuri("r").from("users")
         .where("email", param.email)
         .first();
         
@@ -133,9 +133,9 @@ async createUserWithProfile(
 async save(params: UserSaveParams[]): Promise<number[]> {
   // Email duplicate check
   for (const param of params) {
-    const existing = await this.puri()
+    const existing = await this.getPuri("r").from("users")
       .where("email", param.email)
-      .whereNot("id", param.id ?? 0)  // Exclude self when updating
+      .where("id", "!=", param.id ?? 0)  // Exclude self when updating
       .first();
 
     if (existing) {
@@ -482,7 +482,7 @@ async innerTransaction(): Promise<void> {
 
 ```typescript
 async login(params: LoginParams): Promise<{ user: User }> {
-  const user = await this.puri()
+  const user = await this.getPuri("r").from("users")
     .where("email", params.email)
     .first();
 

--- a/modules/docs/en/core-concepts/model/what-is-model.mdx
+++ b/modules/docs/en/core-concepts/model/what-is-model.mdx
@@ -134,7 +134,7 @@ export type UserSubsetA = User;
 class UserModelClass extends BaseModelClass {
   async findById(id: number): Promise<User> {
     // Business logic
-    const user = await this.puri().where("id", id).first();
+    const user = await this.getPuri("r").from("users").where("id", id).first();
     return user;
   }
 }
@@ -337,7 +337,7 @@ class UserModelClass extends BaseModelClass {
     ```typescript
     // Model method
     async findActiveUsers(): Promise<User[]> {
-      return this.puri().where("is_active", true).many();
+      return this.getPuri("r").from("users").where("is_active", true);
     }
     
     // Reuse in multiple APIs

--- a/modules/docs/en/database/subsets/using-subsets.mdx
+++ b/modules/docs/en/database/subsets/using-subsets.mdx
@@ -336,8 +336,7 @@ const users = await puri
     employee__salary: "employees.salary",
     employee__department__name: "departments.name",
   })
-  .where("users.role", "admin")
-  .many();
+  .where("users.role", "admin");
 
 // Type: { id: number; username: string; ... }[]
 // JOIN manual configuration

--- a/modules/docs/ko/core-concepts/auto-generation/customizing-generated-code.mdx
+++ b/modules/docs/ko/core-concepts/auto-generation/customizing-generated-code.mdx
@@ -295,7 +295,7 @@ class UserModelClass extends BaseModelClass {
   // ✅ 커스텀 메서드 추가 (안전)
   @api({ httpMethod: "POST", clients: ["axios", "tanstack-mutation"] })
   async login(params: UserLoginParams): Promise<{ user: User; token: string }> {
-    const user = await this.puri().where("email", params.email).first();
+    const user = await this.getPuri("r").from("users").where("email", params.email).first();
 
     if (!user) {
       throw new UnauthorizedException("이메일 또는 비밀번호가 일치하지 않습니다");
@@ -320,7 +320,7 @@ class UserModelClass extends BaseModelClass {
 
   // 내부 헬퍼 메서드 (@api 없음)
   async findByEmail(email: string): Promise<User | null> {
-    return this.puri().where("email", email).first();
+    return this.getPuri("r").from("users").where("email", email).first();
   }
 }
 ```

--- a/modules/docs/ko/core-concepts/entity/defining-entities.mdx
+++ b/modules/docs/ko/core-concepts/entity/defining-entities.mdx
@@ -170,10 +170,12 @@ API 응답에서 사용할 필드 조합을 정의합니다.
 
 <CodeGroup>
 ```typescript title="Model에서 사용"
-async findAll(): Promise<UserSubsetA[]> {
-  return this.puri()
-    .select<UserSubsetA>("A")
-    .many();
+async findMany<T extends UserSubsetKey>(
+  subset: T,
+  params: UserListParams,
+): Promise<ListResult<UserSubsetMapping[T]>> {
+  const { qb } = this.getSubsetQueries(subset);
+  return this.executeSubsetQuery({ subset, qb, params });
 }
 ```
 

--- a/modules/docs/ko/core-concepts/entity/enums.mdx
+++ b/modules/docs/ko/core-concepts/entity/enums.mdx
@@ -183,10 +183,10 @@ export class UserModel extends BaseModelClass {
   @api({ httpMethod: "POST" })
   async updateRole(userId: number, role: UserRole) {
     // role은 타입 안전함
-    await this.puri()
+    await this.getPuri("w").from("users")
       .where("id", userId)
       .update({ role });
-      
+
     return { success: true };
   }
 }
@@ -253,9 +253,8 @@ function UserBadge({ role }: { role: UserRole }) {
 ```typescript
 async findAll(orderBy: UserOrderBy = "id-desc") {
   const [field, direction] = orderBy.split("-");
-  return this.puri()
-    .orderBy(field, direction as "asc" | "desc")
-    .many();
+  return this.getPuri("r").from("users")
+    .orderBy(field, direction as "asc" | "desc");
 }
 ```
 
@@ -279,9 +278,8 @@ async findAll(orderBy: UserOrderBy = "id-desc") {
 
 ```typescript
 async search(field: UserSearchField, keyword: string) {
-  return this.puri()
-    .whereLike(field, `%${keyword}%`)
-    .many();
+  return this.getPuri("r").from("users")
+    .whereLike(field, `%${keyword}%`);
 }
 ```
 
@@ -306,7 +304,7 @@ async search(field: UserSearchField, keyword: string) {
 
 ```typescript
 async publish(postId: number) {
-  await this.puri()
+  await this.getPuri("w").from("posts")
     .where("id", postId)
     .update({ status: "published" });
 }
@@ -380,10 +378,10 @@ function hasPermission(user: User, permission: Permission): boolean {
 async grantPermission(userId: number, permission: Permission) {
   const user = await this.findById(userId);
   if (!user.permissions.includes(permission)) {
-    await this.puri()
+    await this.getPuri("w").from("users")
       .where("id", userId)
       .update({
-        permissions: [...user.permissions, permission]
+        permissions: [...user.permissions, permission],
       });
   }
 }

--- a/modules/docs/ko/core-concepts/entity/field-types.mdx
+++ b/modules/docs/ko/core-concepts/entity/field-types.mdx
@@ -650,14 +650,11 @@ export type ProductMetadata = {
     Puri 쿼리의 appendSelect로 SQL 계산합니다.
     
     ```typescript
-    // {entity}.model.ts
-    async findAll() {
-      return this.puri()
-        .appendSelect({
-          full_name: this.puri().knex.raw("first_name || ' ' || last_name")
-        })
-        .many();
-    }
+    // {entity}.model.ts의 subset 쿼리에서 사용
+    const { qb } = this.getSubsetQueries(subset);
+    qb.appendSelect({
+      full_name: this.getPuri("r").raw("first_name || ' ' || last_name"),
+    });
     ```
     
     **장점**: 데이터베이스 레벨 계산, 필터링/정렬 가능
@@ -717,11 +714,14 @@ export type ProductMetadata = {
 ```typescript
 // 코사인 유사도로 검색
 async searchSimilar(queryEmbedding: number[]) {
-  return this.puri()
-    .whereRaw("embedding <=> ?", [JSON.stringify(queryEmbedding)])
-    .orderByRaw("embedding <=> ?", [JSON.stringify(queryEmbedding)])
-    .limit(10)
-    .many();
+  const results = await this.getPuri("r").raw(`
+    SELECT id, content,
+      1 - (embedding <=> ?) AS similarity
+    FROM documents
+    ORDER BY embedding <=> ?
+    LIMIT 10
+  `, [JSON.stringify(queryEmbedding), JSON.stringify(queryEmbedding)]);
+  return results.rows;
 }
 ```
 

--- a/modules/docs/ko/core-concepts/entity/relations.mdx
+++ b/modules/docs/ko/core-concepts/entity/relations.mdx
@@ -107,13 +107,11 @@ Sonamu는 4가지 Relation 타입을 지원합니다:
 <CodeGroup>
 ```typescript title="쿼리"
 // Subset에 relation 포함
-const posts = await this.puri()
-  .select<PostSubsetA>("A")
-  .many();
+const { qb } = this.getSubsetQueries("A");
+const result = await this.executeSubsetQuery({ subset: "A", qb, params });
 
-// posts[0].user.username 접근 가능
-
-````
+// result.rows[0].user.username 접근 가능
+```
 
 ```typescript title="타입 (자동 생성)"
 type PostSubsetA = {
@@ -320,10 +318,11 @@ type UserSubsetA = {
 ```
 
 ```typescript title="쿼리"
-const users = await this.puri().select<UserSubsetA>("A").many();
+const { qb } = this.getSubsetQueries("A");
+const result = await this.executeSubsetQuery({ subset: "A", qb, params });
 
-// users[0].posts는 배열
-console.log(users[0].posts.length);
+// result.rows[0].posts는 배열
+console.log(result.rows[0].posts.length);
 ```
 
 </CodeGroup>
@@ -436,10 +435,11 @@ type PostSubsetA = {
 ```
 
 ```typescript title="쿼리"
-const posts = await this.puri().select<PostSubsetA>("A").many();
+const { qb } = this.getSubsetQueries("A");
+const result = await this.executeSubsetQuery({ subset: "A", qb, params });
 
-// posts[0].tags는 배열
-posts[0].tags.forEach((tag) => {
+// result.rows[0].tags는 배열
+result.rows[0].tags.forEach((tag) => {
   console.log(tag.name);
 });
 ```
@@ -504,19 +504,18 @@ LEFT JOIN departments ON employees.department_id = departments.id
 
 <CodeGroup>
 ```typescript title="BelongsToOne 필터"
-const posts = await this.puri()
-  .where("user.role", "admin")
-  .many();
+const { qb } = this.getSubsetQueries("A");
+qb.where("user.role", "admin");
+const result = await this.executeSubsetQuery({ subset: "A", qb, params });
 ```
 
 ```typescript title="HasMany 필터"
 // Subset에 포함된 HasMany는 필터링 불가
 // 대신 별도 쿼리 사용
 const user = await UserModel.findById(userId);
-const activePosts = await PostModel.puri()
+const activePosts = await PostModel.getPuri("r").from("posts")
   .where("user_id", userId)
-  .where("status", "active")
-  .many();
+  .where("status", "active");
 ```
 
 </CodeGroup>
@@ -524,7 +523,9 @@ const activePosts = await PostModel.puri()
 ### 4. Relation 정렬
 
 ```typescript
-const posts = await this.puri().orderBy("user.username", "asc").many();
+const { qb } = this.getSubsetQueries("A");
+qb.orderBy("user.username", "asc");
+const result = await this.executeSubsetQuery({ subset: "A", qb, params });
 ```
 
 ## Relation 설계 가이드

--- a/modules/docs/ko/core-concepts/model/basemodel-methods.mdx
+++ b/modules/docs/ko/core-concepts/model/basemodel-methods.mdx
@@ -91,8 +91,7 @@ async findActive(): Promise<User[]> {
   return rdb
     .table("users")
     .where("is_active", true)
-    .orderBy("created_at", "desc")
-    .many();
+    .orderBy("created_at", "desc");
 }
 ```
 

--- a/modules/docs/ko/core-concepts/model/business-logic.mdx
+++ b/modules/docs/ko/core-concepts/model/business-logic.mdx
@@ -40,7 +40,7 @@ class UserModelClass extends BaseModelClass {
         throw new BadRequestException("18세 미만은 가입할 수 없습니다");
       }
       
-      const existing = await this.puri()
+      const existing = await this.getPuri("r").from("users")
         .where("email", param.email)
         .first();
         
@@ -133,9 +133,9 @@ async createUserWithProfile(
 async save(params: UserSaveParams[]): Promise<number[]> {
   // 이메일 중복 체크
   for (const param of params) {
-    const existing = await this.puri()
+    const existing = await this.getPuri("r").from("users")
       .where("email", param.email)
-      .whereNot("id", param.id ?? 0)  // 수정 시 자신 제외
+      .where("id", "!=", param.id ?? 0)  // 수정 시 자신 제외
       .first();
 
     if (existing) {
@@ -482,7 +482,7 @@ async innerTransaction(): Promise<void> {
 
 ```typescript
 async login(params: LoginParams): Promise<{ user: User }> {
-  const user = await this.puri()
+  const user = await this.getPuri("r").from("users")
     .where("email", params.email)
     .first();
 

--- a/modules/docs/ko/core-concepts/model/what-is-model.mdx
+++ b/modules/docs/ko/core-concepts/model/what-is-model.mdx
@@ -134,7 +134,7 @@ export type UserSubsetA = User;
 class UserModelClass extends BaseModelClass {
   async findById(id: number): Promise<User> {
     // 비즈니스 로직
-    const user = await this.puri().where("id", id).first();
+    const user = await this.getPuri("r").from("users").where("id", id).first();
     return user;
   }
 }
@@ -336,7 +336,7 @@ class UserModelClass extends BaseModelClass {
     ```typescript
     // Model 메서드
     async findActiveUsers(): Promise<User[]> {
-      return this.puri().where("is_active", true).many();
+      return this.getPuri("r").from("users").where("is_active", true);
     }
     
     // 여러 API에서 재사용

--- a/modules/docs/ko/database/subsets/using-subsets.mdx
+++ b/modules/docs/ko/database/subsets/using-subsets.mdx
@@ -486,8 +486,7 @@ const users = await puri
     employee__salary: "employees.salary",
     employee__department__name: "departments.name",
   })
-  .where("users.role", "admin")
-  .many();
+  .where("users.role", "admin");
 
 // 타입: { id: number; username: string; ... }[]
 // JOIN 수동 설정


### PR DESCRIPTION
이 PR은 AI(Claude Code)에 의해 자동 생성된 Nightly PR입니다.
코드베이스의 ownership은 전적으로 maintainer에게 있으며, 이 PR은 검토 후 판단을 돕기 위한 제안입니다.

## 어떤 issue를 참조했으며, 왜 이 작업을 선정했나요?

[#44 - 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44)을 참조했습니다.

Issue #44의 범위 중:
> 문서와 주석이 코드와 어긋나는 경우 -> 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다.

기존 Nightly PR들(#115~#147)의 description과 comment를 모두 확인하였으며, `this.puri()` 및 `.many()` 문서 오류는 이전에 조치된 적이 없는 문제입니다. (기존에는 `this.db()` → `getPuri()` 및 `getPuri()` → `getPuri("r"/"w")` 패턴이 수정되었으나, `this.puri()` 패턴은 다른 문제이므로 별도 수정이 필요했습니다.)

## 무엇이 문제인가요?

### 1. `this.puri()` 메서드 미존재 (ko 7파일 + en 7파일, 42개소)

`BaseModelClass`에는 `this.puri()`라는 메서드가 존재하지 않습니다. 실제 API는 다음과 같습니다:

- `this.getPuri("r")` — 읽기용 PuriWrapper 반환 (SELECT 쿼리에 사용)
- `this.getPuri("w")` — 쓰기용 PuriWrapper 반환 (INSERT/UPDATE/DELETE에 사용)
- PuriWrapper에서 `.from("tableName")` 또는 `.table("tableName")`을 호출하여 Puri 쿼리 빌더를 획득

문서를 따라 코드를 작성하면 `this.puri is not a function` 런타임 에러가 발생합니다.

### 2. `.many()` 메서드 미존재 (ko 2파일 + en 2파일, 추가 4개소)

`Puri` 클래스에는 `.many()` 메서드가 존재하지 않습니다. 복수 결과를 가져오려면 Puri 쿼리를 `await`하면 배열이 반환됩니다. (`.first()`는 단일 결과 반환용으로 존재합니다.)

### 3. `.select<SubsetKey>("A").many()` 패턴 미존재 (일부 파일)

Puri의 `.select()`는 컬럼 매핑 객체를 받으며, 제네릭으로 Subset 키를 전달하는 API가 아닙니다. Subset 기반 쿼리는 `getSubsetQueries()` + `executeSubsetQuery()` 패턴을 사용합니다.

## 어떤 접근 방식을 채택했으며, 왜 그랬나요?

실제 소스코드(`modules/sonamu/src/database/base-model.ts`, `puri-wrapper.ts`, `puri.ts`)와 miomock 예제 모델(`examples/miomock/api/src/application/*/`)의 실제 사용 패턴을 참조하여 수정했습니다:

1. **단순 쿼리 예제**: `this.puri().where(...)` → `this.getPuri("r"/"w").from("tableName").where(...)` (읽기/쓰기 구분, 테이블명 명시)
2. **Subset 쿼리 예제**: `.select<SubsetA>("A").many()` → `getSubsetQueries()` + `executeSubsetQuery()` 패턴 (실제 API 반영)
3. **벡터 검색 예제**: `.whereRaw().orderByRaw().many()` → `getPuri("r").raw()` 패턴 (`orderByRaw`는 Puri의 public 메서드가 아니므로 raw SQL로 대체, 기존 벡터 검색 문서와 일관성 유지)
4. **`.many()` 제거**: Puri에 존재하지 않으므로 단순 제거 (await하면 배열 반환)
5. **`.whereNot()` → `.where("col", "!=", val)`**: `whereNot`은 Puri의 public 메서드가 아니므로 연산자 형식으로 변환

## 이렇게 하지 않으면 어떤 점이 안 좋은가요?

- 문서를 참조한 사용자가 `this.puri()`, `.many()`, `.select<SubsetKey>()` 등 존재하지 않는 API를 사용하여 컴파일/런타임 에러를 만나게 됩니다.
- 특히 Sonamu 입문자에게 혼란을 주며, 실제 API(`getPuri`, `getSubsetQueries` 등)를 발견하기까지 불필요한 디버깅 시간이 소요됩니다.

## 어떤 기능에 영향을 미치나요?

프레임워크 코드 변경은 없으며, 문서(.mdx 파일)만 수정합니다. 기존 동작에 영향 없습니다.

## 변경 영향을 확인하는 방법

1. 수정된 코드 예제가 `BaseModelClass`의 실제 메서드 시그니처와 일치하는지 확인:
   - `base-model.ts`: `getPuri(which: DBPreset): PuriWrapper`
   - `puri-wrapper.ts`: `.from(tableName)` / `.table(tableName)` → `Puri` 반환
   - `puri.ts`: `.where()`, `.first()`, `.update()`, `.delete()`, `.select()` 등
2. miomock 모델 코드의 실제 사용 패턴과 비교하여 일관성 확인

## 검토 필요 사항

- **벡터 검색 예제 (field-types.mdx)**: 기존의 `whereRaw().orderByRaw()` 체이닝에서 `getPuri("r").raw()` 패턴으로 변경했습니다. PR #147에서 벡터 검색 문서들이 동일한 `getPuri("r").raw()` 패턴으로 수정된 것과 일관되지만, 테이블명이 `documents`로 추정하여 사용한 부분은 문맥에 맞는지 확인이 필요합니다.
- **Subset 예제의 `params` 변수**: `executeSubsetQuery()` 호출 시 `params`를 참조하는데, 이는 함수 인자로 받는다는 전제입니다. 기존 문서의 코드 블록이 메서드 일부분만 보여주는 스니펫이므로 문맥상 자연스럽지만, 필요시 `params` 선언을 추가할 수 있습니다.

## 변경 파일 목록

### 한국어 (ko) - 9파일
- `core-concepts/model/what-is-model.mdx` — 2개소
- `core-concepts/model/business-logic.mdx` — 3개소
- `core-concepts/model/basemodel-methods.mdx` — 1개소
- `core-concepts/auto-generation/customizing-generated-code.mdx` — 2개소
- `core-concepts/entity/defining-entities.mdx` — 1개소
- `core-concepts/entity/field-types.mdx` — 2개소
- `core-concepts/entity/relations.mdx` — 6개소
- `core-concepts/entity/enums.mdx` — 5개소
- `database/subsets/using-subsets.mdx` — 1개소

### 영어 (en) - 9파일
위와 동일한 경로에 동일한 수정이 적용되었습니다.