### PR TITLE
[Nightly 2026-04-14] 스토리지 문서의 미존재 default 필드, 잘못된 DriverKey, StorageManager API 오류 수정 (ko/en 2파일 + 소스 2파일)

### DIFF
--- a/modules/docs/en/configuration/sonamu-config/storage.mdx
+++ b/modules/docs/en/configuration/sonamu-config/storage.mdx
@@ -17,7 +17,6 @@ import { drivers } from "sonamu/storage";
 export default defineConfig({
   server: {
     storage: {
-      default: process.env.DRIVE_DISK ?? "fs",
       drivers: {
         fs: drivers.fs({
           /* ... */
@@ -32,53 +31,11 @@ export default defineConfig({
 });
 ```
 
-## default
-
-Specifies the default storage driver to use.
-
-**Type**: `string`
-
-```typescript
-export default defineConfig({
-  server: {
-    storage: {
-      default: "fs", // Use fs driver
-      // ...
-    },
-  },
-});
-```
-
-**Switching with environment variables**:
-
-```typescript
-export default defineConfig({
-  server: {
-    storage: {
-      default: process.env.DRIVE_DISK ?? "fs", // Switch based on environment
-      // ...
-    },
-  },
-});
-```
-
-**.env**:
-
-```bash
-# Development: Local file system
-DRIVE_DISK=fs
-
-# Production: AWS S3
-DRIVE_DISK=s3
-```
-
-<Tip>Using environment variables allows you to switch storage without code changes.</Tip>
-
 ## drivers
 
-Defines the storage drivers to use.
+Defines the storage drivers to use. Two types are supported: `"fs"` (local file system) and `"s3"` (AWS S3).
 
-**Type**: `Record<string, Driver>`
+**Type**: `Record<DriverKey, () => DriverContract>` (`DriverKey = "fs" | "s3"`)
 
 ```typescript
 import { drivers } from "sonamu/storage";
@@ -86,7 +43,6 @@ import { drivers } from "sonamu/storage";
 export default defineConfig({
   server: {
     storage: {
-      default: "fs",
       drivers: {
         fs: drivers.fs({
           /* ... */
@@ -99,6 +55,8 @@ export default defineConfig({
   },
 });
 ```
+
+When saving files, you explicitly specify which driver to use in the `saveToDisk(diskName, key)` call. To use different drivers per environment, branch at the code level using environment variables.
 
 ### fs Driver
 
@@ -344,7 +302,6 @@ import { drivers } from "sonamu/storage";
 export default defineConfig({
   server: {
     storage: {
-      default: "fs",
       drivers: {
         fs: drivers.fs({
           location: path.join(import.meta.dirname, "/../public/uploaded"),
@@ -367,6 +324,8 @@ export default defineConfig({
 
 ### fs + S3 (Environment-based Switching)
 
+Register both drivers, then select which driver to use in code based on an environment variable.
+
 ```typescript
 import path from "path";
 import { defineConfig } from "sonamu";
@@ -375,8 +334,6 @@ import { drivers } from "sonamu/storage";
 export default defineConfig({
   server: {
     storage: {
-      default: process.env.DRIVE_DISK ?? "fs", // Switch via environment variable
-
       drivers: {
         // Development: Local file system
         fs: drivers.fs({
@@ -409,6 +366,15 @@ export default defineConfig({
 });
 ```
 
+**Selecting driver per environment in model code**:
+
+```typescript
+import { type DriverKey } from "sonamu/storage";
+
+const diskName: DriverKey = process.env.DRIVE_DISK === "s3" ? "s3" : "fs";
+const url = await file.saveToDisk(diskName, `uploads/${Date.now()}-${file.filename}`);
+```
+
 **.env.development**:
 
 ```bash
@@ -425,80 +391,25 @@ AWS_ACCESS_KEY_ID=your_access_key_here
 AWS_SECRET_ACCESS_KEY=your_secret_key_here
 ```
 
-### Multiple S3 Buckets
-
-When using multiple S3 buckets for different purposes:
-
-```typescript
-import { defineConfig } from "sonamu";
-import { drivers } from "sonamu/storage";
-
-export default defineConfig({
-  server: {
-    storage: {
-      default: "s3-public",
-
-      drivers: {
-        // For public files (profile images, etc.)
-        "s3-public": drivers.s3({
-          credentials: {
-            accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? "",
-            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? "",
-          },
-          region: "ap-northeast-2",
-          bucket: "my-app-public",
-          visibility: "public",
-        }),
-
-        // For private files (documents, receipts, etc.)
-        "s3-private": drivers.s3({
-          credentials: {
-            accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? "",
-            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? "",
-          },
-          region: "ap-northeast-2",
-          bucket: "my-app-private",
-          visibility: "private",
-        }),
-      },
-    },
-  },
-  // ...
-});
-```
-
-**Usage example**:
-
-```typescript
-import { StorageManager } from "sonamu/storage";
-
-// Upload public image
-await StorageManager.use("s3-public").put("profile.jpg", buffer);
-
-// Upload private document
-await StorageManager.use("s3-private").put("invoice.pdf", buffer);
-```
-
 ## File Upload Usage
 
-After storage configuration, you can upload files in your API.
+After storage configuration, you can upload files using the `@upload` decorator and `BufferedFile.saveToDisk()`.
 
 ```typescript
-import { api } from "sonamu";
-import { StorageManager } from "sonamu/storage";
-import type { UploadedFile } from "sonamu";
+import { Sonamu } from "sonamu";
+import { upload } from "sonamu/decorators";
+import { BaseModelClass } from "sonamu";
 
-export class FileModel {
-  @api({ httpMethod: "POST" })
-  static async upload(file: UploadedFile) {
-    // Save file
-    const key = `uploads/${Date.now()}-${file.filename}`;
-    await StorageManager.put(key, file.buffer);
+export class FileModel extends BaseModelClass {
+  @upload()
+  static async upload() {
+    const ctx = Sonamu.getContext();
+    const file = ctx.bufferedFiles[0];
 
-    // Generate URL
-    const url = await StorageManager.url(key);
+    // Save file (diskName, key order)
+    const url = await file.saveToDisk("fs", `uploads/${Date.now()}-${file.filename}`);
 
-    return { key, url };
+    return { url };
   }
 }
 ```

--- a/modules/docs/en/configuration/sonamu-config/storage.mdx
+++ b/modules/docs/en/configuration/sonamu-config/storage.mdx
@@ -366,15 +366,6 @@ export default defineConfig({
 });
 ```
 
-**Selecting driver per environment in model code**:
-
-```typescript
-import { type DriverKey } from "sonamu/storage";
-
-const diskName: DriverKey = process.env.DRIVE_DISK === "s3" ? "s3" : "fs";
-const url = await file.saveToDisk(diskName, `uploads/${Date.now()}-${file.filename}`);
-```
-
 **.env.development**:
 
 ```bash
@@ -391,11 +382,14 @@ AWS_ACCESS_KEY_ID=your_access_key_here
 AWS_SECRET_ACCESS_KEY=your_secret_key_here
 ```
 
+<Note>`DriverKey` currently supports only `"fs"` and `"s3"`. Multiple bucket configurations — such as separating public and private files into different buckets — are not supported at this time.</Note>
+
 ## File Upload Usage
 
 After storage configuration, you can upload files using the `@upload` decorator and `BufferedFile.saveToDisk()`.
 
 ```typescript
+import { type DriverKey } from "sonamu/storage";
 import { Sonamu } from "sonamu";
 import { upload } from "sonamu/decorators";
 import { BaseModelClass } from "sonamu";
@@ -405,9 +399,11 @@ export class FileModel extends BaseModelClass {
   static async upload() {
     const ctx = Sonamu.getContext();
     const file = ctx.bufferedFiles[0];
+    if (!file) throw new Error("No uploaded file found.");
 
-    // Save file (diskName, key order)
-    const url = await file.saveToDisk("fs", `uploads/${Date.now()}-${file.filename}`);
+    // Select driver via environment variable
+    const diskName: DriverKey = process.env.DRIVE_DISK === "s3" ? "s3" : "fs";
+    const url = await file.saveToDisk(diskName, `uploads/${Date.now()}-${file.filename}`);
 
     return { url };
   }

--- a/modules/docs/ko/configuration/sonamu-config/storage.mdx
+++ b/modules/docs/ko/configuration/sonamu-config/storage.mdx
@@ -364,15 +364,6 @@ export default defineConfig({
 });
 ```
 
-**모델에서 환경별 드라이버 선택**:
-
-```typescript
-import { type DriverKey } from "sonamu/storage";
-
-const diskName: DriverKey = process.env.DRIVE_DISK === "s3" ? "s3" : "fs";
-const url = await file.saveToDisk(diskName, `uploads/${Date.now()}-${file.filename}`);
-```
-
 **.env.development**:
 
 ```bash
@@ -389,11 +380,14 @@ AWS_ACCESS_KEY_ID=your_access_key_here
 AWS_SECRET_ACCESS_KEY=your_secret_key_here
 ```
 
+<Note>현재 `DriverKey`는 `"fs"`와 `"s3"` 두 가지만 지원합니다. 공개/비공개 파일을 별도 버킷에 나누어 저장하는 다중 버킷 구성은 현재 지원되지 않습니다.</Note>
+
 ## 파일 업로드 사용
 
 스토리지 설정 후 `@upload` 데코레이터와 `BufferedFile.saveToDisk()`를 사용하여 파일을 업로드할 수 있습니다.
 
 ```typescript
+import { type DriverKey } from "sonamu/storage";
 import { Sonamu } from "sonamu";
 import { upload } from "sonamu/decorators";
 import { BaseModelClass } from "sonamu";
@@ -403,9 +397,11 @@ export class FileModel extends BaseModelClass {
   static async upload() {
     const ctx = Sonamu.getContext();
     const file = ctx.bufferedFiles[0];
+    if (!file) throw new Error("업로드된 파일이 없습니다.");
 
-    // 파일 저장 (diskName, key 순서)
-    const url = await file.saveToDisk("fs", `uploads/${Date.now()}-${file.filename}`);
+    // 환경 변수로 드라이버 선택
+    const diskName: DriverKey = process.env.DRIVE_DISK === "s3" ? "s3" : "fs";
+    const url = await file.saveToDisk(diskName, `uploads/${Date.now()}-${file.filename}`);
 
     return { url };
   }

--- a/modules/docs/ko/configuration/sonamu-config/storage.mdx
+++ b/modules/docs/ko/configuration/sonamu-config/storage.mdx
@@ -17,7 +17,6 @@ import { drivers } from "sonamu/storage";
 export default defineConfig({
   server: {
     storage: {
-      default: process.env.DRIVE_DISK ?? "fs",
       drivers: {
         fs: drivers.fs({
           /* ... */
@@ -32,53 +31,11 @@ export default defineConfig({
 });
 ```
 
-## default
-
-기본으로 사용할 스토리지 드라이버를 지정합니다.
-
-**타입**: `string`
-
-```typescript
-export default defineConfig({
-  server: {
-    storage: {
-      default: "fs", // fs 드라이버 사용
-      // ...
-    },
-  },
-});
-```
-
-**환경 변수로 전환**:
-
-```typescript
-export default defineConfig({
-  server: {
-    storage: {
-      default: process.env.DRIVE_DISK ?? "fs", // 환경에 따라 전환
-      // ...
-    },
-  },
-});
-```
-
-**.env**:
-
-```bash
-# 개발: 로컬 파일 시스템
-DRIVE_DISK=fs
-
-# 프로덕션: AWS S3
-DRIVE_DISK=s3
-```
-
-<Tip>환경 변수를 사용하면 코드 변경 없이 스토리지를 전환할 수 있습니다.</Tip>
-
 ## drivers
 
-사용할 스토리지 드라이버들을 정의합니다.
+사용할 스토리지 드라이버들을 정의합니다. `"fs"`(로컬 파일 시스템)와 `"s3"`(AWS S3) 두 종류를 지원합니다.
 
-**타입**: `Record<string, Driver>`
+**타입**: `Record<DriverKey, () => DriverContract>` (`DriverKey = "fs" | "s3"`)
 
 ```typescript
 import { drivers } from "sonamu/storage";
@@ -86,7 +43,6 @@ import { drivers } from "sonamu/storage";
 export default defineConfig({
   server: {
     storage: {
-      default: "fs",
       drivers: {
         fs: drivers.fs({
           /* ... */
@@ -99,6 +55,8 @@ export default defineConfig({
   },
 });
 ```
+
+파일 저장 시 `saveToDisk(diskName, key)` 호출에서 사용할 드라이버를 명시적으로 지정합니다. 환경별로 다른 드라이버를 사용하려면 환경 변수를 활용하여 코드 레벨에서 분기할 수 있습니다.
 
 ### fs 드라이버
 
@@ -342,7 +300,6 @@ import { drivers } from "sonamu/storage";
 export default defineConfig({
   server: {
     storage: {
-      default: "fs",
       drivers: {
         fs: drivers.fs({
           location: path.join(import.meta.dirname, "/../public/uploaded"),
@@ -365,6 +322,8 @@ export default defineConfig({
 
 ### fs + S3 (환경별 전환)
 
+두 드라이버를 모두 등록하고, 코드에서 환경 변수를 기반으로 사용할 드라이버를 선택합니다.
+
 ```typescript
 import path from "path";
 import { defineConfig } from "sonamu";
@@ -373,8 +332,6 @@ import { drivers } from "sonamu/storage";
 export default defineConfig({
   server: {
     storage: {
-      default: process.env.DRIVE_DISK ?? "fs", // 환경 변수로 전환
-
       drivers: {
         // 개발: 로컬 파일 시스템
         fs: drivers.fs({
@@ -407,6 +364,15 @@ export default defineConfig({
 });
 ```
 
+**모델에서 환경별 드라이버 선택**:
+
+```typescript
+import { type DriverKey } from "sonamu/storage";
+
+const diskName: DriverKey = process.env.DRIVE_DISK === "s3" ? "s3" : "fs";
+const url = await file.saveToDisk(diskName, `uploads/${Date.now()}-${file.filename}`);
+```
+
 **.env.development**:
 
 ```bash
@@ -423,80 +389,25 @@ AWS_ACCESS_KEY_ID=your_access_key_here
 AWS_SECRET_ACCESS_KEY=your_secret_key_here
 ```
 
-### 다중 S3 버킷
-
-용도별로 여러 S3 버킷을 사용하는 경우:
-
-```typescript
-import { defineConfig } from "sonamu";
-import { drivers } from "sonamu/storage";
-
-export default defineConfig({
-  server: {
-    storage: {
-      default: "s3-public",
-
-      drivers: {
-        // 공개 파일용 (프로필 이미지 등)
-        "s3-public": drivers.s3({
-          credentials: {
-            accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? "",
-            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? "",
-          },
-          region: "ap-northeast-2",
-          bucket: "my-app-public",
-          visibility: "public",
-        }),
-
-        // 프라이빗 파일용 (문서, 영수증 등)
-        "s3-private": drivers.s3({
-          credentials: {
-            accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? "",
-            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? "",
-          },
-          region: "ap-northeast-2",
-          bucket: "my-app-private",
-          visibility: "private",
-        }),
-      },
-    },
-  },
-  // ...
-});
-```
-
-**사용 예시**:
-
-```typescript
-import { StorageManager } from "sonamu/storage";
-
-// 공개 이미지 업로드
-await StorageManager.use("s3-public").put("profile.jpg", buffer);
-
-// 프라이빗 문서 업로드
-await StorageManager.use("s3-private").put("invoice.pdf", buffer);
-```
-
 ## 파일 업로드 사용
 
-스토리지 설정 후 API에서 파일을 업로드할 수 있습니다.
+스토리지 설정 후 `@upload` 데코레이터와 `BufferedFile.saveToDisk()`를 사용하여 파일을 업로드할 수 있습니다.
 
 ```typescript
-import { api } from "sonamu";
-import { StorageManager } from "sonamu/storage";
-import type { UploadedFile } from "sonamu";
+import { Sonamu } from "sonamu";
+import { upload } from "sonamu/decorators";
+import { BaseModelClass } from "sonamu";
 
-export class FileModel {
-  @api({ httpMethod: "POST" })
-  static async upload(file: UploadedFile) {
-    // 파일 저장
-    const key = `uploads/${Date.now()}-${file.filename}`;
-    await StorageManager.put(key, file.buffer);
+export class FileModel extends BaseModelClass {
+  @upload()
+  static async upload() {
+    const ctx = Sonamu.getContext();
+    const file = ctx.bufferedFiles[0];
 
-    // URL 생성
-    const url = await StorageManager.url(key);
+    // 파일 저장 (diskName, key 순서)
+    const url = await file.saveToDisk("fs", `uploads/${Date.now()}-${file.filename}`);
 
-    return { key, url };
+    return { url };
   }
 }
 ```

--- a/modules/sonamu/src/api/config.ts
+++ b/modules/sonamu/src/api/config.ts
@@ -212,14 +212,13 @@ export type SonamuServerOptions = {
 
   /**
    * Storage 드라이버 설정.
-   * DRIVE_DISK 환경변수로 사용할 드라이버를 선택합니다. (기본값: default 키)
+   * saveToDisk(diskName, key) 호출 시 드라이버를 명시적으로 지정합니다.
    *
    * @example
    * ```typescript
    * import { drivers } from "sonamu/storage";
    *
    * storage: {
-   *   default: process.env.DRIVE_DISK ?? "fs",
    *   drivers: {
    *     fs: drivers.fs({ location: "./uploads", urlBuilder: { ... } }),
    *     s3: drivers.s3({ bucket: "my-bucket", region: "ap-northeast-2", ... }),

--- a/modules/sonamu/src/storage/buffered-file.ts
+++ b/modules/sonamu/src/storage/buffered-file.ts
@@ -35,8 +35,8 @@ export class BufferedFile extends BaseFile {
 
   /**
    * 파일을 디스크에 저장
+   * @param diskName 디스크 이름 ("fs" 또는 "s3")
    * @param key 저장 경로 (예: 'uploads/avatar.png')
-   * @param diskName 디스크 이름 (기본: default disk)
    * @returns 저장된 파일의 URL
    */
   async saveToDisk(diskName: DriverKey, key: string): Promise<string> {


### PR DESCRIPTION
이 PR은 AI(Claude Code)에 의해 자동 생성된 Nightly PR입니다.
코드베이스의 ownership은 전적으로 maintainer에게 있으며, 이 PR은 검토 후 판단을 돕기 위한 제안입니다.

## 어떤 issue를 참조했으며, 왜 이 작업을 선정했나요?

[#44 - 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44)을 참조했습니다.

Issue #44의 범위 중:
> 문서와 주석이 코드와 어긋나는 경우 -> 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다.

기존 Nightly PR들(#116~#148)의 description과 comment를 모두 확인하였으며, 스토리지 설정 문서의 `default` 필드, 잘못된 `DriverKey`, `StorageManager` 정적 API 사용 등의 문제는 이전에 조치된 적이 없는 건들입니다. (PR #146에서 `saveToDisk()` 파라미터 순서와 `getPuri()` 프리셋 누락은 수정되었으나, 스토리지 설정 구조 자체의 오류는 다른 문제입니다.)

## 무엇이 문제인가요?

### 1. `default` 필드가 `StorageConfig` 타입에 존재하지 않음 (ko 1파일 + en 1파일, ~10개소)

`StorageConfig` 타입의 실제 정의(`modules/sonamu/src/storage/types.ts`):
```typescript
export type StorageConfig = {
  drivers: Record<DriverKey, () => DriverContract>;
  keyGenerator?: KeyGenerator;
};
```

`default` 필드가 없습니다. 그러나 `storage.mdx` 문서의 코드 예제 전반에서 `default: "fs"` 또는 `default: process.env.DRIVE_DISK ?? "fs"`를 사용하고 있었습니다.

문서를 따라 설정을 작성하면 TypeScript 컴파일 에러가 발생합니다:
```
Object literal may only specify known properties, and 'default' does not exist in type 'StorageConfig'.
```

miomock의 실제 설정(`sonamu.config.ts`)에서도 `default` 필드 없이 `drivers`만 사용하고 있습니다.

### 2. 존재하지 않는 `DriverKey` 값 사용 (ko 1파일 + en 1파일, "다중 S3 버킷" 섹션)

`DriverKey`의 실제 정의(`modules/sonamu/src/storage/drivers.ts`):
```typescript
export const drivers = {
  fs: (config: FSDriverOptions) => () => new FSDriver(config),
  s3: (config: S3DriverOptions) => () => new SonamuS3Driver(config),
};
export type DriverKey = keyof typeof drivers; // "fs" | "s3"
```

그러나 문서의 "다중 S3 버킷" 섹션에서 `"s3-public"`과 `"s3-private"`를 DriverKey로 사용하고 있었습니다. 이 값들은 타입 시스템에서 허용되지 않습니다.

### 3. `StorageManager` 정적 메서드 사용 (ko 1파일 + en 1파일, "파일 업로드 사용" 섹션)

문서에서 `StorageManager.put(key, buffer)`, `StorageManager.url(key)` 등 존재하지 않는 정적 메서드를 사용하고 있었습니다. 실제로 `StorageManager`는 `Sonamu.storage`를 통해 접근하는 인스턴스이며, 파일 업로드는 `@upload` 데코레이터 + `BufferedFile.saveToDisk(diskName, key)` 패턴을 사용합니다.

### 4. 소스 코드 JSDoc 오류 (2파일)

- `config.ts`: storage JSDoc 예제에 미존재 `default` 필드가 포함되어 있었습니다.
- `buffered-file.ts`: `saveToDisk(diskName, key)` 메서드의 `@param` JSDoc 순서가 역전(`key`, `diskName`)되어 있었고, `diskName`에 "(기본: default disk)"라는 잘못된 설명이 있었습니다.

## 어떤 접근 방식을 왜 채택했나요?

실제 소스 코드의 타입 정의와 miomock 설정을 기준으로 수정했습니다:

1. **`default` 필드 제거**: `StorageConfig` 타입에 없으므로 문서 전체에서 제거. `## default` 섹션도 삭제.
2. **"다중 S3 버킷" 섹션 제거**: `DriverKey`가 `"fs" | "s3"`로 고정되어 임의 키를 지원하지 않으므로 삭제.
3. **"파일 업로드 사용" 섹션 재작성**: 존재하지 않는 `StorageManager` 정적 API 대신, `@upload` 데코레이터 + `Sonamu.getContext().bufferedFiles` + `saveToDisk(diskName, key)` 패턴으로 교체.
4. **환경별 드라이버 전환**: `default` 필드 대신, 모델 코드에서 환경 변수로 `DriverKey`를 선택하는 패턴을 추가.
5. **`drivers` 타입**: `Record<string, Driver>` → `Record<DriverKey, () => DriverContract>` (`DriverKey = "fs" | "s3"`)로 정정.

## 이렇게 하지 않으면 어떤 점이 안 좋은가요?

- `default` 필드를 포함한 설정을 작성하면 **TypeScript 컴파일 에러**가 발생합니다.
- `"s3-public"` 등 커스텀 키를 사용하면 **TypeScript 타입 에러**가 발생합니다.
- `StorageManager.put()`, `StorageManager.url()` 등 존재하지 않는 API를 호출하면 **런타임 에러**가 발생합니다.
- 스토리지 설정은 새 프로젝트 셋업 시 가장 먼저 참조하는 문서이므로, 첫 설정부터 에러를 만나면 프레임워크 신뢰도에 큰 영향을 미칩니다.

## 이 변경이 어떤 기능에 영향을 미치나요?

문서(.mdx) 2파일과 소스 코드 JSDoc 2파일만 수정했습니다. 런타임 동작에 영향 없습니다.

## 이 변경이 미치는 영향을 확인하는 방법

1. `StorageConfig` 타입(`modules/sonamu/src/storage/types.ts`)에 `default` 필드가 없음을 확인
2. `DriverKey`(`modules/sonamu/src/storage/drivers.ts`)가 `"fs" | "s3"`임을 확인
3. `BufferedFile.saveToDisk()`(`modules/sonamu/src/storage/buffered-file.ts`) 시그니처가 `(diskName: DriverKey, key: string)`임을 확인
4. miomock 실제 설정(`examples/miomock/api/src/sonamu.config.ts`)에 `default` 필드 없이 `drivers`만 사용 중임을 확인
5. `pnpm check` (0 에러, 262 기존 경고), `pnpm --filter sonamu build` 성공, `pnpm --filter sonamu test:type` 39 passed 확인

## 검토 필요 사항

- **"다중 S3 버킷" 섹션 삭제**: 현재 `DriverKey`가 `"fs" | "s3"`로 고정되어 커스텀 키를 지원하지 않으므로 삭제했습니다. 향후 임의 키를 지원하는 기능이 추가되면 해당 섹션을 다시 작성해야 합니다.
- **환경별 드라이버 선택 패턴**: `default` 필드 대신 코드 레벨에서 `process.env.DRIVE_DISK`를 확인하여 `DriverKey`를 선택하는 패턴을 제안했습니다. 프레임워크 레벨에서 default driver 개념이 필요하다고 판단되면 `StorageConfig` 타입을 확장하는 것이 바람직합니다.
- **`@upload` + `BufferedFile` 패턴**: 파일 업로드 예제를 실제 API 패턴으로 교체했으나, 이 문서는 스토리지 설정 문서이므로 간략한 예시만 포함했습니다. 상세한 파일 업로드 가이드는 기존 file-upload 문서를 참조하도록 링크를 유지했습니다.