### PR TITLE
[Nightly 2026-04-15] 문서 코드 예제의 미존재 toBuffer()/getResponse() API 및 Context 속성명 오류 수정 (ko/en 7파일)

### DIFF
--- a/modules/docs/en/advanced-features/ai-agents/using-ai-sdk.mdx
+++ b/modules/docs/en/advanced-features/ai-agents/using-ai-sdk.mdx
@@ -314,8 +314,8 @@ class TranscriptionModelClass extends BaseModelClass {
   @upload({ mode: "single" })
   @api({ httpMethod: "POST" })
   async transcribeAudio() {
-    const { files } = Sonamu.getContext();
-    const file = files?.[0]; // Use first file
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
 
     if (!file) {
       throw new Error("No audio file provided");
@@ -323,7 +323,7 @@ class TranscriptionModelClass extends BaseModelClass {
 
     // Speech recognition
     const model = rtzr.transcription("whisper");
-    const buffer = await file.toBuffer();
+    const buffer = file.buffer;
 
     const result = await model.doGenerate({
       audio: buffer,
@@ -404,14 +404,14 @@ class ImageAnalysisModelClass extends BaseModelClass {
   @upload({ mode: "single" })
   @api({ httpMethod: "POST" })
   async analyzeImage() {
-    const { files } = Sonamu.getContext();
-    const file = files?.[0]; // Use first file
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
 
     if (!file || !file.mimetype.startsWith("image/")) {
       throw new Error("An image file is required");
     }
 
-    const buffer = await file.toBuffer();
+    const buffer = file.buffer;
 
     const result = await generateText({
       model: openai("gpt-4o"),

--- a/modules/docs/en/advanced-features/sse/creating-sse-endpoints.mdx
+++ b/modules/docs/en/advanced-features/sse/creating-sse-endpoints.mdx
@@ -24,7 +24,7 @@ class NotificationModelClass extends BaseModelClass {
       }),
     }),
   })
-  async streamNotifications(userId: number, ctx: Context): Promise<void> {
+  async streamNotifications(userId: number, ctx: Context) {
     const sse = ctx.createSSE(
       z.object({
         notification: z.object({
@@ -42,6 +42,8 @@ class NotificationModelClass extends BaseModelClass {
 
     // Close connection
     await sse.end();
+
+    return sse;
   }
 }
 ```

--- a/modules/docs/en/api-reference/context/sonamu-context.mdx
+++ b/modules/docs/en/api-reference/context/sonamu-context.mdx
@@ -91,7 +91,7 @@ class MyModelClass extends BaseModelClass {
     // Send completion event
     await sse.publish("complete", { result: "done" });
 
-    return sse.getResponse();
+    return sse;
   }
 }
 ```

--- a/modules/docs/ko/advanced-features/ai-agents/using-ai-sdk.mdx
+++ b/modules/docs/ko/advanced-features/ai-agents/using-ai-sdk.mdx
@@ -313,8 +313,8 @@ import { rtzr } from "sonamu/ai/providers/rtzr";
 class TranscriptionModelClass extends BaseModelClass {
   @upload()
   async transcribeAudio() {
-    const { files } = Sonamu.getContext();
-    const file = files?.[0]; // 첫 번째 파일 사용
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
 
     if (!file) {
       throw new Error("오디오 파일이 없습니다");
@@ -322,7 +322,7 @@ class TranscriptionModelClass extends BaseModelClass {
 
     // 음성 인식
     const model = rtzr.transcription("whisper");
-    const buffer = await file.toBuffer();
+    const buffer = file.buffer;
 
     const result = await model.doGenerate({
       audio: buffer,
@@ -402,14 +402,14 @@ import { generateText } from "ai";
 class ImageAnalysisModelClass extends BaseModelClass {
   @upload()
   async analyzeImage() {
-    const { files } = Sonamu.getContext();
-    const file = files?.[0]; // 첫 번째 파일 사용
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
 
     if (!file || !file.mimetype.startsWith("image/")) {
       throw new Error("이미지 파일이 필요합니다");
     }
 
-    const buffer = await file.toBuffer();
+    const buffer = file.buffer;
 
     const result = await generateText({
       model: openai("gpt-4o"),

--- a/modules/docs/ko/advanced-features/sse/creating-sse-endpoints.mdx
+++ b/modules/docs/ko/advanced-features/sse/creating-sse-endpoints.mdx
@@ -24,7 +24,7 @@ class NotificationModelClass extends BaseModelClass {
       }),
     }),
   })
-  async streamNotifications(userId: number, ctx: Context): Promise<void> {
+  async streamNotifications(userId: number, ctx: Context) {
     const sse = ctx.createSSE(
       z.object({
         notification: z.object({
@@ -42,6 +42,8 @@ class NotificationModelClass extends BaseModelClass {
 
     // 연결 종료
     await sse.end();
+
+    return sse;
   }
 }
 ```

--- a/modules/docs/ko/api-development/file-upload/uploaded-file-class.mdx
+++ b/modules/docs/ko/api-development/file-upload/uploaded-file-class.mdx
@@ -1,9 +1,9 @@
 ---
-title: "UploadedFile 클래스"
+title: "BufferedFile 클래스"
 description: "파일 정보 접근과 saveToDisk() 메서드"
 ---
 
-UploadedFile 클래스는 업로드된 파일의 정보를 제공하고, `saveToDisk()` 메서드로 파일을 저장합니다.
+BufferedFile 클래스는 업로드된 파일의 정보를 제공하고, `saveToDisk()` 메서드로 파일을 저장합니다.
 
 ## UploadedFile 개요
 
@@ -14,8 +14,8 @@ UploadedFile 클래스는 업로드된 파일의 정보를 제공하고, `saveTo
   <Card title="saveToDisk()" icon="floppy-disk">
     스토리지에 저장 URL 자동 생성
   </Card>
-  <Card title="toBuffer()" icon="memory">
-    Buffer 변환 캐싱 지원
+  <Card title="buffer" icon="memory">
+    Buffer 접근 `.buffer` getter
   </Card>
   <Card title="URL 속성" icon="link">
     url, signedUrl 저장 후 자동 설정
@@ -27,12 +27,14 @@ UploadedFile 클래스는 업로드된 파일의 정보를 제공하고, `saveTo
 ### 파일 정보
 
 ```typescript
-import type { UploadedFile } from "sonamu";
+import type { BufferedFile } from "sonamu";
 
 class FileModel extends BaseModelClass {
   @upload()
-  async upload(params: { file: UploadedFile }): Promise<any> {
-    const { file } = params;
+  async upload(): Promise<any> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
+    if (!file) throw new Error("File is required");
 
     // 파일 정보 접근
     console.log({
@@ -68,8 +70,10 @@ class FileModel extends BaseModelClass {
 ```typescript
 class FileModel extends BaseModelClass {
   @upload()
-  async upload(params: { file: UploadedFile }): Promise<{ url: string }> {
-    const { file } = params;
+  async upload(): Promise<{ url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
+    if (!file) throw new Error("File is required");
 
     // 파일 저장 (기본 디스크 사용)
     const url = await file.saveToDisk("fs", `uploads/${Date.now()}-${file.filename}`);
@@ -88,21 +92,22 @@ class FileModel extends BaseModelClass {
 ```typescript
 class FileModel extends BaseModelClass {
   @upload()
-  async uploadToS3(params: { file: UploadedFile }): Promise<{ url: string }> {
-    const { file } = params;
+  async uploadToS3(): Promise<{ url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
+    if (!file) throw new Error("File is required");
 
     // S3 디스크에 저장
-    const url = await file.saveToDisk(
-      "s3", // 디스크 이름
-      `uploads/${Date.now()}-${file.filename}`,
-    );
+    const url = await file.saveToDisk("s3", `uploads/${Date.now()}-${file.filename}`);
 
     return { url };
   }
 
   @upload()
-  async uploadPublic(params: { file: UploadedFile }): Promise<{ url: string }> {
-    const { file } = params;
+  async uploadPublic(): Promise<{ url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
+    if (!file) throw new Error("File is required");
 
     // Public 디스크에 저장
     const url = await file.saveToDisk("public", `public/${Date.now()}-${file.filename}`);
@@ -112,18 +117,20 @@ class FileModel extends BaseModelClass {
 }
 ```
 
-## Buffer 변환
+## buffer Getter
 
-### toBuffer() 메서드
+### buffer 속성
 
 ```typescript
 class FileModel extends BaseModelClass {
   @upload()
-  async processImage(params: { image: UploadedFile }): Promise<{ url: string }> {
-    const { image } = params;
+  async processImage(): Promise<{ url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const image = bufferedFiles?.[0];
+    if (!image) throw new Error("Image is required");
 
-    // Buffer로 변환 (캐싱됨)
-    const buffer = await image.toBuffer();
+    // Buffer에 직접 접근
+    const buffer = image.buffer;
 
     console.log("Buffer size:", buffer.length);
 
@@ -148,7 +155,7 @@ class FileModel extends BaseModelClass {
 }
 ```
 
-<Info>`toBuffer()`는 결과를 캐싱하므로, 여러 번 호출해도 한 번만 읽습니다.</Info>
+<Info>`.buffer`는 multipart 파싱 시 미리 로드된 Buffer를 반환하는 getter입니다.</Info>
 
 ## MD5 해시
 
@@ -157,11 +164,13 @@ class FileModel extends BaseModelClass {
 ```typescript
 class FileModel extends BaseModelClass {
   @upload()
-  async uploadWithHash(params: { file: UploadedFile }): Promise<{
+  async uploadWithHash(): Promise<{
     url: string;
     md5: string;
   }> {
-    const { file } = params;
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
+    if (!file) throw new Error("File is required");
 
     // MD5 해시 계산
     const md5Hash = await file.md5();
@@ -213,8 +222,10 @@ class FileValidator {
 // 사용
 class FileModel extends BaseModelClass {
   @upload()
-  async upload(params: { file: UploadedFile }): Promise<{ url: string }> {
-    const { file } = params;
+  async upload(): Promise<{ url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
+    if (!file) throw new Error("File is required");
 
     // 크기 검증 (10MB)
     FileValidator.validateSize(file, 10 * 1024 * 1024);
@@ -242,8 +253,10 @@ class FileValidator {
 // 사용
 class ImageModel extends BaseModelClass {
   @upload()
-  async uploadImage(params: { image: UploadedFile }): Promise<{ url: string }> {
-    const { image } = params;
+  async uploadImage(): Promise<{ url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const image = bufferedFiles?.[0];
+    if (!image) throw new Error("Image is required");
 
     // MIME 타입 검증
     FileValidator.validateMimeType(image, ["image/jpeg", "image/png", "image/gif", "image/webp"]);
@@ -273,8 +286,10 @@ class FileValidator {
 // 사용
 class DocumentModel extends BaseModelClass {
   @upload()
-  async uploadDocument(params: { document: UploadedFile }): Promise<{ url: string }> {
-    const { document } = params;
+  async uploadDocument(): Promise<{ url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const document = bufferedFiles?.[0];
+    if (!document) throw new Error("Document is required");
 
     // 확장자 검증
     FileValidator.validateExtension(document, ["pdf", "doc", "docx", "txt"]);
@@ -346,8 +361,10 @@ class FileValidator {
 // 사용
 class MediaModel extends BaseModelClass {
   @upload()
-  async uploadImage(params: { image: UploadedFile }): Promise<{ url: string }> {
-    const { image } = params;
+  async uploadImage(): Promise<{ url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const image = bufferedFiles?.[0];
+    if (!image) throw new Error("Image is required");
 
     FileValidator.validateImage(image);
 
@@ -365,7 +382,7 @@ class MediaModel extends BaseModelClass {
 ```typescript
 class UserModel extends BaseModelClass {
   @upload()
-  async uploadProfileImage(params: { image: UploadedFile }): Promise<{
+  async uploadProfileImage(): Promise<{
     imageId: number;
     url: string;
     thumbnailUrl: string;
@@ -376,13 +393,15 @@ class UserModel extends BaseModelClass {
       throw new Error("Authentication required");
     }
 
-    const { image } = params;
+    const { bufferedFiles } = context;
+    const image = bufferedFiles?.[0];
+    if (!image) throw new Error("Image is required");
 
     // 검증
     FileValidator.validateImage(image);
 
     // 원본 이미지 Buffer
-    const buffer = await image.toBuffer();
+    const buffer = image.buffer;
 
     // 썸네일 생성
     const sharp = require("sharp");
@@ -432,7 +451,7 @@ class UserModel extends BaseModelClass {
 ```typescript
 class FileModel extends BaseModelClass {
   @upload()
-  async uploadMultiple(params: { files: UploadedFile[]; category?: string }): Promise<{
+  async uploadMultiple(params: { category?: string }): Promise<{
     uploadedFiles: Array<{
       fileId: number;
       filename: string;
@@ -440,20 +459,21 @@ class FileModel extends BaseModelClass {
       md5: string;
     }>;
   }> {
-    const { files, category } = params;
+    const { bufferedFiles } = Sonamu.getContext();
+    const { category } = params;
 
-    if (!files || files.length === 0) {
+    if (!bufferedFiles || bufferedFiles.length === 0) {
       throw new Error("At least one file is required");
     }
 
-    if (files.length > 10) {
+    if (bufferedFiles.length > 10) {
       throw new Error("Maximum 10 files allowed");
     }
 
     const uploadedFiles = [];
     const wdb = this.getPuri("w");
 
-    for (const file of files) {
+    for (const file of bufferedFiles) {
       // 검증
       if (file.size > 20 * 1024 * 1024) {
         throw new Error(`File ${file.filename} too large (max 20MB)`);
@@ -515,8 +535,10 @@ class FileModel extends BaseModelClass {
 ```typescript
 class FileModel extends BaseModelClass {
   @upload()
-  async uploadAdvanced(params: { file: UploadedFile }): Promise<any> {
-    const { file } = params;
+  async uploadAdvanced(): Promise<any> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
+    if (!file) throw new Error("File is required");
 
     // 원본 Fastify MultipartFile 접근
     const rawFile = file.raw;
@@ -537,8 +559,8 @@ class FileModel extends BaseModelClass {
 ## 주의사항
 
 <Warning>
-  **UploadedFile 사용 시 주의사항**: 1. `saveToDisk()` 호출 전 검증 필수 2. `toBuffer()`는
-  캐싱되므로 여러 번 호출 가능 3. `url`, `signedUrl`은 저장 후에만 사용 가능 4. 대용량 파일은
+  **UploadedFile 사용 시 주의사항**: 1. `saveToDisk()` 호출 전 검증 필수 2.
+  `.buffer`로 미리 로드된 Buffer에 직접 접근 가능 3. `url`, `signedUrl`은 저장 후에만 사용 가능 4. 대용량 파일은
   스트리밍 고려 5. Storage 설정 확인
 </Warning>
 

--- a/modules/docs/ko/api-reference/context/sonamu-context.mdx
+++ b/modules/docs/ko/api-reference/context/sonamu-context.mdx
@@ -91,7 +91,7 @@ class MyModelClass extends BaseModelClass {
     // 완료 이벤트 전송
     await sse.publish("complete", { result: "done" });
 
-    return sse.getResponse();
+    return sse;
   }
 }
 ```


### PR DESCRIPTION
이 PR은 AI(Claude Code)에 의해 자동 생성된 Nightly PR입니다.
코드베이스의 ownership은 전적으로 maintainer에게 있으며, 이 PR은 검토 후 판단을 돕기 위한 제안입니다.

## 어떤 issue를 참조했으며, 왜 이 작업을 선정했나요?

[#44 - 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44)을 참조했습니다.

Issue #44의 범위 중:
> 문서와 주석이 코드와 어긋나는 경우 -> 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다.

기존 Nightly PR들(#117~#150)의 description을 모두 확인하였으며, 이번에 수정하는 `toBuffer()` 메서드 미존재, `files` Context 속성 미존재, SSE `getResponse()` 미존재 문제는 이전에 조치된 적이 없는 건들입니다.

## 무엇이 문제인가요?

### 1. `toBuffer()` 메서드가 어떤 파일 클래스에도 존재하지 않음 (ko 3파일 + en 1파일)

`BufferedFile` 클래스의 실제 정의(`modules/sonamu/src/storage/buffered-file.ts`):
- `.buffer` getter (동기) - Buffer에 직접 접근
- `.md5()` - MD5 해시 계산
- `.saveToDisk()` - 디스크에 저장

`UploadedFile` 클래스(`modules/sonamu/src/storage/uploaded-file.ts`):
- `.download()` (비동기) - 저장소에서 다운로드

어디에도 `toBuffer()` 메서드가 없습니다. 문서를 따라 코드를 작성하면 런타임에 `TypeError: file.toBuffer is not a function`이 발생합니다.

### 2. Context에 `files` 속성이 존재하지 않음 (ko 1파일 + en 1파일)

`Context` 타입의 실제 정의(`modules/sonamu/src/api/context.ts`):
```typescript
bufferedFiles?: BufferedFile[];   // buffer 모드
uploadedFiles?: UploadedFile[];   // stream 모드
```

`files` 속성은 없습니다. AI SDK 문서(`using-ai-sdk.mdx`)에서 `const { files } = Sonamu.getContext()`를 사용하고 있었으나, 이는 항상 `undefined`를 반환합니다.

### 3. SSE `getResponse()` 메서드가 존재하지 않음 (ko 1파일 + en 1파일)

`SSEConnection` 인터페이스(`modules/sonamu/src/stream/sse.ts`):
```typescript
export interface SSEConnection<T extends z.ZodObject> {
  get closed(): boolean;
  onClose(callback: () => void): void;
  publish<K extends keyof z.infer<T>>(event: K, data: z.infer<T>[K]): void;
  end(): Promise<void>;
}
```

`getResponse()` 메서드가 없습니다. `sonamu-context.mdx`의 SSE 예제에서 `return sse.getResponse()`를 사용하고 있었습니다.

### 4. SSE 엔드포인트 예제에서 `return sse` 누락 (ko 1파일 + en 1파일)

`@stream` 데코레이터 문서(`stream.mdx`)의 모든 예제는 `return sse;`를 사용하지만, `creating-sse-endpoints.mdx`의 기본 예제만 `Promise<void>` 반환 타입에 `return` 없이 종료되고 있었습니다.

## 어떤 접근 방식을 채택했나요?

1. **한국어 `uploaded-file-class.mdx` 전면 동기화**: 영어 버전은 이미 올바르게 수정되어 있었으므로(BufferedFile, Context 접근, .buffer getter), 한국어 버전을 영어 버전의 구조와 일치시켰습니다.

2. **AI SDK 문서 최소 수정**: `files` → `bufferedFiles`, `toBuffer()` → `.buffer`만 변경했습니다.

3. **SSE 문서 최소 수정**: `getResponse()` → `sse` 반환, `creating-sse-endpoints.mdx`에 `return sse;` 추가만 수행했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가요?

- 사용자가 문서의 코드 예제를 그대로 복사하면 `TypeError: file.toBuffer is not a function`, `TypeError: sse.getResponse is not a function` 등의 런타임 에러가 발생합니다.
- Context에서 `files` 속성을 사용하면 항상 `undefined`가 반환되어 파일 처리가 불가능합니다.
- 특히 AI SDK 통합(음성 인식, 이미지 분석) 문서는 실전 활용 빈도가 높아 영향이 큽니다.

## 어떤 기능에 영향을 미치나요?

- 문서 코드 예제만 변경합니다. 소스 코드 변경은 없습니다.
- 영향 범위: 파일 업로드 API, AI SDK 통합, SSE 엔드포인트 가이드

## 변경 영향을 확인하는 방법

- 각 문서의 코드 예제에서 참조하는 메서드/속성이 실제 소스 코드에 존재하는지 확인:
  - `BufferedFile.buffer` getter: `modules/sonamu/src/storage/buffered-file.ts:27`
  - `Context.bufferedFiles`: `modules/sonamu/src/api/context.ts:29`
  - `SSEConnection` 인터페이스: `modules/sonamu/src/stream/sse.ts:24-29`
- `pnpm check`: 0 에러 통과
- `pnpm --filter sonamu build`: 성공
- `pnpm --filter sonamu test:type`: 39 passed, no type errors

## 검토 필요 사항

- 한국어 `uploaded-file-class.mdx`는 전면 재작성되었습니다. 영어 버전과 구조가 일치하도록 했으나, 번역 품질이나 미묘한 표현 차이가 있을 수 있습니다.
- `FileValidator` 클래스의 타입 파라미터가 영어 문서에서도 `UploadedFile`로 남아 있는데, 이는 베이스 클래스 `BaseFile`의 속성만 사용하므로 기능상 문제는 없으나, `BufferedFile`로 통일할지는 maintainer 판단이 필요합니다.