### PR TITLE
[Nightly 2026-04-16] Puri 문서의 미존재 .count() 인스턴스 메서드 및 truncate 참조 수정, batchUpdate JSDoc 파라미터명 불일치 수정

### DIFF
--- a/modules/docs/en/database/puri/basic-queries.mdx
+++ b/modules/docs/en/database/puri/basic-queries.mdx
@@ -18,7 +18,7 @@ Puri is a type-safe query builder that lets you write SQL queries safely in Type
     Modify data update, increment, decrement
   </Card>
   <Card title="DELETE" icon="trash">
-    Delete data delete, truncate
+    Delete data delete
   </Card>
 </CardGroup>
 
@@ -411,19 +411,23 @@ const emails = await db
 
 </CodeGroup>
 
-## count() - Count Records
+## count - Count Records
 
-Quickly query record count.
+To query record count, use the `Puri.count()` static method inside `select`.
 
 ```typescript
-const count = await db.table("users").where("role", "admin").count();
+const result = await db
+  .table("users")
+  .where("role", "admin")
+  .select({ total: Puri.count() })
+  .first();
 
-console.log(`Total admins: ${count}`);
+console.log(`Total admins: ${result.total}`);
 // Type: number
 ```
 
 <Tip>
-  `count()` is a simple count method, not an aggregate function. For complex aggregations, see
+  `Puri.count()` is a static method used inside the `SELECT` clause. For more complex aggregations, see
   [Aggregations](/en/database/puri/aggregations).
 </Tip>
 
@@ -466,10 +470,11 @@ async findUsers(params: {
     .offset((page - 1) * pageSize);
 
   // Total count
-  const total = await this.getPuri("r")
+  const { total } = await this.getPuri("r")
     .table("users")
     .where("role", role)
-    .count();
+    .select({ total: Puri.count() })
+    .first();
 
   return { users, total };
 }

--- a/modules/docs/en/database/puri/type-safety.mdx
+++ b/modules/docs/en/database/puri/type-safety.mdx
@@ -339,7 +339,9 @@ async paginate<T>(
 
   // Total count
   const countQuery = query.clone();
-  const total = await countQuery.count();
+  const { total } = await countQuery
+    .select({ total: Puri.count() })
+    .first();
 
   // Page data
   const data = await query

--- a/modules/docs/ko/database/puri/basic-queries.mdx
+++ b/modules/docs/ko/database/puri/basic-queries.mdx
@@ -18,7 +18,7 @@ Puri는 TypeScript로 안전하게 SQL 쿼리를 작성할 수 있는 타입 안
     데이터 수정하기 update, increment, decrement
   </Card>
   <Card title="DELETE" icon="trash">
-    데이터 삭제하기 delete, truncate
+    데이터 삭제하기 delete
   </Card>
 </CardGroup>
 
@@ -411,19 +411,23 @@ const emails = await db
 
 </CodeGroup>
 
-## count() - 개수 세기
+## count - 개수 세기
 
-레코드 개수를 빠르게 조회합니다.
+레코드 개수를 조회하려면 `Puri.count()` 정적 메서드를 `select` 안에서 사용합니다.
 
 ```typescript
-const count = await db.table("users").where("role", "admin").count();
+const result = await db
+  .table("users")
+  .where("role", "admin")
+  .select({ total: Puri.count() })
+  .first();
 
-console.log(`Total admins: ${count}`);
+console.log(`Total admins: ${result.total}`);
 // 타입: number
 ```
 
 <Tip>
-  `count()`는 집계 함수가 아닌 간단한 개수 조회 메서드입니다. 복잡한 집계는
+  `Puri.count()`는 `SELECT` 절 안에서 사용하는 정적 메서드입니다. 더 복잡한 집계는
   [Aggregations](/ko/database/puri/aggregations) 참고
 </Tip>
 
@@ -466,10 +470,11 @@ async findUsers(params: {
     .offset((page - 1) * pageSize);
 
   // 전체 개수
-  const total = await this.getPuri("r")
+  const { total } = await this.getPuri("r")
     .table("users")
     .where("role", role)
-    .count();
+    .select({ total: Puri.count() })
+    .first();
 
   return { users, total };
 }

--- a/modules/docs/ko/database/puri/type-safety.mdx
+++ b/modules/docs/ko/database/puri/type-safety.mdx
@@ -339,7 +339,9 @@ async paginate<T>(
 
   // 전체 개수
   const countQuery = query.clone();
-  const total = await countQuery.count();
+  const { total } = await countQuery
+    .select({ total: Puri.count() })
+    .first();
 
   // 페이지 데이터
   const data = await query

--- a/modules/sonamu/src/database/_batch_update.ts
+++ b/modules/sonamu/src/database/_batch_update.ts
@@ -15,7 +15,7 @@ export type RowWithId<Id extends string> = {
 
 /**
  * Batch update rows in a table. Technically its a patch since it only updates the specified columns. Any omitted columns will not be affected
- * @param db
+ * @param knex
  * @param tableName
  * @param ids
  * @param rows


### PR DESCRIPTION
이 PR은 AI(Claude Code)에 의해 자동 생성된 Nightly PR입니다.
코드베이스의 ownership은 전적으로 maintainer에게 있으며, 이 PR은 검토 후 판단을 돕기 위한 제안입니다.

## 어떤 issue를 참조했으며, 왜 이 작업을 선정했나요?

[#44 - 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44)을 참조했습니다.

Issue #44의 범위 중:
> 문서와 주석이 코드와 어긋나는 경우 -> 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다.

기존 Nightly PR들(#128~#152)의 description을 모두 확인하였으며, `.count()` 인스턴스 메서드 사용, `truncate` 참조, `batchUpdate` JSDoc 불일치는 이전에 조치된 적이 없는 건들입니다. (PR #148에서 `this.puri()` → `getPuri()` 수정, PR #147에서 `this.db()` → `getPuri()` 수정 등은 별도의 문제입니다.)

## 무엇이 문제인가요?

### 1. `.count()` 인스턴스 메서드가 Puri에 존재하지 않음 (ko 2파일 + en 2파일, 4개소)

`Puri` 클래스에는 `.count()`를 쿼리 체인에서 호출하는 인스턴스 메서드가 없습니다. `count`는 오직 **정적 메서드**(`Puri.count()`)로만 존재하며, `SELECT` 절 안에서 사용해야 합니다:

```typescript
// 실제 API (puri.ts:99)
static count(column: string = "*"): SqlExpression<"number">
```

그러나 문서의 코드 예제에서는 인스턴스 메서드처럼 사용하고 있었습니다:

```typescript
// ❌ 문서 (basic-queries.mdx, type-safety.mdx)
const count = await db.table("users").where("role", "admin").count();

// ✅ 실제 사용법 (miomock 테스트 코드, aggregations.mdx와 일치)
const result = await db.table("users").select({ total: Puri.count() }).first();
```

문서를 따라 코드를 작성하면 `TypeError: db.table(...).where(...).count is not a function` 런타임 에러가 발생합니다.

### 2. `truncate` 메서드가 Puri에 존재하지 않음 (ko 1파일 + en 1파일, 1개소)

`basic-queries.mdx`의 개요 Card에서 DELETE 항목에 "delete, truncate"으로 표시하고 있으나, `puri.ts`에 `truncate()` 메서드는 구현되어 있지 않습니다.

### 3. `batchUpdate` JSDoc `@param db` vs 실제 파라미터 `knex` (소스 1파일)

`_batch_update.ts`의 `batchUpdate()` 함수에서:
- JSDoc: `@param db`
- 실제 시그니처: `knex: Knex`

IDE의 인텔리센스에서 잘못된 파라미터명이 표시됩니다.

## 어떤 접근 방식을 채택했으며, 왜 그랬나요?

1. **`.count()` → `Puri.count()` 패턴**: miomock 테스트 코드(`puri-query.test.ts`, `puri-type-safety.test.ts`)와 `aggregations.mdx` 문서에서 이미 사용하고 있는 `select({ total: Puri.count() }).first()` 패턴으로 일관되게 수정했습니다.

2. **`truncate` 제거**: Puri 소스코드(`puri.ts`) 전체를 검색하여 `truncate` 메서드가 없음을 확인한 후, Card의 설명에서만 제거했습니다.

3. **JSDoc `@param db` → `@param knex`**: 실제 함수 시그니처에 맞게 최소 수정만 수행했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가요?

- `basic-queries.mdx`는 Puri 쿼리 빌더의 **입문 문서**입니다. 사용자가 가장 먼저 참조하는 문서에서 "개수 세기"의 코드 예제가 런타임 에러를 발생시키면, 프레임워크에 대한 첫인상이 크게 손상됩니다.
- `type-safety.mdx`의 paginate 예제는 실전에서 바로 복사해서 사용하기 쉬운 패턴입니다. 이 예제가 동작하지 않으면 불필요한 디버깅 시간이 소요됩니다.
- `truncate`이 Card에 나열되어 있으면 사용자가 해당 기능이 존재한다고 기대하지만, 실제로는 없습니다.

## 이 변경이 어떤 기능에 영향을 미치나요?

문서(.mdx) 4파일과 소스 코드 JSDoc 1파일만 수정했습니다. 런타임 동작에 영향 없습니다.

## 이 변경이 미치는 영향을 확인하는 방법

- `Puri.count()` 정적 메서드 존재 확인: `modules/sonamu/src/database/puri.ts:99`
- 인스턴스 `.count()` 메서드 부재 확인: `puri.ts` 전체에서 정적 메서드 외에 count 인스턴스 메서드 없음
- `truncate` 메서드 부재 확인: `puri.ts` 전체에서 truncate 문자열 없음
- `batchUpdate` 시그니처 확인: `_batch_update.ts:25` → `knex: Knex`
- miomock 테스트의 올바른 사용 패턴 확인: `puri-query.test.ts:371`, `puri-type-safety.test.ts:552`
- `pnpm check`: 0 에러, 264 기존 경고
- `pnpm --filter sonamu build`: 성공
- `pnpm --filter sonamu test:type`: 39 passed, no type errors

## 검토 필요 사항

- **`.count()` 인스턴스 메서드 추가 여부**: 현재는 정적 메서드만 존재하지만, 문서에서 `.count()`를 인스턴스 메서드로 사용하는 패턴이 여러 곳에 있었다는 것은 해당 API가 직관적이라는 의미일 수 있습니다. 만약 `query.count()` 편의 메서드를 추가하고 싶다면 문서를 되돌리는 대신 소스코드에 메서드를 추가하는 것도 고려할 수 있습니다.
- **`truncate` 기능 추가 여부**: Card에서 truncate을 제거했지만, 향후 Puri에 `truncate()` 메서드를 추가할 계획이 있다면 Card 설명을 유지할 수 있습니다.