### PR TITLE
[Nightly 2026-04-17] 영어 문서 동기화: api-decorator cacheControl/compress 섹션 및 using-services Service 생성 메커니즘 섹션 추가

### DIFF
--- a/modules/docs/en/api-development/creating-apis/api-decorator.mdx
+++ b/modules/docs/en/api-development/creating-apis/api-decorator.mdx
@@ -454,6 +454,199 @@ class UserModelClass extends BaseModelClass<
 }
 ```
 
+### @api + cacheControl/compress Options
+
+You can control caching and compression of API responses directly from the `@api` decorator.
+
+#### Cache-Control Configuration
+
+```typescript
+class PostModelClass extends BaseModelClass<
+  PostSubsetKey,
+  PostSubsetMapping,
+  typeof postSubsetQueries,
+  typeof postLoaderQueries
+> {
+  constructor() {
+    super("Post", postSubsetQueries, postLoaderQueries);
+  }
+
+  // Public post list - 1 hour cache
+  @api({
+    httpMethod: "GET",
+    cacheControl: {
+      maxAge: 3600, // Browser cache: 1 hour
+      sMaxAge: 7200, // CDN cache: 2 hours
+      staleWhileRevalidate: 86400, // Allow stale state for 24 hours
+    },
+  })
+  async getPublicPosts(): Promise<Post[]> {
+    const rdb = this.getPuri("r");
+    return rdb.table("posts").where("public", true).select("*");
+  }
+
+  // Using cache presets
+  @api({
+    httpMethod: "GET",
+    cacheControl: "5m", // 5 minute cache
+  })
+  async getTrendingPosts(): Promise<Post[]> {
+    // ...
+  }
+}
+```
+
+**Cache-Control Options**:
+
+- `maxAge`: Browser cache duration (seconds)
+- `sMaxAge`: CDN/proxy cache duration (seconds)
+- `staleWhileRevalidate`: Stale state allowance duration (seconds)
+- `public`: Public cache flag (default: true)
+- `private`: Private cache (per-user)
+
+**Preset Strings**:
+
+- Time unit strings like `"1m"`, `"5m"`, `"1h"`, `"1d"` can be used
+
+#### Compression Configuration
+
+```typescript
+class DataModelClass extends BaseModelClass<
+  DataSubsetKey,
+  DataSubsetMapping,
+  typeof dataSubsetQueries,
+  typeof dataLoaderQueries
+> {
+  constructor() {
+    super("Data", dataSubsetQueries, dataLoaderQueries);
+  }
+
+  // Large dataset - enable compression
+  @api({
+    httpMethod: "GET",
+    compress: true, // Enable gzip/deflate compression
+  })
+  async getLargeDataset(): Promise<DataPoint[]> {
+    const rdb = this.getPuri("r");
+    return rdb.table("data_points").limit(10000).select("*");
+  }
+
+  // Already compressed data - disable compression
+  @api({
+    httpMethod: "GET",
+    compress: false, // Disable compression
+  })
+  async getCompressedFile(): Promise<Buffer> {
+    // Return already compressed file
+    // ...
+  }
+}
+```
+
+**Compression Options**:
+
+- `true`: Compress response with gzip/deflate
+- `false`: Disable compression (default)
+
+#### Combined Usage
+
+```typescript
+class ApiModelClass extends BaseModelClass<
+  ApiSubsetKey,
+  ApiSubsetMapping,
+  typeof apiSubsetQueries,
+  typeof apiLoaderQueries
+> {
+  constructor() {
+    super("Api", apiSubsetQueries, apiLoaderQueries);
+  }
+
+  // Caching + compression
+  @api({
+    httpMethod: "GET",
+    cacheControl: { maxAge: 3600, sMaxAge: 7200 },
+    compress: true,
+  })
+  async getReport(reportId: number): Promise<Report> {
+    const rdb = this.getPuri("r");
+
+    // Large report data
+    const report = await rdb.table("reports").where("id", reportId).first();
+
+    if (!report) {
+      throw new Error("Report not found");
+    }
+
+    return report;
+  }
+}
+```
+
+**Practical Example: API Optimization**:
+
+```typescript
+class OptimizedApiModelClass extends BaseModelClass<
+  OptimizedApiSubsetKey,
+  OptimizedApiSubsetMapping,
+  typeof optimizedApiSubsetQueries,
+  typeof optimizedApiLoaderQueries
+> {
+  constructor() {
+    super("OptimizedApi", optimizedApiSubsetQueries, optimizedApiLoaderQueries);
+  }
+
+  // Static content: long cache + compression
+  @api({
+    httpMethod: "GET",
+    cacheControl: { maxAge: 86400, sMaxAge: 604800 }, // 1 day / 1 week
+    compress: true,
+  })
+  async getStaticContent(): Promise<Content> {
+    // ...
+  }
+
+  // Dynamic content: short cache + compression
+  @api({
+    httpMethod: "GET",
+    cacheControl: "5m",
+    compress: true,
+  })
+  async getDynamicData(): Promise<Data[]> {
+    // ...
+  }
+
+  // Private data: no cache (private)
+  @api({
+    httpMethod: "GET",
+    cacheControl: { private: true, maxAge: 0 },
+  })
+  async getUserPrivateData(userId: number): Promise<PrivateData> {
+    // ...
+  }
+
+  // Large download: compression only
+  @api({
+    httpMethod: "GET",
+    compress: true,
+  })
+  async downloadLargeFile(fileId: string): Promise<Buffer> {
+    // ...
+  }
+}
+```
+
+<Info>
+**Performance Tips**:
+- Use `cacheControl` for static or infrequently changing data
+- Use `compress: true` for responses larger than 10KB
+- Use `{ private: true, maxAge: 0 }` to prevent caching of private data
+</Info>
+
+<Warning>
+  **Caution**: - `compress: true` increases CPU usage (inefficient for small responses) - Excessively
+  long cache durations can delay update propagation - `private: true` disables CDN caching
+</Warning>
+
 ## Error Handling
 
 ### Automatic Error Conversion

--- a/modules/docs/en/frontend-integration/generated-services/using-services.mdx
+++ b/modules/docs/en/frontend-integration/generated-services/using-services.mdx
@@ -311,6 +311,234 @@ For detailed information about SSR, see the following documents.
   </Card>
 </CardGroup>
 
+### Understanding the Service Creation Mechanism
+
+Services are **Namespace-based static function collections**.
+
+#### Services are Namespaces, Not Classes
+
+```typescript
+// services.generated.ts (auto-generated)
+
+// ❌ Not a class
+// class UserService { ... }
+
+// ✅ It's a Namespace
+export namespace UserService {
+  // Static functions
+  export async function getUser<T extends UserSubsetKey>(
+    subset: T,
+    id: number,
+  ): Promise<UserSubsetMapping[T]> {
+    return fetch({
+      method: "GET",
+      url: `/api/user/getUser?${qs.stringify({ subset, id })}`,
+    });
+  }
+
+  export async function save(spa: UserSaveParams[]): Promise<number[]> {
+    return fetch({
+      method: "POST",
+      url: `/api/user/save`,
+      data: { spa },
+    });
+  }
+
+  // TanStack Query Hook
+  export const useUser = <T extends UserSubsetKey>(subset: T, id: number) =>
+    useQuery({
+      queryKey: ["User", "getUser", subset, id],
+      queryFn: () => getUser(subset, id),
+    });
+}
+```
+
+**Namespace Characteristics**:
+
+- **Stateless**: No instance creation needed
+- **Static calls**: Call `UserService.getUser()` directly
+- **Type-safe**: Full type inference via TypeScript Namespaces
+- **Tree-shakable**: Unused functions are excluded from the bundle
+
+#### Services Have No Dependency Injection (DI)
+
+Services are **pure functions**, so no dependencies are injected:
+
+```typescript
+// ❌ No DI (not a class)
+// new UserService(dependencies)
+
+// ✅ Direct call
+const user = await UserService.getUser("A", 123);
+```
+
+**How is Context passed?**
+
+Services **pass Context via HTTP requests**:
+
+```typescript
+// Service internals (simplified)
+export async function getUser(subset: string, id: number) {
+  return fetch({
+    method: "GET",
+    url: `/api/user/getUser?subset=${subset}&id=${id}`,
+    // Context is passed via HTTP headers
+    headers: {
+      Authorization: `Bearer ${getToken()}`,
+      Cookie: document.cookie, // Session information
+    },
+  });
+}
+```
+
+On the backend, **Context is automatically extracted from the HTTP request**:
+
+```typescript
+// Backend Model
+class UserModelClass extends BaseModelClass {
+  @api({ httpMethod: "GET" })
+  async getUser(subset: string, id: number) {
+    // Context is automatically parsed from the HTTP request
+    const context = Sonamu.getContext();
+
+    console.log(context.user); // Authenticated user
+    console.log(context.session); // Session information
+    console.log(context.ip); // Client IP
+
+    // Authorization checks possible
+    if (!context.user) {
+      throw new UnauthorizedError();
+    }
+
+    return this.findById(id, [subset]);
+  }
+}
+```
+
+#### Service Creation Process
+
+```mermaid
+flowchart LR
+    A[Model @api] --> B[Sonamu Sync]
+    B --> C[services.generated.ts]
+    C --> D[Namespace Functions]
+    C --> E[TanStack Query Hook]
+
+    style A fill:#e3f2fd
+    style B fill:#fff9c4
+    style C fill:#e8f5e9
+    style D fill:#c8e6c9
+    style E fill:#f3e5f5
+```
+
+**Creation Steps**:
+
+1. **Backend**: Write `@api` decorator on Model
+2. **Sonamu Sync**: Run `pnpm sonamu sync`
+3. **Auto-generation**: `services.generated.ts` file created
+4. **Namespace Functions**: Each API method converted to Namespace function
+5. **Hook Generation**: GET methods automatically generate `useQuery` Hooks
+
+#### Where Are Model Instances?
+
+**Created directly in Server Components**:
+
+```typescript
+// Server Component
+export default async function UserPage() {
+  // ✅ Instantiate Model directly on the server
+  const userModel = new UserModel();
+  const user = await userModel.findById(1, ["A"]);
+
+  return <div>{user.username}</div>;
+}
+```
+
+**Why is `new UserModel()` safe?**
+
+- Models are **stateless**, so creating new instances each time is safe
+- The constructor only initializes Subset queries
+- Context is dynamically retrieved via `Sonamu.getContext()`
+
+```typescript
+// Model internals
+class UserModelClass extends BaseModelClass {
+  constructor() {
+    super("User", userSubsetQueries, userLoaderQueries);
+    // No state stored
+  }
+
+  async findById(id: number, subsets: string[]) {
+    // Context is dynamically retrieved here
+    const context = Sonamu.getContext();
+
+    // Execute DB query
+    return this.getPuri("r", subsets).where("id", id).first();
+  }
+}
+```
+
+#### Service vs Model Comparison
+
+| Item              | Service (Frontend)      | Model (Backend)        |
+| ----------------- | ----------------------- | ---------------------- |
+| **Type**          | Namespace               | Class Instance         |
+| **Call Style**    | `UserService.getUser()` | `userModel.findById()` |
+| **State**         | Stateless               | Stateless              |
+| **Dependencies**  | None                    | BaseModelClass         |
+| **Context**       | Passed via HTTP headers | `Sonamu.getContext()`  |
+| **Usage Context** | Client Component        | Server Component / API |
+| **Creation**      | Auto-generated          | Developer-written      |
+
+<Warning>
+  **Cautions when creating Model instances**: 1. **Server Components only**: Models cannot be imported
+  in Client Components 2. **Create each time**: Singleton pattern unnecessary (stateless) 3. **Context
+  access**: `Sonamu.getContext()` automatically retrieves from request context
+</Warning>
+
+<Info>
+  **Recommended patterns**: - **Client Component**: Use Service - **Server Component**: Use Model
+  directly - **API endpoint**: `@api` decorator on Model
+</Info>
+
+### Client Components
+
+Services can be freely used in Client Components.
+
+```typescript
+// app/users/[id]/edit-button.tsx
+"use client";
+
+import { useState } from "react";
+import { UserService } from "@/services/services.generated";
+
+export function EditButton({ userId }: { userId: number }) {
+  const [editing, setEditing] = useState(false);
+
+  async function handleEdit() {
+    setEditing(true);
+
+    try {
+      await UserService.updateProfile({
+        username: "newname",
+      });
+
+      alert("Updated!");
+    } catch (error) {
+      alert("Failed!");
+    } finally {
+      setEditing(false);
+    }
+  }
+
+  return (
+    <button onClick={handleEdit} disabled={editing}>
+      {editing ? "Saving..." : "Edit"}
+    </button>
+  );
+}
+```
+
 ## Error Handling
 
 ### SonamuError Handling


### PR DESCRIPTION
> 이 PR은 AI(Claude Code)에 의해 자동 생성된 Nightly PR입니다.
> 코드베이스의 ownership은 전적으로 maintainer에게 있으며, 이 PR은 검토 후 판단을 돕기 위한 제안입니다.

## 어떤 issue를 참조했으며, 왜 이 작업을 선정했나요?

[#44 - 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44)을 참조했습니다.

Issue #44의 범위 중:
> sonamu-docs 업데이트: `/modules/docs/ko/` 하위의 한국어 문서의 내용을 업데이트한 후 → `/modules/docs/en/` 하위의 동일한 경로에 `.mdx` 파일로 존재하는 영어 문서의 내용을 업데이트해야 합니다.

기존 Nightly PR들(#119~#153)의 description과 comment를 모두 확인하였으며, 이 두 파일의 KO→EN 동기화 누락은 이전에 조치된 적이 없는 건들입니다.

## 무엇이 문제인가요?

### 1. api-decorator.mdx EN 문서에 cacheControl/compress 섹션 누락 (193줄)

한국어 문서(`ko/api-development/creating-apis/api-decorator.mdx`)에는 `@api + cacheControl/compress 옵션` 섹션(KO 457~648줄)이 존재하지만, 영어 문서에는 이 전체 섹션이 빠져 있었습니다. 이 섹션은 다음 내용을 포함합니다:

- **Cache-Control 설정**: `maxAge`, `sMaxAge`, `staleWhileRevalidate`, 프리셋 문자열(`"5m"`, `"1h"` 등)
- **압축 설정**: `compress: true/false` 옵션
- **조합 사용**: 캐싱 + 압축 동시 적용 예제
- **실전 API 최적화 예제**: 정적/동적/개인정보/대용량 다운로드 시나리오
- **성능 팁 및 주의사항**

이 기능은 소스코드(`src/api/decorators.ts` 50-53줄)에 실제 구현되어 있어 정확한 문서입니다.

### 2. using-services.mdx EN 문서에 Service 생성 메커니즘 섹션 누락 (228줄)

한국어 문서(`ko/frontend-integration/generated-services/using-services.mdx`)에는 `Service 생성 메커니즘 이해하기` 섹션(KO 426~652줄)이 존재하지만, 영어 문서에는 이 전체 섹션이 빠져 있었습니다. 이 섹션은 다음 내용을 포함합니다:

- **Service는 Namespace**: 클래스가 아닌 Namespace 기반 정적 함수 모음임을 설명
- **DI 없음**: Context가 HTTP 헤더로 전달되는 메커니즘 설명
- **Service 생성 과정**: Model @api → Sonamu Sync → services.generated.ts 흐름 다이어그램
- **Model Instance**: Server Component에서 직접 인스턴스화하는 방법과 그것이 안전한 이유
- **Service vs Model 비교 테이블**: 타입, 호출 방식, 상태, 의존성, Context, 사용 위치, 생성 방법 비교
- **Client Components**: Client Component에서의 Service 사용 실전 예제

## 이렇게 하지 않으면 어떤 점이 안 좋은가요?

영어 사용자가 다음 핵심 기능/개념에 접근할 수 없습니다:
1. `@api` 데코레이터의 `cacheControl`/`compress` 옵션 → API 응답 최적화 방법을 알 수 없음
2. Service가 Namespace인 이유와 DI 없이 동작하는 원리 → 아키텍처 이해 불가
3. Server Component에서 Model 직접 사용 vs Client Component에서 Service 사용 패턴 → 잘못된 사용 패턴 채택 가능

## 어떤 접근 방식을 채택했으며, 왜 그랬나요?

한국어 원문의 구조, 코드 예제, 마크다운 형식을 그대로 유지하면서 영어로 번역하는 방식을 채택했습니다. 코드 예제의 변수명/함수명은 원본과 동일하게 유지하되, 주석과 설명문만 영어로 변환했습니다. 이는 KO/EN 문서 간 구조적 일관성을 보장하기 위함입니다.

## 이 변경이 어떤 기능에 영향을 미치나요?

문서 전용 변경이므로 런타임에 영향을 미치지 않습니다. 영어 문서의 정보 완전성만 개선됩니다.

## 변경의 영향을 확인하는 방법

1. `modules/docs/en/api-development/creating-apis/api-decorator.mdx`를 열어 "### @api + cacheControl/compress Options" 섹션이 "Error Handling" 섹션 바로 앞에 존재하는지 확인
2. `modules/docs/en/frontend-integration/generated-services/using-services.mdx`를 열어 "### Understanding the Service Creation Mechanism" 섹션이 "## Error Handling" 섹션 바로 앞에 존재하는지 확인
3. `pnpm check` 통과 확인 (0 errors)

## 추후 사람의 확인이 필요한 부분

- **번역 품질**: AI 번역이므로 자연스러운 영어 표현인지 네이티브 리뷰가 도움이 될 수 있습니다.
- **using-services.mdx KO/EN 줄 수 차이**: EN(879줄) vs KO(990줄)로 아직 111줄 차이가 있습니다. 이는 `useTypeForm으로 폼 처리하기` 섹션(KO 237~346줄) 등이 EN에 아직 누락되어 있기 때문이며, 향후 별도 PR에서 다룰 수 있습니다.
- **테스팅 문서의 미존재 모델 메서드 문제**: 테스팅 문서 전체(`testing/` 하위 24개 파일, 200+개소)에서 `userModel.create()`, `userModel.count()`, `userModel.getUser()`, `userModel.getUsers()` 등 실제로 존재하지 않는 모델 메서드가 사용되고 있습니다. 실제 API는 `save()`, `findMany()`, `findById()`, `Puri.count()`입니다. 이 문제는 범위가 매우 넓어 별도의 집중 작업이 필요합니다.