### PR TITLE
[Nightly 2026-04-20] IdAsyncSelect preload/searchable Props 문서화 및 fixture gen 로그인 가능 User 생성 모드 문서화 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/frontend-integration/react-components/id-async-select.mdx
+++ b/modules/docs/en/frontend-integration/react-components/id-async-select.mdx
@@ -543,11 +543,27 @@ function CompanySelectForm() {
 | `displayField`   | `string \| ((row) => string)` |          | Display field (auto-detected if omitted) |
 | `valueField`     | `string`                      |          | Value field (default: "id")              |
 | `baseListParams` | `object`                      |          | Additional parameters for search         |
+| `preload`        | `boolean`                     |          | Load full list on mount (default: `false`) |
+| `searchable`     | `boolean`                     |          | Show search filter in dropdown           |
 | `multiple`       | `boolean`                     |          | Multiple selection mode                  |
 | `placeholder`    | `string`                      |          | Placeholder text                         |
 | `clearable`      | `boolean`                     |          | Whether selection can be cleared         |
 | `disabled`       | `boolean`                     |          | Disabled state                           |
 | `className`      | `string`                      |          | Additional CSS class                     |
+
+### `preload` and `searchable` Combinations
+
+The component's rendering mode changes depending on `preload` and `searchable` values:
+
+| `preload` | `searchable` | Behavior                                                                    |
+| --------- | ------------ | --------------------------------------------------------------------------- |
+| `false`   | unset        | **Default async mode**: searches on the server as the user types a keyword  |
+| `true`    | unset        | **Sync dropdown mode**: loads full list on mount, no search input shown     |
+| `true`    | `true`       | **Hybrid mode**: loads full list on mount + shows server search filter      |
+
+<Info>
+  When `baseListParams` contains meaningful filter values, the component also behaves in sync dropdown mode, the same as `preload`.
+</Info>
 
 ## Cautions
 

--- a/modules/docs/en/tools-and-cli/sonamu-cli/fixture.mdx
+++ b/modules/docs/en/tools-and-cli/sonamu-cli/fixture.mdx
@@ -126,6 +126,10 @@ pnpm fixture gen
 
 ? Number to generate per Entity: 5
 
+? User entity is included. Select generation method:
+❯ 1. Generate loginable user fixtures
+  2. Generate dummy data (not loginable)
+
 ? Save method: (Use arrow keys)
 ❯ Save to Fixture DB
   Save to file (auto filename)
@@ -134,6 +138,52 @@ pnpm fixture gen
 
 ? Generate more realistic data with LLM? (fixtureHint-based, requires ANTHROPIC_API_KEY) No
 ```
+
+<Info>
+  The generation method prompt is only shown when User entity is included in the selection.
+  If User entity is not selected, the flow proceeds directly to the save method selection.
+</Info>
+
+**Loginable User Fixture Generation**:
+
+When you select the User entity and choose "Generate loginable user fixtures", the system creates actually loginable users through better-auth's `sign-up/email` endpoint.
+
+How this mode works:
+
+1. `FixtureGenerator` generates User data (name, email, username, etc.)
+2. Calls better-auth sign-up API via `Sonamu.auth.handler()` to register users
+3. Automatically updates `email_verified` to `true` for all created users
+4. Outputs the list of created credentials (email, password) to the console
+
+```
+Generating 5 loginable users...
+  ✅ alice@example.com created
+  ✅ bob@example.com created
+  ⚠️  carol@example.com already exists - skipping.
+  ✅ dave@example.com created
+  ✅ eve@example.com created
+
+email_verified = true update completed
+
+✅ 4 loginable users created
+
+Created accounts:
+┌─────────┬──────────────────────┬────────────┐
+│ (index) │ email                │ password   │
+├─────────┼──────────────────────┼────────────┤
+│ 0       │ alice@example.com    │ Test1234!  │
+│ 1       │ bob@example.com      │ Test1234!  │
+│ 2       │ dave@example.com     │ Test1234!  │
+│ 3       │ eve@example.com      │ Test1234!  │
+└─────────┴──────────────────────┴────────────┘
+```
+
+<Warning>
+  All generated users share the same password `Test1234!`. This feature is intended for
+  development/test environments only and should never be used against a production database.
+</Warning>
+
+Selecting "Generate dummy data (not loginable)" uses the existing `generateBatch()` flow to insert data directly into the DB. In this case, no better-auth authentication records are created, so login is not possible.
 
 **CLI options**:
 

--- a/modules/docs/ko/frontend-integration/react-components/id-async-select.mdx
+++ b/modules/docs/ko/frontend-integration/react-components/id-async-select.mdx
@@ -543,11 +543,27 @@ function CompanySelectForm() {
 | `displayField`   | `string \| ((row) => string)` |      | 표시 필드 (생략 시 자동 탐지) |
 | `valueField`     | `string`                      |      | 값 필드 (기본: "id")          |
 | `baseListParams` | `object`                      |      | 검색 시 추가 파라미터         |
+| `preload`        | `boolean`                     |      | 마운트 시 전체 목록 즉시 로드 (기본: `false`) |
+| `searchable`     | `boolean`                     |      | 드롭다운 내 검색 필터 표시    |
 | `multiple`       | `boolean`                     |      | 다중 선택 모드                |
 | `placeholder`    | `string`                      |      | 플레이스홀더 텍스트           |
 | `clearable`      | `boolean`                     |      | 선택 해제 가능 여부           |
 | `disabled`       | `boolean`                     |      | 비활성화 여부                 |
 | `className`      | `string`                      |      | 추가 CSS 클래스               |
+
+### `preload`와 `searchable` 조합
+
+`preload`와 `searchable` 값에 따라 컴포넌트의 렌더링 모드가 달라집니다:
+
+| `preload` | `searchable` | 동작                                                                 |
+| --------- | ------------ | -------------------------------------------------------------------- |
+| `false`   | 미지정       | **기본 async 모드**: 사용자가 키워드를 입력하면 서버에서 검색        |
+| `true`    | 미지정       | **sync 드롭다운 모드**: 마운트 시 전체 목록 로드, 검색창 없이 표시   |
+| `true`    | `true`       | **하이브리드 모드**: 마운트 시 전체 목록 로드 + 서버 검색 필터 표시  |
+
+<Info>
+  `baseListParams`에 의미 있는 필터 값이 있는 경우에도 `preload`와 동일하게 sync 드롭다운 모드로 동작합니다.
+</Info>
 
 ## 주의사항
 

--- a/modules/docs/ko/tools-and-cli/sonamu-cli/fixture.mdx
+++ b/modules/docs/ko/tools-and-cli/sonamu-cli/fixture.mdx
@@ -126,6 +126,10 @@ pnpm fixture gen
 
 ? 각 Entity별 생성 개수: 5
 
+? User 엔티티가 포함되어 있습니다. 생성 방식을 선택하세요:
+❯ 1. 로그인 가능한 사용자 fixture 생성
+  2. 확인용 데이터(로그인 불가) 생성
+
 ? 저장 방식: (Use arrow keys)
 ❯ Fixture DB에 저장
   파일로 저장 (자동 파일명)
@@ -134,6 +138,52 @@ pnpm fixture gen
 
 ? LLM으로 더 현실적인 데이터를 생성할까요? (fixtureHint 기반, ANTHROPIC_API_KEY 필요) No
 ```
+
+<Info>
+  User 엔티티가 선택에 포함된 경우에만 생성 방식 선택 프롬프트가 표시됩니다.
+  User 엔티티가 없으면 바로 저장 방식 선택으로 넘어갑니다.
+</Info>
+
+**로그인 가능한 User Fixture 생성**:
+
+User 엔티티를 선택하고 "로그인 가능한 사용자 fixture 생성"을 선택하면, better-auth의 `sign-up/email` 엔드포인트를 통해 실제로 로그인 가능한 사용자를 생성합니다.
+
+이 모드의 동작:
+
+1. `FixtureGenerator`로 User 데이터(name, email, username 등)를 생성
+2. `Sonamu.auth.handler()`를 통해 better-auth sign-up API를 호출하여 사용자 등록
+3. 생성된 모든 사용자의 `email_verified`를 `true`로 자동 업데이트
+4. 생성된 계정 목록(email, password)을 콘솔에 출력
+
+```
+로그인 가능한 사용자 5명 생성 중...
+  ✅ alice@example.com 생성 완료
+  ✅ bob@example.com 생성 완료
+  ⚠️  carol@example.com 이미 존재 - 건너뜁니다.
+  ✅ dave@example.com 생성 완료
+  ✅ eve@example.com 생성 완료
+
+email_verified = true 업데이트 완료
+
+✅ 4명의 로그인 가능한 사용자 생성 완료
+
+생성된 계정 목록:
+┌─────────┬──────────────────────┬────────────┐
+│ (index) │ email                │ password   │
+├─────────┼──────────────────────┼────────────┤
+│ 0       │ alice@example.com    │ Test1234!  │
+│ 1       │ bob@example.com      │ Test1234!  │
+│ 2       │ dave@example.com     │ Test1234!  │
+│ 3       │ eve@example.com      │ Test1234!  │
+└─────────┴──────────────────────┴────────────┘
+```
+
+<Warning>
+  생성된 모든 사용자의 비밀번호는 `Test1234!`로 동일합니다. 이 기능은 개발/테스트 환경 전용이며,
+  프로덕션 데이터베이스에서 사용해서는 안 됩니다.
+</Warning>
+
+"확인용 데이터(로그인 불가) 생성"을 선택하면 기존과 동일하게 `generateBatch()`로 DB에 직접 데이터를 삽입합니다. 이 경우 better-auth 인증 레코드가 생성되지 않으므로 로그인은 불가능합니다.
 
 **CLI 옵션**:
 


### PR DESCRIPTION
> 이 PR은 AI(Claude)에 의해 자동으로 생성되었습니다.
> 모든 변경사항은 제안이며, 최종 결정은 프로젝트 소유자에게 있습니다.

## 무엇을, 왜

#44 이슈의 지침에 따라, 소스코드에 존재하지만 문서에 누락된 2가지 항목을 문서화합니다.

### 1. IdAsyncSelect: `preload` / `searchable` Props 누락

**근거**: `id-async-select.tsx` (84-86행)에 `preload`와 `searchable` props가 정의되어 있고, 컴포넌트의 렌더링 모드를 결정하는 중요한 기능입니다. 그러나 한국어/영어 문서의 Props 레퍼런스 테이블에 이 두 props가 빠져 있었습니다.

**변경 내용**:
- Props 레퍼런스 테이블에 `preload`와 `searchable` 항목 추가
- `preload`/`searchable` 조합에 따른 3가지 렌더링 모드(async, sync dropdown, hybrid) 설명 추가
- `baseListParams` 필터 값이 있을 때도 sync dropdown 모드로 동작하는 점 안내

**이렇게 하지 않으면**: 사용자가 소규모 데이터셋에서 async 검색 대신 드롭다운으로 전환하거나, 드롭다운에서 검색 기능을 활성화하는 방법을 알 수 없습니다. 소스코드를 직접 읽어야만 이 기능을 발견할 수 있습니다.

**영향**: `IdAsyncSelect` 컴포넌트를 사용하는 프론트엔드 코드. 문서 추가만이므로 기존 동작에 영향 없음.

### 2. Fixture gen: 로그인 가능 User fixture 생성 모드 누락

**근거**: `fixture.ts` (96-220행, 커밋 94C4C8B7)에서 User 엔티티가 포함된 경우 "로그인 가능한 사용자 fixture" vs "확인용 데이터" 선택 분기가 추가되었으나, 한국어/영어 문서에 이 기능이 전혀 언급되지 않았습니다.

**변경 내용**:
- 대화형 모드 예시에 User 생성 방식 선택 프롬프트 추가
- "로그인 가능한 User Fixture 생성" 섹션 추가: better-auth sign-up API 호출, email_verified 자동 업데이트, 기본 비밀번호(Test1234!), 출력 형식 등 설명
- "확인용 데이터" 선택 시 기존 generateBatch() 흐름이 유지됨을 명시

**이렇게 하지 않으면**: `pnpm fixture gen`으로 User를 생성할 때 "로그인 가능" 옵션이 나타나지만, 이것이 무엇을 하는지, 기본 비밀번호가 무엇인지 문서에서 확인할 수 없습니다.

**영향**: `pnpm fixture gen` CLI 도구의 사용자 경험. 문서 추가만이므로 기존 동작에 영향 없음.

## 접근 방식

소스코드의 JSDoc 주석, 타입 정의, 런타임 로직을 분석하여 기존 문서의 스타일(마크다운 테이블, Info/Warning 블록)과 일관되게 문서를 작성했습니다. 새로운 기능을 추가하거나 기존 텍스트를 수정하지 않고, 누락된 정보만 추가했습니다.

## 확인 방법

- `pnpm check` (oxlint + oxfmt) 통과 확인됨
- 변경 파일 4개 모두 `.mdx` 문서 파일이므로, `pnpm --filter sonamu-docs dev`로 로컬 문서 서버에서 렌더링 결과를 확인할 수 있습니다
- IdAsyncSelect 문서: `/ko/frontend-integration/react-components/id-async-select` 페이지의 "Props 레퍼런스" 및 "`preload`와 `searchable` 조합" 섹션
- Fixture 문서: `/ko/tools-and-cli/sonamu-cli/fixture` 페이지의 "gen - 자동 Fixture 생성" 섹션

## 사람의 확인이 필요한 부분

- IdAsyncSelect의 `searchable` prop은 소스코드에서 명시적 기본값이 지정되지 않아 `undefined`로 동작합니다. 문서에서는 기본값을 별도로 기재하지 않았는데, 이것이 의도한 바인지 확인이 필요합니다.
- Fixture gen 로그인 모드의 출력 예시(email, 테이블 형식)는 소스코드의 `console.table` 및 `console.log` 호출을 기반으로 재구성한 것으로, 실제 출력과 세부 포맷이 다를 수 있습니다.