### PR TITLE
[Nightly 2026-04-21] SearchModal setInterval 무한 폴링 수정 및 파일 업로드·검색 컴포넌트 문서 정비 (코드 1파일, 문서 ko/en 3파일)

### DIFF
--- a/modules/docs/en/frontend-integration/react-components/search-components.mdx
+++ b/modules/docs/en/frontend-integration/react-components/search-components.mdx
@@ -91,7 +91,7 @@ export function UserListPage() {
   const { listParams, register } = useListParams(UserListParams, {
     num: 24,
     page: 1,
-    search: UserSearchField.options[0],  // default: "id"
+    search: UserSearchField.options[0],  // first enum value
     keyword: "",
   });
 

--- a/modules/docs/en/frontend-integration/react-components/search-components.mdx
+++ b/modules/docs/en/frontend-integration/react-components/search-components.mdx
@@ -85,12 +85,13 @@ import { useListParams } from "@sonamu-kit/react-components";
 import { Input } from "@sonamu-kit/react-components/components";
 import { UserSearchFieldSelect } from "@/components/user/UserSearchFieldSelect";
 import { UserService } from "@/services/services.generated";
+import { UserSearchField } from "@/services/sonamu.generated";
 
 export function UserListPage() {
   const { listParams, register } = useListParams(UserListParams, {
     num: 24,
     page: 1,
-    search: "id" as const,
+    search: UserSearchField.options[0],  // default: "id"
     keyword: "",
   });
 

--- a/modules/docs/ko/api-development/file-upload/url-generation.mdx
+++ b/modules/docs/ko/api-development/file-upload/url-generation.mdx
@@ -31,11 +31,13 @@ description: "Public URL과 Signed URL"
 ```typescript
 class FileModel extends BaseModelClass {
   @upload()
-  async upload(params: { file: UploadedFile }): Promise<{
+  async upload(): Promise<{
     url: string;
     signedUrl: string;
   }> {
-    const { file } = params;
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
+    if (!file) throw new Error("파일이 필요합니다");
 
     // 파일 저장
     await file.saveToDisk("fs", `uploads/${Date.now()}.${file.extname}`);

--- a/modules/sonamu/ui-web/src/components/SearchModal.tsx
+++ b/modules/sonamu/ui-web/src/components/SearchModal.tsx
@@ -213,10 +213,6 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
     const maxAttempts = 50;
     const interval = setInterval(() => {
       attempts++;
-      if (attempts >= maxAttempts) {
-        clearInterval(interval);
-        return;
-      }
       const element = document.getElementById(id);
       if (element) {
         clearInterval(interval);
@@ -228,6 +224,8 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
           element.style.boxShadow = "";
           element.style.transition = "background-color 1s, box-shadow 1s";
         }, 1000);
+      } else if (attempts >= maxAttempts) {
+        clearInterval(interval);
       }
     }, 100);
   };

--- a/modules/sonamu/ui-web/src/components/SearchModal.tsx
+++ b/modules/sonamu/ui-web/src/components/SearchModal.tsx
@@ -209,9 +209,17 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
   };
 
   const scrollToElement = (id: string) => {
+    let attempts = 0;
+    const maxAttempts = 50;
     const interval = setInterval(() => {
+      attempts++;
+      if (attempts >= maxAttempts) {
+        clearInterval(interval);
+        return;
+      }
       const element = document.getElementById(id);
       if (element) {
+        clearInterval(interval);
         element.scrollIntoView({ behavior: "instant", block: "center" });
         element.style.backgroundColor = "#fef3c7";
         element.style.boxShadow = "0 0 0 2px #fbbf24";
@@ -220,7 +228,6 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
           element.style.boxShadow = "";
           element.style.transition = "background-color 1s, box-shadow 1s";
         }, 1000);
-        clearInterval(interval);
       }
     }, 100);
   };


### PR DESCRIPTION
> 이 PR은 AI(Claude)에 의해 자동으로 생성되었습니다.
> 모든 변경사항은 제안이며, 최종 결정은 프로젝트 소유자에게 있습니다.

## 무엇을, 왜

#44 이슈의 지침에 따라, 코드의 잠재적 버그 1건과 문서-소스코드 불일치 2건을 수정합니다.

### 1. SearchModal `scrollToElement` setInterval 무한 폴링 방지

**근거**: `SearchModal.tsx`의 `scrollToElement` 함수(211행)에서 `setInterval`로 대상 DOM 요소를 100ms마다 폴링하는데, 요소가 영영 나타나지 않는 경우(네비게이션 실패, 존재하지 않는 ID 등) interval이 무한히 실행됩니다. 브라우저 탭이 열려 있는 한 메모리와 CPU를 계속 소모하는 리소스 누수입니다.

**변경 내용**:
- 최대 50회(5초) 재시도 후 자동 중단하는 상한 추가
- `clearInterval` 호출을 DOM 조작 전으로 이동하여 논리적 순서 개선

**이렇게 하지 않으면**: 검색 결과에서 존재하지 않는 요소로 이동하려 할 때, 페이지를 떠나거나 탭을 닫을 때까지 interval이 100ms마다 `document.getElementById`를 호출하며 실행됩니다.

**영향**: Sonamu UI 웹 대시보드의 SearchModal 컴포넌트. 정상적인 경우(요소를 찾는 경우)의 동작은 기존과 동일합니다.

### 2. url-generation.mdx 한국어 문서의 @upload 파일 접근 패턴 수정

**근거**: 한국어 `url-generation.mdx`(31행)에서 `@upload()` 메서드가 `params: { file: UploadedFile }`로 파일을 받는 것처럼 기술되어 있지만, 실제 프레임워크 API(`sonamu.ts` 913행, `context.ts` 29행)는 `Sonamu.getContext().bufferedFiles`를 통해 파일에 접근합니다. 동일 문서의 영어 버전과 `saving-files.mdx` 한국어 버전은 이미 올바른 패턴을 사용하고 있습니다.

**변경 내용**: 첫 번째 코드 예제를 `Sonamu.getContext().bufferedFiles` 패턴으로 수정

**이렇게 하지 않으면**: 이 문서를 보고 파일 업로드를 구현하는 사용자가 존재하지 않는 `params` 패턴을 사용하게 되어 런타임 오류가 발생합니다.

**영향**: 문서 변경만이므로 기존 동작에 영향 없음.

### 3. search-components.mdx 영어 문서 한국어 문서와 동기화

**근거**: 한국어 `search-components.mdx`(78-84행)에서는 `UserSearchField`를 import하고 `UserSearchField.options[0]`으로 기본값을 설정하지만, 영어 문서(87-93행)에서는 import이 없고 `"id" as const`를 하드코딩합니다. enum 값이 변경될 때 자동 적용되는 `options[0]` 패턴이 더 안전합니다.

**변경 내용**: 영어 문서에 `UserSearchField` import 추가, `options[0]` 패턴으로 수정

**이렇게 하지 않으면**: 한국어/영어 문서가 서로 다른 패턴을 가르치게 되어 사용자 혼란을 유발합니다.

**영향**: 문서 변경만이므로 기존 동작에 영향 없음.

## 접근 방식

Issue #44의 지침에 따라 코드의 잠재적 위험 요소와 문서-소스코드 불일치를 중심으로 코드베이스를 분석했습니다. `puri.ts` SQL injection(인지 및 해결 중), `PostgresPubSub.destroy()` null 체크(불필요), `practices` 폴더(보존)는 지침에 따라 제외했습니다.

## 검증 결과

- `pnpm check` (oxlint + oxfmt): 통과 (기존 264 warnings, 0 errors)
- `pnpm --filter ui-web build` (tsc --noEmit + vite build): 통과

## 확인 방법

- **SearchModal 수정**: Sonamu UI 대시보드에서 검색 후 결과를 클릭하여 스크롤 이동이 정상 동작하는지 확인. 존재하지 않는 요소 ID로 테스트하여 5초 후 interval이 중단되는지 확인.
- **url-generation.mdx**: `pnpm --filter sonamu-docs dev`로 `/ko/api-development/file-upload/url-generation` 페이지의 첫 번째 코드 예제가 `bufferedFiles` 패턴으로 표시되는지 확인.
- **search-components.mdx**: `/en/frontend-integration/react-components/search-components` 페이지의 "Basic Usage" 섹션에서 `UserSearchField.options[0]` 패턴이 표시되는지 확인.

## 사람의 확인이 필요한 부분

- SearchModal의 maxAttempts=50 (5초) 상한이 실제 사용 환경에서 충분한지. 네트워크가 느린 환경에서 페이지 렌더링이 5초 이상 걸린다면 상한을 늘려야 할 수 있습니다.