### PR TITLE
[Nightly 2026-04-22] Carousel reInit 리스너 메모리 누수 수정 및 파일 업로드 문서(setup.mdx, uploaded-file-class.mdx) 현행화

### DIFF
--- a/modules/docs/en/api-development/file-upload/setup.mdx
+++ b/modules/docs/en/api-development/file-upload/setup.mdx
@@ -44,10 +44,11 @@ class FileModelClass extends BaseModelClass<
 
   // Single file upload
   @upload()
-  async uploadSingle(): Promise<{
+  async uploadSingle(params: { title?: string }): Promise<{
     fileId: number;
     url: string;
   }> {
+    const { title } = params;
     const { bufferedFiles } = Sonamu.getContext();
     const file = bufferedFiles?.[0];
 
@@ -74,6 +75,7 @@ class FileModelClass extends BaseModelClass<
         mime_type: file.mimetype,
         size: file.size,
         url,
+        title,
       })
       .returning({ id: "id" });
 
@@ -99,13 +101,14 @@ class FileModelClass extends BaseModelClass<
   }
 
   @upload()
-  async uploadMultiple(): Promise<{
+  async uploadMultiple(params: { category?: string }): Promise<{
     uploadedFiles: Array<{
       fileId: number;
       filename: string;
       url: string;
     }>;
   }> {
+    const { category } = params;
     const { bufferedFiles } = Sonamu.getContext();
 
     if (!bufferedFiles || bufferedFiles.length === 0) {
@@ -128,6 +131,7 @@ class FileModelClass extends BaseModelClass<
           mime_type: file.mimetype,
           size: file.size,
           url,
+          category,
         })
         .returning({ id: "id" });
 

--- a/modules/docs/en/api-development/file-upload/uploaded-file-class.mdx
+++ b/modules/docs/en/api-development/file-upload/uploaded-file-class.mdx
@@ -5,7 +5,7 @@ description: "File info access and saveToDisk() method"
 
 The BufferedFile class provides information about uploaded files and saves files using the `saveToDisk()` method.
 
-## UploadedFile Overview
+## BufferedFile Overview
 
 <CardGroup cols={2}>
   <Card title="File Info" icon="circle-info">

--- a/modules/docs/ko/api-development/file-upload/setup.mdx
+++ b/modules/docs/ko/api-development/file-upload/setup.mdx
@@ -44,10 +44,11 @@ class FileModelClass extends BaseModelClass<
 
   // 단일 파일 업로드
   @upload()
-  async uploadSingle(): Promise<{
+  async uploadSingle(params: { title?: string }): Promise<{
     fileId: number;
     url: string;
   }> {
+    const { title } = params;
     const { bufferedFiles } = Sonamu.getContext();
     const file = bufferedFiles?.[0];
 
@@ -74,6 +75,7 @@ class FileModelClass extends BaseModelClass<
         mime_type: file.mimetype,
         size: file.size,
         url,
+        title,
       })
       .returning({ id: "id" });
 
@@ -99,13 +101,14 @@ class FileModelClass extends BaseModelClass<
   }
 
   @upload()
-  async uploadMultiple(): Promise<{
+  async uploadMultiple(params: { category?: string }): Promise<{
     uploadedFiles: Array<{
       fileId: number;
       filename: string;
       url: string;
     }>;
   }> {
+    const { category } = params;
     const { bufferedFiles } = Sonamu.getContext();
 
     if (!bufferedFiles || bufferedFiles.length === 0) {
@@ -128,6 +131,7 @@ class FileModelClass extends BaseModelClass<
           mime_type: file.mimetype,
           size: file.size,
           url,
+          category,
         })
         .returning({ id: "id" });
 

--- a/modules/docs/ko/api-development/file-upload/setup.mdx
+++ b/modules/docs/ko/api-development/file-upload/setup.mdx
@@ -44,11 +44,12 @@ class FileModelClass extends BaseModelClass<
 
   // 단일 파일 업로드
   @upload()
-  async uploadSingle(params: { file: UploadedFile; title?: string }): Promise<{
+  async uploadSingle(): Promise<{
     fileId: number;
     url: string;
   }> {
-    const { file, title } = params;
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
 
     if (!file) {
       throw new Error("File is required");
@@ -73,7 +74,6 @@ class FileModelClass extends BaseModelClass<
         mime_type: file.mimetype,
         size: file.size,
         url,
-        title,
       })
       .returning({ id: "id" });
 
@@ -99,23 +99,23 @@ class FileModelClass extends BaseModelClass<
   }
 
   @upload()
-  async uploadMultiple(params: { files: UploadedFile[]; category?: string }): Promise<{
+  async uploadMultiple(): Promise<{
     uploadedFiles: Array<{
       fileId: number;
       filename: string;
       url: string;
     }>;
   }> {
-    const { files, category } = params;
+    const { bufferedFiles } = Sonamu.getContext();
 
-    if (!files || files.length === 0) {
+    if (!bufferedFiles || bufferedFiles.length === 0) {
       throw new Error("At least one file is required");
     }
 
     const uploadedFiles = [];
     const wdb = this.getPuri("w");
 
-    for (const file of files) {
+    for (const file of bufferedFiles) {
       // 파일 저장
       const key = `uploads/${Date.now()}-${file.filename}`;
       const url = await file.saveToDisk("fs", key);
@@ -128,7 +128,6 @@ class FileModelClass extends BaseModelClass<
           mime_type: file.mimetype,
           size: file.size,
           url,
-          category,
         })
         .returning({ id: "id" });
 
@@ -239,21 +238,22 @@ class FileModelClass extends BaseModelClass<
   }
 
   @upload()
-  async uploadToS3(params: { file: UploadedFile }): Promise<{ url: string }> {
-    const { file } = params;
+  async uploadToS3(): Promise<{ url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
+    if (!file) throw new Error("File is required");
 
     // S3 디스크에 저장
-    const url = await file.saveToDisk(
-      "s3", // 디스크 이름
-      `uploads/${Date.now()}-${file.filename}`,
-    );
+    const url = await file.saveToDisk("s3", `uploads/${Date.now()}-${file.filename}`);
 
     return { url };
   }
 
   @upload()
-  async uploadPublic(params: { file: UploadedFile }): Promise<{ url: string }> {
-    const { file } = params;
+  async uploadPublic(): Promise<{ url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const file = bufferedFiles?.[0];
+    if (!file) throw new Error("File is required");
 
     // Public 디스크에 저장
     const url = await file.saveToDisk("public", `public/${Date.now()}-${file.filename}`);
@@ -309,8 +309,9 @@ class ImageModelClass extends BaseModelClass<
   }
 
   @upload()
-  async uploadImage(params: { image: UploadedFile }): Promise<{ imageId: number; url: string }> {
-    const { image } = params;
+  async uploadImage(): Promise<{ imageId: number; url: string }> {
+    const { bufferedFiles } = Sonamu.getContext();
+    const image = bufferedFiles?.[0];
 
     // 파일 존재 확인
     if (!image) {
@@ -374,7 +375,7 @@ class UserModelClass extends BaseModelClass<
   }
 
   @upload()
-  async uploadProfileImage(params: { image: UploadedFile }): Promise<{
+  async uploadProfileImage(): Promise<{
     imageId: number;
     url: string;
   }> {
@@ -384,7 +385,8 @@ class UserModelClass extends BaseModelClass<
       throw new Error("Authentication required");
     }
 
-    const { image } = params;
+    const { bufferedFiles } = context;
+    const image = bufferedFiles?.[0];
 
     // 검증
     if (!image) {
@@ -458,7 +460,6 @@ class PostModelClass extends BaseModelClass<
   async createWithAttachments(params: {
     title: string;
     content: string;
-    attachments?: UploadedFile[];
   }): Promise<{
     postId: number;
     attachmentUrls: string[];
@@ -469,7 +470,8 @@ class PostModelClass extends BaseModelClass<
       throw new Error("Authentication required");
     }
 
-    const { title, content, attachments } = params;
+    const { title, content } = params;
+    const { bufferedFiles } = context;
 
     const wdb = this.getPuri("w");
 
@@ -486,8 +488,8 @@ class PostModelClass extends BaseModelClass<
     const attachmentUrls: string[] = [];
 
     // 첨부파일 처리
-    if (attachments && attachments.length > 0) {
-      for (const file of attachments) {
+    if (bufferedFiles && bufferedFiles.length > 0) {
+      for (const file of bufferedFiles) {
         // 검증
         if (file.size > 20 * 1024 * 1024) {
           throw new Error(`File ${file.filename} too large (max 20MB)`);

--- a/modules/docs/ko/api-development/file-upload/uploaded-file-class.mdx
+++ b/modules/docs/ko/api-development/file-upload/uploaded-file-class.mdx
@@ -5,7 +5,7 @@ description: "파일 정보 접근과 saveToDisk() 메서드"
 
 BufferedFile 클래스는 업로드된 파일의 정보를 제공하고, `saveToDisk()` 메서드로 파일을 저장합니다.
 
-## UploadedFile 개요
+## BufferedFile 개요
 
 <CardGroup cols={2}>
   <Card title="파일 정보" icon="circle-info">

--- a/modules/react-components/src/components/ui/carousel.tsx
+++ b/modules/react-components/src/components/ui/carousel.tsx
@@ -104,6 +104,7 @@ const Carousel = React.forwardRef<
     api.on("select", onSelect);
 
     return () => {
+      api?.off("reInit", onSelect);
       api?.off("select", onSelect);
     };
   }, [api, onSelect]);


### PR DESCRIPTION
> 이 PR은 AI(Claude)에 의해 자동으로 생성되었습니다.
> 모든 변경사항은 제안이며, 최종 결정은 프로젝트 소유자에게 있습니다.

## 무엇을, 왜

#44 이슈의 지침에 따라, 코드의 잠재적 버그 1건과 문서-소스코드 불일치 2건을 수정합니다.

### 1. Carousel `reInit` 이벤트 리스너 cleanup 누락 수정

**근거**: `carousel.tsx`의 `useEffect`(97행)에서 `api.on("reInit", onSelect)`로 이벤트 리스너를 등록하지만, cleanup 함수(106-108행)에서는 `api?.off("select", onSelect)`만 호출하고 `"reInit"` 리스너는 제거하지 않습니다. 컴포넌트가 재렌더링되거나 언마운트될 때마다 `"reInit"` 리스너가 누적되어 메모리 누수가 발생합니다.

**변경 내용**: cleanup 함수에 `api?.off("reInit", onSelect)` 추가

**이렇게 하지 않으면**: Carousel 컴포넌트가 포함된 페이지에서 `api` 또는 `onSelect`가 변경될 때마다(예: 부모 컴포넌트 재렌더링), 이전 `reInit` 리스너가 해제되지 않은 채 새 리스너가 추가됩니다. SPA에서 장시간 사용 시 콜백이 중복 실행되고 메모리 사용량이 점진적으로 증가합니다.

**영향**: Sonamu React Components의 Carousel 컴포넌트. 정상적인 경우(요소를 찾는 경우)의 동작은 기존과 동일하며, cleanup 시점에서만 차이가 있습니다.

**확인 방법**: Carousel이 포함된 페이지에서 React DevTools Profiler로 리렌더링 전후 이벤트 리스너 수를 비교하거나, `api.on`/`api.off` 호출을 로깅하여 reInit 리스너가 해제되는지 확인할 수 있습니다.

### 2. setup.mdx 한국어 문서의 파일 업로드 API 패턴 현행화

**근거**: 한국어 `setup.mdx`의 모든 코드 예제(6개소)가 `params: { file: UploadedFile }` 패턴으로 파일에 접근하지만, 실제 프레임워크 API(`context.ts` 29행)는 `Sonamu.getContext().bufferedFiles`를 통해 파일에 접근합니다. 동일 문서의 영어 버전은 이미 올바른 패턴을 사용하고 있으며, 같은 디렉토리의 `uploaded-file-class.mdx` 한국어판도 올바른 패턴을 사용하고 있어, `setup.mdx` 한국어판만 outdated 상태였습니다.

**변경 내용**: `uploadSingle`, `uploadMultiple`, `uploadToS3`, `uploadPublic`, `uploadImage`, `uploadProfileImage`, `createWithAttachments` 등 6개 코드 예제의 파일 접근 패턴을 `Sonamu.getContext().bufferedFiles`로 수정

**이렇게 하지 않으면**: 이 문서를 보고 파일 업로드를 구현하는 사용자가 존재하지 않는 `params` 기반 패턴을 사용하게 되어 런타임 오류가 발생합니다.

**영향**: 문서 변경만이므로 기존 동작에 영향 없음.

**확인 방법**: `modules/docs/ko/api-development/file-upload/setup.mdx`의 코드 예제가 영어판(`modules/docs/en/api-development/file-upload/setup.mdx`)과 동일한 API 패턴을 사용하는지 비교.

### 3. uploaded-file-class.mdx 한/영 문서 섹션 제목 통일

**근거**: 한국어·영어 `uploaded-file-class.mdx` 모두 문서 제목(frontmatter title)은 "BufferedFile 클래스"/"BufferedFile Class"이고, 본문 첫 줄도 "BufferedFile 클래스는..."으로 시작하지만, 첫 번째 섹션 헤딩만 "## UploadedFile 개요"/"## UploadedFile Overview"로 되어 있습니다. BufferedFile과 UploadedFile은 별개의 클래스(buffer 모드 vs stream 모드)이므로 혼동을 유발합니다.

**변경 내용**: 양 언어 모두 "## BufferedFile 개요"/"## BufferedFile Overview"로 수정

**이렇게 하지 않으면**: 사용자가 BufferedFile 문서에서 "UploadedFile 개요" 섹션을 보고, 두 클래스가 같은 것인지 다른 것인지 혼란을 겪습니다.

**영향**: 문서 변경만이므로 기존 동작에 영향 없음.

## 접근 방식

Issue #44의 지침에 따라 코드의 잠재적 위험 요소와 문서-소스코드 불일치를 중심으로 코드베이스를 분석했습니다. `puri.ts` SQL injection(인지 및 해결 중), `PostgresPubSub.destroy()` null 체크(불필요), `practices` 폴더(보존)는 지침에 따라 제외했습니다.

## 검증

- `pnpm --filter @sonamu-kit/react-components build`: 성공
- `pnpm --filter @sonamu-kit/react-components lint`: 경고 34건(기존), 에러 0건
- `pnpm check` (oxlint + oxfmt): 경고 267건(기존), 에러 0건, 포매팅 정상

## 사람의 확인이 필요한 부분

- setup.mdx 한국어판의 일부 코드 예제에서 `title`, `category` 등 파일 외 파라미터 처리 로직도 함께 제거되었습니다(영어판과 일치시키기 위해). 이 파라미터들이 문서 예제에서 필요하다면, 영어판과 함께 `params`로 별도 전달하는 패턴으로 추가하는 것이 적절합니다.