### PR TITLE
[Nightly 2026-04-27] how-sonamu-works 및 using-services 문서의 getPuri() 미존재 API 호출 패턴 수정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/core-concepts/how-sonamu-works.mdx
+++ b/modules/docs/en/core-concepts/how-sonamu-works.mdx
@@ -165,7 +165,7 @@ class UserModelClass extends BaseModelClass<
   // CRUD API
   @api({ httpMethod: "GET", clients: ["axios", "tanstack-query"] })
   async findById<T extends UserSubsetKey>(subset: T, id: number): Promise<UserSubsetMapping[T]> {
-    const user = await this.getPuri("r").where("id", id).first();
+    const user = await this.getPuri("r").table("users").where("id", id).first();
     return user;
   }
 
@@ -173,6 +173,7 @@ class UserModelClass extends BaseModelClass<
   @api({ httpMethod: "POST", clients: ["axios"] })
   async changePassword(userId: number, newPassword: string): Promise<void> {
     await this.getPuri("w")
+      .table("users")
       .where("id", userId)
       .update({ password: await this.hashPassword(newPassword) });
   }
@@ -356,7 +357,7 @@ Let's see how Sonamu works during actual development:
 ```typescript
 @api({ httpMethod: "GET" })
 async findById(id: number): Promise<Post> {
-  return await this.getPuri("r").where("id", id).first();
+  return await this.getPuri("r").table("posts").where("id", id).first();
 }
 ```
 **Auto-generated on save:**
@@ -499,7 +500,7 @@ type User = {
 
 // 3. Model method (type-safe)
 async findByEmail(email: string): Promise<User> {
-  return await this.getPuri("r").where("email", email).first();
+  return await this.getPuri("r").table("users").where("email", email).first();
 }
 
 ↓

--- a/modules/docs/en/frontend-integration/generated-services/using-services.mdx
+++ b/modules/docs/en/frontend-integration/generated-services/using-services.mdx
@@ -473,7 +473,7 @@ class UserModelClass extends BaseModelClass {
     const context = Sonamu.getContext();
 
     // Execute DB query
-    return this.getPuri("r", subsets).where("id", id).first();
+    return this.getPuri("r").table("users").where("id", id).first();
   }
 }
 ```

--- a/modules/docs/ko/core-concepts/how-sonamu-works.mdx
+++ b/modules/docs/ko/core-concepts/how-sonamu-works.mdx
@@ -164,7 +164,7 @@ class UserModelClass extends BaseModelClass<
   // CRUD API
   @api({ httpMethod: "GET", clients: ["axios", "tanstack-query"] })
   async findById<T extends UserSubsetKey>(subset: T, id: number): Promise<UserSubsetMapping[T]> {
-    const user = await this.getPuri("r").where("id", id).first();
+    const user = await this.getPuri("r").table("users").where("id", id).first();
     return user;
   }
 
@@ -172,6 +172,7 @@ class UserModelClass extends BaseModelClass<
   @api({ httpMethod: "POST", clients: ["axios"] })
   async changePassword(userId: number, newPassword: string): Promise<void> {
     await this.getPuri("w")
+      .table("users")
       .where("id", userId)
       .update({ password: await this.hashPassword(newPassword) });
   }
@@ -354,7 +355,7 @@ export class UserService {
 ```typescript
 @api({ httpMethod: "GET" })
 async findById(id: number): Promise<Post> {
-  return await this.getPuri("r").where("id", id).first();
+  return await this.getPuri("r").table("posts").where("id", id).first();
 }
 ```
 **저장 시 자동 생성:**
@@ -497,7 +498,7 @@ type User = {
 
 // 3. Model 메서드 (타입 안전)
 async findByEmail(email: string): Promise<User> {
-  return await this.getPuri("r").where("email", email).first();
+  return await this.getPuri("r").table("users").where("email", email).first();
 }
 
 ↓

--- a/modules/docs/ko/frontend-integration/generated-services/using-services.mdx
+++ b/modules/docs/ko/frontend-integration/generated-services/using-services.mdx
@@ -585,7 +585,7 @@ class UserModelClass extends BaseModelClass {
     const context = Sonamu.getContext();
 
     // DB 쿼리 실행
-    return this.getPuri("r", subsets).where("id", id).first();
+    return this.getPuri("r").table("users").where("id", id).first();
   }
 }
 ```


### PR DESCRIPTION
이 PR은 issue #44의 지침에 따라 AI(Claude)에 의해 자동 생성되었습니다. 코드베이스의 ownership은 전적으로 사람에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 참조한 issue

- #44 (내일 새벽에 AI에게 맡길 일들)

## 작업 선정 이유

코드베이스(`modules/sonamu/src/database/puri-wrapper.ts`)와 문서의 코드 예제를 비교 분석한 결과, **두 개의 핵심 문서에서 실제 소스코드에 존재하지 않는 API를 호출하는 코드 예제**가 발견되었습니다.

`PuriWrapper` 클래스는 `.where()`, `.update()` 등의 메서드를 직접 제공하지 않습니다. 반드시 `.table()` 또는 `.from()`을 먼저 호출하여 `Puri` 객체를 얻은 후 체이닝해야 합니다. 또한 `getPuri()`의 시그니처는 `getPuri(which: DBPreset): PuriWrapper`로 단 하나의 파라미터만 받습니다.

이 문서들은 Sonamu를 처음 접하는 개발자가 가장 먼저 읽게 되는 입문 문서이므로, 코드 예제가 정확해야 합니다.

## 접근 방식

### 최소 개입 원칙
- 문서의 설명 텍스트나 구조는 변경하지 않고, 코드 예제의 API 호출 패턴만 수정했습니다.
- `.table("tableName")` 호출을 추가하여 실제 API와 일치하도록 했습니다.
- 테이블명은 문맥에 맞게 지정했습니다: User 관련은 `"users"`, Post 관련은 `"posts"`.

### 근거
- miomock 예제 코드(실제 동작하는 코드)에서 `trx.table("projects__employees").whereIn(...)` 패턴 사용
- `modules/sonamu/src/skills/sonamu/puri.md`에서 `this.getPuri("r").table("users").select(...)` 패턴 사용
- `PuriWrapper`는 최초 커밋(34cb9a51)부터 현재까지 `.where()` 메서드를 가진 적이 없음

## 이렇게 하지 않으면

- 개발자가 문서의 코드를 복사하여 사용할 경우 `TypeError: this.getPuri("r").where is not a function` 런타임 에러가 발생합니다.
- `using-services.mdx`의 `getPuri("r", subsets)` 패턴은 TypeScript 컴파일 시점에서 에러가 발생합니다.

## 변경 내역

### 1. `modules/docs/ko/core-concepts/how-sonamu-works.mdx` + 영어 버전
- `findById`: `getPuri("r").where("id", id)` → `getPuri("r").table("users").where("id", id)` 
- `changePassword`: `getPuri("w").where("id", userId)` → `getPuri("w").table("users").where("id", userId)`
- Step 3 예제: `getPuri("r").where("id", id)` → `getPuri("r").table("posts").where("id", id)`
- 타입 안전성 예제: `getPuri("r").where("email", email)` → `getPuri("r").table("users").where("email", email)`

### 2. `modules/docs/ko/frontend-integration/generated-services/using-services.mdx` + 영어 버전
- `getPuri("r", subsets).where("id", id)` → `getPuri("r").table("users").where("id", id)`
  - 미존재 두 번째 파라미터(`subsets`) 제거 + `.table()` 추가

## 영향 범위

- 문서 4파일만 변경, 소스 코드 변경 없음
- 기존 동작에 영향 없음

## 사람의 확인이 필요한 부분

- **동일 패턴이 다른 문서에도 존재합니다**: `getPuri("r").where(...)` (`.table()` 없이) 패턴이 한국어 14개소, 영어 14개소에 더 있습니다 (`scaffold.mdx`, `scaffolding-tab.mdx`, `dev.mdx`, `migrate.mdx`, `api-decorator.mdx`, `development-workflow.mdx`). 이번 PR에서는 가장 핵심적인 입문 문서 2개만 수정했으나, 나머지 문서들도 동일하게 수정할지 판단이 필요합니다.

## 검증

- `pnpm check` (oxlint + oxfmt) 통과 확인