### PR TITLE
[Nightly 2026-04-28] FAQ/트러블슈팅 문서의 getPuri() 인자 누락 및 .table() 누락된 체이닝 패턴 수정 (ko/en 6파일)

### DIFF
--- a/modules/docs/en/faq/database.mdx
+++ b/modules/docs/en/faq/database.mdx
@@ -29,13 +29,14 @@ export class Puri<TSchema, TTables, TResult> implements Promise<TResult[]> {
 
 ```typescript
 // ✅ Use await directly (returns array)
-const users = await UserModel.getPuri().select("id", "name");
+const users = await UserModel.getPuri("r").table("users").select("id", "name");
 
 // ✅ Use .first() for single object query
-const user = await UserModel.getPuri().select("id", "name").where({ id: 1 }).first();
+const user = await UserModel.getPuri("r").table("users").select("id", "name").where({ id: 1 }).first();
 
 // ✅ Use Puri.count() for counting
-const result = await UserModel.getPuri()
+const result = await UserModel.getPuri("r")
+  .table("users")
   .select({ count: Puri.count() })
   .where({ status: "active" });
 const count = result[0].count;
@@ -55,23 +56,28 @@ Use static methods like `Puri.count()`, `Puri.sum()`, `Puri.avg()`.
 
 ```typescript
 // COUNT
-const result = await UserModel.getPuri()
+const result = await UserModel.getPuri("r")
+  .table("users")
   .select({ count: Puri.count() })
   .where({ status: "active" });
 const count = result[0].count;
 
 // SUM
-const result = await OrderModel.getPuri()
+const result = await OrderModel.getPuri("r")
+  .table("orders")
   .select({ total: Puri.sum("amount") })
   .where({ status: "completed" });
 const total = result[0].total;
 
 // AVG
-const result = await ProductModel.getPuri().select({ avg_price: Puri.avg("price") });
+const result = await ProductModel.getPuri("r")
+  .table("products")
+  .select({ avg_price: Puri.avg("price") });
 const avgPrice = result[0].avg_price;
 
 // COUNT + GROUP BY
-const stats = await OrderModel.getPuri()
+const stats = await OrderModel.getPuri("r")
+  .table("orders")
   .select("user_id", { count: Puri.count(), total: Puri.sum("amount") })
   .groupBy("user_id");
 ```
@@ -83,7 +89,8 @@ const stats = await OrderModel.getPuri()
 **INNER JOIN:**
 
 ```typescript
-const ordersWithUser = await OrderModel.getPuri()
+const ordersWithUser = await OrderModel.getPuri("r")
+  .table("orders")
   .select("orders.id", "orders.total", "users.name")
   .join("users", "users.id", "orders.user_id");
 ```
@@ -91,7 +98,8 @@ const ordersWithUser = await OrderModel.getPuri()
 **LEFT JOIN:**
 
 ```typescript
-const usersWithOrders = await UserModel.getPuri()
+const usersWithOrders = await UserModel.getPuri("r")
+  .table("users")
   .select("users.id", "users.name", "orders.total")
   .leftJoin("orders", "orders.user_id", "users.id");
 ```
@@ -99,7 +107,8 @@ const usersWithOrders = await UserModel.getPuri()
 **Complex JOIN conditions (callback approach):**
 
 ```typescript
-const result = await UserModel.getPuri()
+const result = await UserModel.getPuri("r")
+  .table("users")
   .select("users.*", "orders.total")
   .leftJoin("orders", (j) => {
     j.on("orders.user_id", "users.id").on("orders.status", "=", "completed");
@@ -366,6 +375,7 @@ Use `Puri.rawString()` and `.whereRaw()` for JSONB operators.
 ```typescript
 // metadata->>'brand' = 'Samsung'
 const products = await ProductModel.getPuri("r")
+  .table("products")
   .select({
     id: "products.id",
     name: "products.name",
@@ -380,6 +390,7 @@ const products = await ProductModel.getPuri("r")
 ```typescript
 // metadata @> '{"warranty": 2}'
 const productsWithWarranty = await ProductModel.getPuri("r")
+  .table("products")
   .select("*")
   .whereRaw("products.metadata @> ?", [JSON.stringify({ warranty: 2 })]);
 ```
@@ -389,6 +400,7 @@ const productsWithWarranty = await ProductModel.getPuri("r")
 ```typescript
 // metadata ? 'discount'
 const productsWithDiscount = await ProductModel.getPuri("r")
+  .table("products")
   .select("*")
   .whereRaw("products.metadata ?? 'discount'"); // Use ?? instead of ?
 ```
@@ -398,6 +410,7 @@ const productsWithDiscount = await ProductModel.getPuri("r")
 ```typescript
 // metadata->'specs'->>'cpu'
 const laptops = await ProductModel.getPuri("r")
+  .table("products")
   .select({
     id: "products.id",
     name: "products.name",
@@ -432,7 +445,8 @@ const laptops = await ProductModel.getPuri("r")
 **Search query:**
 
 ```typescript
-const posts = await PostModel.getPuri()
+const posts = await PostModel.getPuri("r")
+  .table("posts")
   .select("*")
   .whereTsSearch("search_vector", "typescript database", {
     parser: "websearch_to_tsquery",
@@ -443,7 +457,8 @@ const posts = await PostModel.getPuri()
 **Highlighting:**
 
 ```typescript
-const posts = await PostModel.getPuri()
+const posts = await PostModel.getPuri("r")
+  .table("posts")
   .select({
     id: "posts.id",
     title: Puri.tsHighlight("posts.title", "typescript"),

--- a/modules/docs/en/troubleshooting/performance/n-plus-one-problems.mdx
+++ b/modules/docs/en/troubleshooting/performance/n-plus-one-problems.mdx
@@ -15,11 +15,14 @@ The N+1 problem is a performance issue where 1 main query triggers N additional 
 // N+1 problem occurring
 async function getUsersWithOrders() {
   // 1. Fetch users (1 query)
-  const users = await UserModel.getPuri().select("id", "name"); // 100 users
+  const users = await UserModel.getPuri("r").table("users").select("id", "name"); // 100 users
 
   // 2. Fetch orders for each user (N queries)
   for (const user of users) {
-    const orders = await OrderModel.getPuri().select("*").where({ user_id: user.id });
+    const orders = await OrderModel.getPuri("r")
+      .table("orders")
+      .select("*")
+      .where({ user_id: user.id });
 
     user.orders = orders; // 100 queries!
   }
@@ -241,10 +244,13 @@ When Subsets are not available, you can optimize with whereIn:
 ```typescript
 // N+1 problem
 async function getUsersWithOrders() {
-  const users = await UserModel.getPuri().select("id", "name");
+  const users = await UserModel.getPuri("r").table("users").select("id", "name");
 
   for (const user of users) {
-    user.orders = await OrderModel.getPuri().select("*").where({ user_id: user.id });
+    user.orders = await OrderModel.getPuri("r")
+      .table("orders")
+      .select("*")
+      .where({ user_id: user.id });
   }
 
   return users;
@@ -253,12 +259,15 @@ async function getUsersWithOrders() {
 // Optimized with whereIn
 async function getUsersWithOrders() {
   // 1. Fetch users
-  const users = await UserModel.getPuri().select("id", "name");
+  const users = await UserModel.getPuri("r").table("users").select("id", "name");
 
   const userIds = users.map((u) => u.id);
 
   // 2. Fetch all orders at once
-  const orders = await OrderModel.getPuri().select("*").whereIn("user_id", userIds);
+  const orders = await OrderModel.getPuri("r")
+    .table("orders")
+    .select("*")
+    .whereIn("user_id", userIds);
 
   // 3. Map in memory
   const ordersByUserId = orders.reduce(
@@ -329,7 +338,9 @@ class PostModelClass extends BaseModelClass {
     // N+1 occurring!
     for (const post of posts) {
       post.author = await UserModel.findById(post.author_id);
-      post.comments = await CommentModel.getPuri().where({ post_id: post.id });
+      post.comments = await CommentModel.getPuri("r")
+        .table("comments")
+        .where({ post_id: post.id });
     }
 
     return posts;
@@ -355,15 +366,17 @@ class PostModelClass extends BaseModelClass {
 class DashboardService {
   // N+1 occurring
   async getDashboardSlow() {
-    const users = await UserModel.getPuri().select("id", "name");
+    const users = await UserModel.getPuri("r").table("users").select("id", "name");
 
     const stats = [];
     for (const user of users) {
-      const orderCount = await OrderModel.getPuri()
+      const orderCount = await OrderModel.getPuri("r")
+        .table("orders")
         .select({ count: Puri.count() })
         .where({ user_id: user.id });
 
-      const totalSpent = await OrderModel.getPuri()
+      const totalSpent = await OrderModel.getPuri("r")
+        .table("orders")
         .select({ total: Puri.sum("total") })
         .where({ user_id: user.id });
 
@@ -379,7 +392,8 @@ class DashboardService {
 
   // Optimized with JOIN
   async getDashboardFast() {
-    return UserModel.getPuri()
+    return UserModel.getPuri("r")
+      .table("users")
       .select(
         "users.id",
         "users.name",
@@ -426,7 +440,7 @@ test("N+1 problem check", async () => {
   // Query counter
   let queryCount = 0;
 
-  const db = UserModel.getPuri().getDB();
+  const db = UserModel.getDB("r");
   db.on("query", () => queryCount++);
 
   // Test
@@ -479,7 +493,7 @@ const result = await PostModel.executeSubsetQuery({
 });
 
 // Manual loading - avoid
-const posts = await PostModel.getPuri();
+const posts = await PostModel.getPuri("r").table("posts").select("*");
 for (const post of posts) {
   post.author = await UserModel.findById(post.author_id);
 }

--- a/modules/docs/en/troubleshooting/performance/query-optimization.mdx
+++ b/modules/docs/en/troubleshooting/performance/query-optimization.mdx
@@ -11,10 +11,10 @@ This guide covers effective query optimization methods using the Puri query buil
 
 ```typescript
 // Bad example - selecting all columns
-const users = await UserModel.getPuri().select("*");
+const users = await UserModel.getPuri("r").table("users").select("*");
 
 // Good example - selecting only required columns
-const users = await UserModel.getPuri().select("id", "email", "name");
+const users = await UserModel.getPuri("r").table("users").select("id", "email", "name");
 ```
 
 **Performance Benefits:**
@@ -27,10 +27,10 @@ const users = await UserModel.getPuri().select("id", "email", "name");
 
 ```typescript
 // Query utilizing indexes
-const activeUsers = await UserModel.getPuri().select("id", "email").where({ status: "active" }); // Index needed on status column
+const activeUsers = await UserModel.getPuri("r").table("users").select("id", "email").where({ status: "active" }); // Index needed on status column
 
 // Query that cannot use indexes - avoid
-const users = await UserModel.getPuri()
+const users = await UserModel.getPuri("r").table("users")
   .select("id", "email")
   .whereRaw("LOWER(email) = ?", ["test@example.com"]); // Function usage
 ```
@@ -39,7 +39,7 @@ const users = await UserModel.getPuri()
 
 ```typescript
 // Limit results with LIMIT
-const recentUsers = await UserModel.getPuri()
+const recentUsers = await UserModel.getPuri("r").table("users")
   .select("id", "name", "created_at")
   .orderBy("created_at", "desc")
   .limit(10); // Top 10 only
@@ -70,7 +70,7 @@ const recentUsers = await UserModel.getPuri()
 
 ```typescript
 // Query utilizing index
-const user = await UserModel.getPuri()
+const user = await UserModel.getPuri("r").table("users")
   .select("id", "name")
   .where({ email: "test@example.com" }) // Uses email index
   .first();
@@ -103,7 +103,7 @@ const user = await UserModel.getPuri()
 
 ```typescript
 // Utilizing composite index
-const userOrders = await OrderModel.getPuri().select("id", "total").where({
+const userOrders = await OrderModel.getPuri("r").table("orders").select("id", "total").where({
   user_id: 1,
   status: "completed", // Uses user_id + status composite index
 });
@@ -113,7 +113,7 @@ const userOrders = await OrderModel.getPuri().select("id", "total").where({
 
 ```typescript
 // Check execution plan with PostgreSQL EXPLAIN
-const query = UserModel.getPuri().select("id", "email").where({ status: "active" }).toQuery();
+const query = UserModel.getPuri("r").table("users").select("id", "email").where({ status: "active" }).toQuery();
 
 console.log(query);
 
@@ -127,12 +127,12 @@ console.log(query);
 
 ```typescript
 // INNER JOIN - only data with relationships
-const ordersWithUser = await OrderModel.getPuri()
+const ordersWithUser = await OrderModel.getPuri("r").table("orders")
   .select("orders.id", "orders.total", "users.name")
   .join("users", "users.id", "orders.user_id"); // INNER JOIN
 
 // LEFT JOIN - include even without relationships
-const usersWithOrders = await UserModel.getPuri()
+const usersWithOrders = await UserModel.getPuri("r").table("users")
   .select("users.id", "users.name", "orders.total")
   .leftJoin("orders", "orders.user_id", "users.id"); // LEFT JOIN
 ```
@@ -141,13 +141,13 @@ const usersWithOrders = await UserModel.getPuri()
 
 ```typescript
 // Bad example - filtering after join
-const result = await OrderModel.getPuri()
+const result = await OrderModel.getPuri("r").table("orders")
   .select("orders.*", "users.name")
   .join("users", "users.id", "orders.user_id")
   .where({ "users.status": "active" }); // Filtering after join
 
 // Good example - filtering before join
-const result = await OrderModel.getPuri()
+const result = await OrderModel.getPuri("r").table("orders")
   .select("orders.*", "users.name")
   .join(knex.raw("users ON users.id = orders.user_id AND users.status = ?", ["active"])); // Include in join condition
 ```
@@ -158,11 +158,11 @@ const result = await OrderModel.getPuri()
 
 ```typescript
 // Inefficient - fetch all rows then count
-const users = await UserModel.getPuri().select("*");
+const users = await UserModel.getPuri("r").table("users").select("*");
 const count = users.length;
 
 // Efficient - count in DB
-const result = await UserModel.getPuri()
+const result = await UserModel.getPuri("r").table("users")
   .select({ count: Puri.count() })
   .where({ status: "active" });
 const count = result[0].count;
@@ -172,7 +172,7 @@ const count = result[0].count;
 
 ```typescript
 // Order statistics
-const orderStats = await OrderModel.getPuri()
+const orderStats = await OrderModel.getPuri("r").table("orders")
   .select("user_id", knex.raw("COUNT(*) as order_count"), knex.raw("SUM(total) as total_amount"))
   .where({ status: "completed" })
   .groupBy("user_id")
@@ -188,7 +188,7 @@ const orderStats = await OrderModel.getPuri()
 async function getUsers(page: number, limit: number) {
   const offset = (page - 1) * limit;
 
-  return UserModel.getPuri()
+  return UserModel.getPuri("r").table("users")
     .select("id", "name", "email")
     .orderBy("created_at", "desc")
     .offset(offset)
@@ -201,7 +201,7 @@ async function getUsers(page: number, limit: number) {
 ```typescript
 // Cursor-based pagination (faster)
 async function getUsersCursor(lastId?: number, limit: number = 20) {
-  const query = UserModel.getPuri()
+  const query = UserModel.getPuri("r").table("users")
     .select("id", "name", "email", "created_at")
     .orderBy("id", "desc")
     .limit(limit);
@@ -230,12 +230,12 @@ const secondPage = await getUsersCursor(firstPage[firstPage.length - 1].id, 20);
 
 ```typescript
 // IN - loads subquery results into memory
-const usersWithOrders = await UserModel.getPuri()
+const usersWithOrders = await UserModel.getPuri("r").table("users")
   .select("id", "name")
   .whereIn("id", knex.select("user_id").from("orders").where({ status: "completed" }));
 
 // EXISTS - only checks existence (faster)
-const usersWithOrders = await UserModel.getPuri()
+const usersWithOrders = await UserModel.getPuri("r").table("users")
   .select("id", "name")
   .whereRaw("EXISTS (SELECT 1 FROM orders WHERE orders.user_id = users.id AND orders.status = ?)", [
     "completed",
@@ -246,14 +246,14 @@ const usersWithOrders = await UserModel.getPuri()
 
 ```typescript
 // Subquery - avoid
-const users = await UserModel.getPuri().select(
+const users = await UserModel.getPuri("r").table("users").select(
   "id",
   "name",
   knex.raw("(SELECT COUNT(*) FROM orders WHERE orders.user_id = users.id) as order_count"),
 );
 
 // LEFT JOIN + GROUP BY (faster)
-const users = await UserModel.getPuri()
+const users = await UserModel.getPuri("r").table("users")
   .select("users.id", "users.name", knex.raw("COUNT(orders.id) as order_count"))
   .leftJoin("orders", "orders.user_id", "users.id")
   .groupBy("users.id");
@@ -276,7 +276,7 @@ async function getUsersWithDetails(userIds: number[]) {
 
 // Good - query all at once with whereIn
 async function getUsersWithDetails(userIds: number[]) {
-  return UserModel.getPuri().select("*").whereIn("id", userIds);
+  return UserModel.getPuri("r").table("users").select("*").whereIn("id", userIds);
 }
 ```
 
@@ -289,7 +289,7 @@ async function processAllUsers() {
   let offset = 0;
 
   while (true) {
-    const users = await UserModel.getPuri().select("id", "email").offset(offset).limit(chunkSize);
+    const users = await UserModel.getPuri("r").table("users").select("id", "email").offset(offset).limit(chunkSize);
 
     if (users.length === 0) break;
 
@@ -330,7 +330,7 @@ async function getCachedUsers() {
   if (cached) return cached;
 
   // Cache miss - query DB
-  const users = await UserModel.getPuri().select("id", "name").where({ status: "active" });
+  const users = await UserModel.getPuri("r").table("users").select("id", "name").where({ status: "active" });
 
   // Store in cache (5 minutes)
   await Sonamu.cache.set(cacheKey, users, { ttl: "5m" });
@@ -345,7 +345,7 @@ async function getCachedUsers() {
 
 ```typescript
 // Generate query
-const query = UserModel.getPuri()
+const query = UserModel.getPuri("r").table("users")
   .select("users.id", "users.name", "orders.total")
   .join("orders", "orders.user_id", "users.id")
   .where({ "users.status": "active" })

--- a/modules/docs/ko/faq/database.mdx
+++ b/modules/docs/ko/faq/database.mdx
@@ -29,13 +29,14 @@ export class Puri<TSchema, TTables, TResult> implements Promise<TResult[]> {
 
 ```typescript
 // ✅ await를 직접 사용 (배열 반환)
-const users = await UserModel.getPuri().select("id", "name");
+const users = await UserModel.getPuri("r").table("users").select("id", "name");
 
 // ✅ .first()로 단일 객체 조회
-const user = await UserModel.getPuri().select("id", "name").where({ id: 1 }).first();
+const user = await UserModel.getPuri("r").table("users").select("id", "name").where({ id: 1 }).first();
 
 // ✅ Puri.count()로 카운트
-const result = await UserModel.getPuri()
+const result = await UserModel.getPuri("r")
+  .table("users")
   .select({ count: Puri.count() })
   .where({ status: "active" });
 const count = result[0].count;
@@ -55,23 +56,28 @@ const count = result[0].count;
 
 ```typescript
 // COUNT
-const result = await UserModel.getPuri()
+const result = await UserModel.getPuri("r")
+  .table("users")
   .select({ count: Puri.count() })
   .where({ status: "active" });
 const count = result[0].count;
 
 // SUM
-const result = await OrderModel.getPuri()
+const result = await OrderModel.getPuri("r")
+  .table("orders")
   .select({ total: Puri.sum("amount") })
   .where({ status: "completed" });
 const total = result[0].total;
 
 // AVG
-const result = await ProductModel.getPuri().select({ avg_price: Puri.avg("price") });
+const result = await ProductModel.getPuri("r")
+  .table("products")
+  .select({ avg_price: Puri.avg("price") });
 const avgPrice = result[0].avg_price;
 
 // COUNT + GROUP BY
-const stats = await OrderModel.getPuri()
+const stats = await OrderModel.getPuri("r")
+  .table("orders")
   .select("user_id", { count: Puri.count(), total: Puri.sum("amount") })
   .groupBy("user_id");
 ```
@@ -83,7 +89,8 @@ const stats = await OrderModel.getPuri()
 **INNER JOIN:**
 
 ```typescript
-const ordersWithUser = await OrderModel.getPuri()
+const ordersWithUser = await OrderModel.getPuri("r")
+  .table("orders")
   .select("orders.id", "orders.total", "users.name")
   .join("users", "users.id", "orders.user_id");
 ```
@@ -91,7 +98,8 @@ const ordersWithUser = await OrderModel.getPuri()
 **LEFT JOIN:**
 
 ```typescript
-const usersWithOrders = await UserModel.getPuri()
+const usersWithOrders = await UserModel.getPuri("r")
+  .table("users")
   .select("users.id", "users.name", "orders.total")
   .leftJoin("orders", "orders.user_id", "users.id");
 ```
@@ -99,7 +107,8 @@ const usersWithOrders = await UserModel.getPuri()
 **복잡한 JOIN 조건 (콜백 방식):**
 
 ```typescript
-const result = await UserModel.getPuri()
+const result = await UserModel.getPuri("r")
+  .table("users")
   .select("users.*", "orders.total")
   .leftJoin("orders", (j) => {
     j.on("orders.user_id", "users.id").on("orders.status", "=", "completed");
@@ -366,6 +375,7 @@ export async function down(knex: Knex): Promise<void> {
 ```typescript
 // metadata->>'brand' = 'Samsung'
 const products = await ProductModel.getPuri("r")
+  .table("products")
   .select({
     id: "products.id",
     name: "products.name",
@@ -380,6 +390,7 @@ const products = await ProductModel.getPuri("r")
 ```typescript
 // metadata @> '{"warranty": 2}'
 const productsWithWarranty = await ProductModel.getPuri("r")
+  .table("products")
   .select("*")
   .whereRaw("products.metadata @> ?", [JSON.stringify({ warranty: 2 })]);
 ```
@@ -389,6 +400,7 @@ const productsWithWarranty = await ProductModel.getPuri("r")
 ```typescript
 // metadata ? 'discount'
 const productsWithDiscount = await ProductModel.getPuri("r")
+  .table("products")
   .select("*")
   .whereRaw("products.metadata ?? 'discount'"); // ? 대신 ?? 사용
 ```
@@ -398,6 +410,7 @@ const productsWithDiscount = await ProductModel.getPuri("r")
 ```typescript
 // metadata->'specs'->>'cpu'
 const laptops = await ProductModel.getPuri("r")
+  .table("products")
   .select({
     id: "products.id",
     name: "products.name",
@@ -432,7 +445,8 @@ const laptops = await ProductModel.getPuri("r")
 **검색 쿼리:**
 
 ```typescript
-const posts = await PostModel.getPuri()
+const posts = await PostModel.getPuri("r")
+  .table("posts")
   .select("*")
   .whereTsSearch("search_vector", "typescript database", {
     parser: "websearch_to_tsquery",
@@ -443,7 +457,8 @@ const posts = await PostModel.getPuri()
 **하이라이팅:**
 
 ```typescript
-const posts = await PostModel.getPuri()
+const posts = await PostModel.getPuri("r")
+  .table("posts")
   .select({
     id: "posts.id",
     title: Puri.tsHighlight("posts.title", "typescript"),

--- a/modules/docs/ko/troubleshooting/performance/n-plus-one-problems.mdx
+++ b/modules/docs/ko/troubleshooting/performance/n-plus-one-problems.mdx
@@ -15,11 +15,14 @@ N+1 문제는 1개의 메인 쿼리 후, N개의 추가 쿼리가 발생하는 �
 // ❌ N+1 문제 발생
 async function getUsersWithOrders() {
   // 1. 사용자 조회 (1번 쿼리)
-  const users = await UserModel.getPuri().select("id", "name"); // 100명의 사용자
+  const users = await UserModel.getPuri("r").table("users").select("id", "name"); // 100명의 사용자
 
   // 2. 각 사용자의 주문 조회 (N번 쿼리)
   for (const user of users) {
-    const orders = await OrderModel.getPuri().select("*").where({ user_id: user.id });
+    const orders = await OrderModel.getPuri("r")
+      .table("orders")
+      .select("*")
+      .where({ user_id: user.id });
 
     user.orders = orders; // 100번 쿼리!
   }
@@ -241,10 +244,13 @@ Subset이 없는 경우 whereIn으로 최적화할 수 있습니다:
 ```typescript
 // ❌ N+1 문제
 async function getUsersWithOrders() {
-  const users = await UserModel.getPuri().select("id", "name");
+  const users = await UserModel.getPuri("r").table("users").select("id", "name");
 
   for (const user of users) {
-    user.orders = await OrderModel.getPuri().select("*").where({ user_id: user.id });
+    user.orders = await OrderModel.getPuri("r")
+      .table("orders")
+      .select("*")
+      .where({ user_id: user.id });
   }
 
   return users;
@@ -253,12 +259,15 @@ async function getUsersWithOrders() {
 // ✅ whereIn으로 최적화
 async function getUsersWithOrders() {
   // 1. 사용자 조회
-  const users = await UserModel.getPuri().select("id", "name");
+  const users = await UserModel.getPuri("r").table("users").select("id", "name");
 
   const userIds = users.map((u) => u.id);
 
   // 2. 모든 주문 한 번에 조회
-  const orders = await OrderModel.getPuri().select("*").whereIn("user_id", userIds);
+  const orders = await OrderModel.getPuri("r")
+    .table("orders")
+    .select("*")
+    .whereIn("user_id", userIds);
 
   // 3. 메모리에서 매핑
   const ordersByUserId = orders.reduce(
@@ -329,7 +338,9 @@ class PostModelClass extends BaseModelClass {
     // N+1 발생!
     for (const post of posts) {
       post.author = await UserModel.findById(post.author_id);
-      post.comments = await CommentModel.getPuri().where({ post_id: post.id });
+      post.comments = await CommentModel.getPuri("r")
+        .table("comments")
+        .where({ post_id: post.id });
     }
 
     return posts;
@@ -355,15 +366,17 @@ class PostModelClass extends BaseModelClass {
 class DashboardService {
   // ❌ N+1 발생
   async getDashboardSlow() {
-    const users = await UserModel.getPuri().select("id", "name");
+    const users = await UserModel.getPuri("r").table("users").select("id", "name");
 
     const stats = [];
     for (const user of users) {
-      const orderCount = await OrderModel.getPuri()
+      const orderCount = await OrderModel.getPuri("r")
+        .table("orders")
         .select({ count: Puri.count() })
         .where({ user_id: user.id });
 
-      const totalSpent = await OrderModel.getPuri()
+      const totalSpent = await OrderModel.getPuri("r")
+        .table("orders")
         .select({ total: Puri.sum("total") })
         .where({ user_id: user.id });
 
@@ -379,7 +392,8 @@ class DashboardService {
 
   // ✅ JOIN으로 최적화
   async getDashboardFast() {
-    return UserModel.getPuri()
+    return UserModel.getPuri("r")
+      .table("users")
       .select(
         "users.id",
         "users.name",
@@ -426,7 +440,7 @@ test("N+1 문제 확인", async () => {
   // 쿼리 카운터
   let queryCount = 0;
 
-  const db = UserModel.getPuri().getDB();
+  const db = UserModel.getDB("r");
   db.on("query", () => queryCount++);
 
   // 테스트
@@ -479,7 +493,7 @@ const result = await PostModel.executeSubsetQuery({
 });
 
 // ❌ 수동 로딩
-const posts = await PostModel.getPuri();
+const posts = await PostModel.getPuri("r").table("posts").select("*");
 for (const post of posts) {
   post.author = await UserModel.findById(post.author_id);
 }

--- a/modules/docs/ko/troubleshooting/performance/query-optimization.mdx
+++ b/modules/docs/ko/troubleshooting/performance/query-optimization.mdx
@@ -11,10 +11,10 @@ Puri 쿼리 빌더를 활용한 효과적인 쿼리 최적화 방법을 다룹�
 
 ```typescript
 // ❌ 나쁜 예 - 모든 컬럼 조회
-const users = await UserModel.getPuri().select("*");
+const users = await UserModel.getPuri("r").table("users").select("*");
 
 // ✅ 좋은 예 - 필요한 컬럼만 조회
-const users = await UserModel.getPuri().select("id", "email", "name");
+const users = await UserModel.getPuri("r").table("users").select("id", "email", "name");
 ```
 
 **성능 차이:**
@@ -27,10 +27,10 @@ const users = await UserModel.getPuri().select("id", "email", "name");
 
 ```typescript
 // ✅ 인덱스를 활용한 쿼리
-const activeUsers = await UserModel.getPuri().select("id", "email").where({ status: "active" }); // status 컬럼에 인덱스 필요
+const activeUsers = await UserModel.getPuri("r").table("users").select("id", "email").where({ status: "active" }); // status 컬럼에 인덱스 필요
 
 // ❌ 인덱스를 사용할 수 없는 쿼리
-const users = await UserModel.getPuri()
+const users = await UserModel.getPuri("r").table("users")
   .select("id", "email")
   .whereRaw("LOWER(email) = ?", ["test@example.com"]); // 함수 사용
 ```
@@ -39,7 +39,7 @@ const users = await UserModel.getPuri()
 
 ```typescript
 // ✅ LIMIT으로 결과 제한
-const recentUsers = await UserModel.getPuri()
+const recentUsers = await UserModel.getPuri("r").table("users")
   .select("id", "name", "created_at")
   .orderBy("created_at", "desc")
   .limit(10); // 상위 10개만
@@ -70,7 +70,7 @@ const recentUsers = await UserModel.getPuri()
 
 ```typescript
 // 인덱스를 활용한 쿼리
-const user = await UserModel.getPuri()
+const user = await UserModel.getPuri("r").table("users")
   .select("id", "name")
   .where({ email: "test@example.com" }) // email 인덱스 사용
   .first();
@@ -103,7 +103,7 @@ const user = await UserModel.getPuri()
 
 ```typescript
 // ✅ 복합 인덱스 활용
-const userOrders = await OrderModel.getPuri().select("id", "total").where({
+const userOrders = await OrderModel.getPuri("r").table("orders").select("id", "total").where({
   user_id: 1,
   status: "completed", // user_id + status 복합 인덱스 사용
 });
@@ -113,7 +113,7 @@ const userOrders = await OrderModel.getPuri().select("id", "total").where({
 
 ```typescript
 // PostgreSQL EXPLAIN으로 실행 계획 확인
-const query = UserModel.getPuri().select("id", "email").where({ status: "active" }).toQuery();
+const query = UserModel.getPuri("r").table("users").select("id", "email").where({ status: "active" }).toQuery();
 
 console.log(query);
 
@@ -127,12 +127,12 @@ console.log(query);
 
 ```typescript
 // ✅ INNER JOIN - 관계가 있는 데이터만
-const ordersWithUser = await OrderModel.getPuri()
+const ordersWithUser = await OrderModel.getPuri("r").table("orders")
   .select("orders.id", "orders.total", "users.name")
   .join("users", "users.id", "orders.user_id"); // INNER JOIN
 
 // ✅ LEFT JOIN - 관계가 없어도 포함
-const usersWithOrders = await UserModel.getPuri()
+const usersWithOrders = await UserModel.getPuri("r").table("users")
   .select("users.id", "users.name", "orders.total")
   .leftJoin("orders", "orders.user_id", "users.id"); // LEFT JOIN
 ```
@@ -141,13 +141,13 @@ const usersWithOrders = await UserModel.getPuri()
 
 ```typescript
 // ❌ 나쁜 예 - 조인 후 필터링
-const result = await OrderModel.getPuri()
+const result = await OrderModel.getPuri("r").table("orders")
   .select("orders.*", "users.name")
   .join("users", "users.id", "orders.user_id")
   .where({ "users.status": "active" }); // 조인 후 필터링
 
 // ✅ 좋은 예 - 조인 전 필터링
-const result = await OrderModel.getPuri()
+const result = await OrderModel.getPuri("r").table("orders")
   .select("orders.*", "users.name")
   .join(knex.raw("users ON users.id = orders.user_id AND users.status = ?", ["active"])); // 조인 조건에 포함
 ```
@@ -158,11 +158,11 @@ const result = await OrderModel.getPuri()
 
 ```typescript
 // ❌ 비효율적 - 모든 행 가져온 후 카운트
-const users = await UserModel.getPuri().select("*");
+const users = await UserModel.getPuri("r").table("users").select("*");
 const count = users.length;
 
 // ✅ 효율적 - DB에서 카운트
-const result = await UserModel.getPuri()
+const result = await UserModel.getPuri("r").table("users")
   .select({ count: Puri.count() })
   .where({ status: "active" });
 const count = result[0].count;
@@ -172,7 +172,7 @@ const count = result[0].count;
 
 ```typescript
 // 주문 통계
-const orderStats = await OrderModel.getPuri()
+const orderStats = await OrderModel.getPuri("r").table("orders")
   .select("user_id", knex.raw("COUNT(*) as order_count"), knex.raw("SUM(total) as total_amount"))
   .where({ status: "completed" })
   .groupBy("user_id")
@@ -188,7 +188,7 @@ const orderStats = await OrderModel.getPuri()
 async function getUsers(page: number, limit: number) {
   const offset = (page - 1) * limit;
 
-  return UserModel.getPuri()
+  return UserModel.getPuri("r").table("users")
     .select("id", "name", "email")
     .orderBy("created_at", "desc")
     .offset(offset)
@@ -201,7 +201,7 @@ async function getUsers(page: number, limit: number) {
 ```typescript
 // ✅ 커서 기반 페이지네이션 (더 빠름)
 async function getUsersCursor(lastId?: number, limit: number = 20) {
-  const query = UserModel.getPuri()
+  const query = UserModel.getPuri("r").table("users")
     .select("id", "name", "email", "created_at")
     .orderBy("id", "desc")
     .limit(limit);
@@ -230,12 +230,12 @@ const secondPage = await getUsersCursor(firstPage[firstPage.length - 1].id, 20);
 
 ```typescript
 // ❌ IN - 서브쿼리 결과를 메모리에 로드
-const usersWithOrders = await UserModel.getPuri()
+const usersWithOrders = await UserModel.getPuri("r").table("users")
   .select("id", "name")
   .whereIn("id", knex.select("user_id").from("orders").where({ status: "completed" }));
 
 // ✅ EXISTS - 존재 여부만 확인 (더 빠름)
-const usersWithOrders = await UserModel.getPuri()
+const usersWithOrders = await UserModel.getPuri("r").table("users")
   .select("id", "name")
   .whereRaw("EXISTS (SELECT 1 FROM orders WHERE orders.user_id = users.id AND orders.status = ?)", [
     "completed",
@@ -246,14 +246,14 @@ const usersWithOrders = await UserModel.getPuri()
 
 ```typescript
 // ❌ 서브쿼리
-const users = await UserModel.getPuri().select(
+const users = await UserModel.getPuri("r").table("users").select(
   "id",
   "name",
   knex.raw("(SELECT COUNT(*) FROM orders WHERE orders.user_id = users.id) as order_count"),
 );
 
 // ✅ LEFT JOIN + GROUP BY (더 빠름)
-const users = await UserModel.getPuri()
+const users = await UserModel.getPuri("r").table("users")
   .select("users.id", "users.name", knex.raw("COUNT(orders.id) as order_count"))
   .leftJoin("orders", "orders.user_id", "users.id")
   .groupBy("users.id");
@@ -276,7 +276,7 @@ async function getUsersWithDetails(userIds: number[]) {
 
 // ✅ whereIn으로 한 번에 조회
 async function getUsersWithDetails(userIds: number[]) {
-  return UserModel.getPuri().select("*").whereIn("id", userIds);
+  return UserModel.getPuri("r").table("users").select("*").whereIn("id", userIds);
 }
 ```
 
@@ -289,7 +289,7 @@ async function processAllUsers() {
   let offset = 0;
 
   while (true) {
-    const users = await UserModel.getPuri().select("id", "email").offset(offset).limit(chunkSize);
+    const users = await UserModel.getPuri("r").table("users").select("id", "email").offset(offset).limit(chunkSize);
 
     if (users.length === 0) break;
 
@@ -330,7 +330,7 @@ async function getCachedUsers() {
   if (cached) return cached;
 
   // 캐시 미스 - DB 조회
-  const users = await UserModel.getPuri().select("id", "name").where({ status: "active" });
+  const users = await UserModel.getPuri("r").table("users").select("id", "name").where({ status: "active" });
 
   // 캐시 저장 (5분)
   await Sonamu.cache.set(cacheKey, users, { ttl: "5m" });
@@ -345,7 +345,7 @@ async function getCachedUsers() {
 
 ```typescript
 // 쿼리 생성
-const query = UserModel.getPuri()
+const query = UserModel.getPuri("r").table("users")
   .select("users.id", "users.name", "orders.total")
   .join("orders", "orders.user_id", "users.id")
   .where({ "users.status": "active" })


### PR DESCRIPTION
이 PR은 AI(Claude Code)에 의해 자동 생성된 Nightly PR입니다. 코드베이스의 ownership은 전적으로 maintainer에게 있으며, 이 PR은 검토 후 판단을 돕기 위한 제안입니다.

## 어떤 issue를 참조했으며, 왜 이 작업을 선정했나요?

[#44 - 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44)을 참조했습니다.

Issue #44의 범위 중:
> 문서와 주석이 코드와 어긋나는 경우 -> 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다.

직전 PR [#160](https://github.com/cartanova-ai/sonamu/pull/160)의 description "사람의 확인이 필요한 부분"에 명시된 follow-up 항목입니다. 입문 문서 2개(`how-sonamu-works.mdx`, `using-services.mdx`)는 #160에서 수정되었지만, 동일한 잘못된 패턴이 FAQ와 트러블슈팅 문서에 다수 남아 있어 이번 PR에서 처리합니다.

## 무엇이 문제인가요?

`BaseModel.getPuri(which: DBPreset): PuriWrapper` (`modules/sonamu/src/database/base-model.ts:58`)는 인스턴스 메서드이며 **DBPreset 인자가 필수**입니다. 또한 `PuriWrapper`는 `.from()`, `.table()`, `.transaction()`, `ub*()` 메서드만 가지고 있어 (`modules/sonamu/src/database/puri-wrapper.ts`), 쿼리를 체이닝하려면 반드시 `.table()` 또는 `.from()`을 먼저 호출해야 합니다.

그러나 다음 문서들의 코드 예제에 다음 잘못된 패턴이 다수 사용되고 있었습니다:

1. `Model.getPuri()` — 인자 누락 (TypeScript 컴파일 에러)
2. `Model.getPuri("r").select(...)` / `.where(...)` — `.table()` 누락 (TypeScript 컴파일 에러)
3. `UserModel.getPuri().getDB()` — `PuriWrapper`에 `getDB` 메서드 없음 (런타임 `TypeError`)

## 변경 내역

### 1. `modules/docs/{ko,en}/faq/database.mdx` (2파일)

- Puri 기본 사용/집계/JOIN/JSONB/Full-Text Search 섹션의 모든 잘못된 예제 정정
- `UserModel.getPuri()` → `UserModel.getPuri("r").table("users")` 등
- 이미 올바른 `getPuri("r").table(...)` 패턴이었던 일부 예제는 그대로 유지

### 2. `modules/docs/{ko,en}/troubleshooting/performance/n-plus-one-problems.mdx` (2파일)

- N+1 시연 예제, whereIn 최적화 예제, 대시보드 데이터 예제, "수동 로딩" anti-pattern 예제 등 정정
- 쿼리 카운트 테스트 예제의 `UserModel.getPuri().getDB()` → `UserModel.getDB("r")`로 변경 (`BaseModel.getDB(which)` 사용)

### 3. `modules/docs/{ko,en}/troubleshooting/performance/query-optimization.mdx` (2파일)

- 컬럼 선택, WHERE 최적화, LIMIT, 인덱스 활용, JOIN 최적화, 집계, 페이지네이션, 서브쿼리, 배치/청크 처리, 캐싱 등 모든 섹션의 예제 정정

## 어떤 접근 방식을 채택했으며, 왜 그랬나요?

### 최소 개입 원칙

- 문서의 설명, 구조, 헤딩, 결론은 일절 변경하지 않고 코드 예제의 API 호출 패턴만 수정했습니다.
- 테이블명은 모델명에서 직관적으로 추론(`UserModel` → `users`, `OrderModel` → `orders` 등)했습니다. 이는 `examples/miomock/api/src/application/user/user.model.ts:23,240` 등의 실제 사용 패턴과 일치합니다.
- 모든 예제가 read 컨텍스트(SELECT/JOIN 등)였으므로 `getPuri("r")`을 사용했습니다.

### 일괄 변환 정확성

- `query-optimization.mdx`는 동일한 `UserModel.getPuri()` / `OrderModel.getPuri()` 패턴이 광범위하게 반복되어 일괄 치환을 사용했습니다 (40개+ 위치). 변환 후 `(UserModel|OrderModel|...)\.getPuri\(\)` 패턴이 0건임을 확인했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가요?

- 문서 코드 예제를 그대로 복사한 사용자가 다음과 같은 에러를 만나게 됩니다:
  - TypeScript: `Expected 1 arguments, but got 0.`, `Property 'select' does not exist on type 'PuriWrapper'.`
  - 런타임: `TypeError: ...getDB is not a function`
- FAQ와 트러블슈팅 문서는 사용자가 문제 해결을 위해 빠르게 참조하는 문서이므로, 이 예제들이 동작하지 않으면 문서의 신뢰도가 크게 손상됩니다.

## 이 변경이 어떤 기능에 영향을 미치나요?

문서 6파일만 변경, 소스 코드 변경 없음. 런타임 동작에 영향 없음.

## 변경 영향을 확인하는 방법

- `pnpm check` (oxlint + oxfmt) 통과 (0 errors)
- `pnpm --filter sonamu-docs dev` 후 다음 페이지의 코드 예제가 모두 컴파일 가능한 형태인지 확인:
  - `/{ko,en}/faq/database`
  - `/{ko,en}/troubleshooting/performance/n-plus-one-problems`
  - `/{ko,en}/troubleshooting/performance/query-optimization`
- API 검증: `BaseModelClass.getPuri(which: DBPreset): PuriWrapper` (`modules/sonamu/src/database/base-model.ts:58`), `PuriWrapper`의 메서드 목록 (`modules/sonamu/src/database/puri-wrapper.ts:30-210`).

## 추후 사람의 확인이 필요한 부분

- **동일 패턴의 미수정 파일**: 다음 두 파일에도 동일한 잘못된 패턴이 남아 있으나, PR 비대화를 막기 위해 별도 작업으로 미루었습니다. 다음 Nightly PR에서 다룰 수 있습니다.
  - `modules/docs/{ko,en}/troubleshooting/debugging/vitest-debug.mdx` (2개소)
  - `modules/docs/{ko,en}/troubleshooting/performance/caching-strategies.mdx` (8개소)
- **테이블명 추론 정확성**: 문서가 가상의 모델을 사용하므로 테이블명을 모델명의 복수형으로 추론했습니다. 도큐먼트 컨벤션상 다른 이름(`user`, `order` 등 단수형)을 사용해야 한다면 일괄 조정이 필요합니다.