### PR TITLE
[Nightly 2026-04-29] vitest-debug/caching-strategies/migrate 문서의 getPuri() 인자 누락 및 .table() 누락 수정 (ko/en 6파일)

### DIFF
--- a/modules/docs/en/tools-and-cli/sonamu-cli/migrate.mdx
+++ b/modules/docs/en/tools-and-cli/sonamu-cli/migrate.mdx
@@ -260,7 +260,7 @@ pnpm migrate run
 ```typescript title="user.model.ts"
 class UserModelClass extends BaseModelClass {
   async updateProfileImage(userId: number, imageUrl: string) {
-    await this.getPuri("w").update({ profile_image: imageUrl }).where("id", userId);
+    await this.getPuri("w").table("users").update({ profile_image: imageUrl }).where("id", userId);
   }
 }
 ```

--- a/modules/docs/en/troubleshooting/debugging/vitest-debug.mdx
+++ b/modules/docs/en/troubleshooting/debugging/vitest-debug.mdx
@@ -305,7 +305,8 @@ test("check mock state", () => {
 ```typescript
 test("check DB query", async () => {
   // Enable query logging (during development)
-  const result = await UserModel.getPuri()
+  const result = await UserModel.getPuri("r")
+    .table("users")
     .select("*")
     .where({ email: "test@example.com" })
     .debug() // Output query
@@ -324,7 +325,7 @@ test("verify data creation", async () => {
   await UserModel.create({ email });
 
   // Check directly from DB
-  const users = await UserModel.getPuri().select("*").getMany();
+  const users = await UserModel.getPuri("r").table("users").select("*").getMany();
 
   console.log("All users:", users);
 

--- a/modules/docs/en/troubleshooting/performance/caching-strategies.mdx
+++ b/modules/docs/en/troubleshooting/performance/caching-strategies.mdx
@@ -202,14 +202,17 @@ class StatisticsService {
   private async calculateDailyStats(date: string) {
     // Complex statistics calculation
     const [userCount, orderCount, revenue] = await Promise.all([
-      UserModel.getPuri()
+      UserModel.getPuri("r")
+        .table("users")
         .select({ count: Puri.count() })
         .then((r) => r[0].count),
-      OrderModel.getPuri()
+      OrderModel.getPuri("r")
+        .table("orders")
         .select({ count: Puri.count() })
         .where("created_at", ">=", date)
         .then((r) => r[0].count),
-      OrderModel.getPuri()
+      OrderModel.getPuri("r")
+        .table("orders")
         .select({ total: Puri.sum("total") })
         .where("created_at", ">=", date)
         .then((r) => r[0].total),
@@ -401,17 +404,21 @@ class DashboardService {
       factory: async () => {
         // Execute multiple aggregation queries in parallel
         const [totalUsers, activeUsers, totalOrders, todayRevenue] = await Promise.all([
-          UserModel.getPuri()
+          UserModel.getPuri("r")
+            .table("users")
             .select({ count: Puri.count() })
             .then((r) => r[0].count),
-          UserModel.getPuri()
+          UserModel.getPuri("r")
+            .table("users")
             .select({ count: Puri.count() })
             .where({ status: "active" })
             .then((r) => r[0].count),
-          OrderModel.getPuri()
+          OrderModel.getPuri("r")
+            .table("orders")
             .select({ count: Puri.count() })
             .then((r) => r[0].count),
-          OrderModel.getPuri()
+          OrderModel.getPuri("r")
+            .table("orders")
             .select({ total: Puri.sum("total") })
             .where("created_at", ">=", new Date().toISOString().split("T")[0])
             .then((r) => r[0].total),

--- a/modules/docs/ko/tools-and-cli/sonamu-cli/migrate.mdx
+++ b/modules/docs/ko/tools-and-cli/sonamu-cli/migrate.mdx
@@ -260,7 +260,7 @@ pnpm migrate run
 ```typescript title="user.model.ts"
 class UserModelClass extends BaseModelClass {
   async updateProfileImage(userId: number, imageUrl: string) {
-    await this.getPuri("w").update({ profile_image: imageUrl }).where("id", userId);
+    await this.getPuri("w").table("users").update({ profile_image: imageUrl }).where("id", userId);
   }
 }
 ```

--- a/modules/docs/ko/troubleshooting/debugging/vitest-debug.mdx
+++ b/modules/docs/ko/troubleshooting/debugging/vitest-debug.mdx
@@ -305,7 +305,8 @@ test("Mock 상태 확인", () => {
 ```typescript
 test("DB 쿼리 확인", async () => {
   // 쿼리 로깅 활성화 (개발 중)
-  const result = await UserModel.getPuri()
+  const result = await UserModel.getPuri("r")
+    .table("users")
     .select("*")
     .where({ email: "test@example.com" })
     .debug() // 쿼리 출력
@@ -324,7 +325,7 @@ test("데이터 생성 확인", async () => {
   await UserModel.create({ email });
 
   // DB에서 직접 확인
-  const users = await UserModel.getPuri().select("*").getMany();
+  const users = await UserModel.getPuri("r").table("users").select("*").getMany();
 
   console.log("전체 사용자:", users);
 

--- a/modules/docs/ko/troubleshooting/performance/caching-strategies.mdx
+++ b/modules/docs/ko/troubleshooting/performance/caching-strategies.mdx
@@ -202,14 +202,17 @@ class StatisticsService {
   private async calculateDailyStats(date: string) {
     // 복잡한 통계 계산
     const [userCount, orderCount, revenue] = await Promise.all([
-      UserModel.getPuri()
+      UserModel.getPuri("r")
+        .table("users")
         .select({ count: Puri.count() })
         .then((r) => r[0].count),
-      OrderModel.getPuri()
+      OrderModel.getPuri("r")
+        .table("orders")
         .select({ count: Puri.count() })
         .where("created_at", ">=", date)
         .then((r) => r[0].count),
-      OrderModel.getPuri()
+      OrderModel.getPuri("r")
+        .table("orders")
         .select({ total: Puri.sum("total") })
         .where("created_at", ">=", date)
         .then((r) => r[0].total),
@@ -401,17 +404,21 @@ class DashboardService {
       factory: async () => {
         // 여러 집계 쿼리 병렬 실행
         const [totalUsers, activeUsers, totalOrders, todayRevenue] = await Promise.all([
-          UserModel.getPuri()
+          UserModel.getPuri("r")
+            .table("users")
             .select({ count: Puri.count() })
             .then((r) => r[0].count),
-          UserModel.getPuri()
+          UserModel.getPuri("r")
+            .table("users")
             .select({ count: Puri.count() })
             .where({ status: "active" })
             .then((r) => r[0].count),
-          OrderModel.getPuri()
+          OrderModel.getPuri("r")
+            .table("orders")
             .select({ count: Puri.count() })
             .then((r) => r[0].count),
-          OrderModel.getPuri()
+          OrderModel.getPuri("r")
+            .table("orders")
             .select({ total: Puri.sum("total") })
             .where("created_at", ">=", new Date().toISOString().split("T")[0])
             .then((r) => r[0].total),


### PR DESCRIPTION
이 PR은 AI(Claude Code)에 의해 자동 생성된 Nightly PR입니다. 코드베이스의 ownership은 전적으로 maintainer에게 있으며, 이 PR은 검토 후 판단을 돕기 위한 제안입니다.

## 어떤 issue를 참조했으며, 왜 이 작업을 선정했나요?

[#44 - 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44)을 참조했습니다.

Issue #44의 범위 중:
> 문서와 주석이 코드와 어긋나는 경우 -> 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다.

직전 PR [#161](https://github.com/cartanova-ai/sonamu/pull/161)의 description "사람의 확인이 필요한 부분"에 명시된 follow-up 항목을 처리합니다. PR #161에서 다음 두 파일이 미수정 follow-up으로 명시되었습니다:
- `modules/docs/{ko,en}/troubleshooting/debugging/vitest-debug.mdx` (2개소)
- `modules/docs/{ko,en}/troubleshooting/performance/caching-strategies.mdx` (8개소 → 실제 작업 시 7개소 확인)

추가로 master 전체를 재검색한 결과, `migrate.mdx`에 동일 카테고리의 `.update()` 체이닝 누락 1개소도 함께 발견되어 같은 PR에서 처리합니다. 이로써 `modules/docs` 내 모든 `getPuri()` 인자 누락 / `.table()` 누락된 코드 예제가 정리됩니다.

## 무엇이 문제인가요?

`BaseModelClass.getPuri(which: DBPreset): PuriWrapper` (`modules/sonamu/src/database/base-model.ts:58`)는 인스턴스 메서드이며 **DBPreset 인자가 필수**입니다. `PuriWrapper`는 `.from()`, `.table()`, `.transaction()`, `ub*()` 메서드만 가지고 있어 (`modules/sonamu/src/database/puri-wrapper.ts`), 쿼리를 체이닝하려면 반드시 `.table()` 또는 `.from()`을 먼저 호출해야 합니다.

다음 패턴이 남아 있어 사용자가 코드를 그대로 복사하면 컴파일/런타임 에러가 발생합니다:

1. `UserModel.getPuri()` — 인자 누락 (TS2554: Expected 1 arguments, but got 0)
2. `Model.getPuri("r"|"w").select|.where|.update(...)` — `.table()` 누락 (TS2339: Property 'select' does not exist on type 'PuriWrapper')

## 변경 내역

### 1. `modules/docs/{ko,en}/troubleshooting/debugging/vitest-debug.mdx` (2파일, 각 2개소)

- 쿼리 로깅 예제: `UserModel.getPuri().select("*").where(...)` → `UserModel.getPuri("r").table("users").select("*").where(...)`
- 데이터 확인 예제: `UserModel.getPuri().select("*").getMany()` → `UserModel.getPuri("r").table("users").select("*").getMany()`

### 2. `modules/docs/{ko,en}/troubleshooting/performance/caching-strategies.mdx` (2파일, 각 7개소)

- 일일 통계 캐싱(`StatisticsService.calculateDailyStats`)의 3개 집계 쿼리
- 대시보드 통계 캐싱(`DashboardService.getDashboardStats`)의 4개 집계 쿼리
- 모두 `Model.getPuri()` → `Model.getPuri("r").table(<tableName>)` 형태로 정정 (UserModel→users, OrderModel→orders)

### 3. `modules/docs/{ko,en}/tools-and-cli/sonamu-cli/migrate.mdx` (2파일, 각 1개소)

- 마이그레이션 후 코드 업데이트 예제: `this.getPuri("w").update(...).where(...)` → `this.getPuri("w").table("users").update(...).where(...)`

## 어떤 접근 방식을 채택했으며, 왜 그랬나요?

### 직전 PR과 동일한 변환 패턴 사용

- PR #160, #161에서 채택한 변환 규칙(`Model.getPuri(...)` → `Model.getPuri("r"|"w").table(<tableName>)`)을 그대로 따랐습니다. 코드베이스 일관성과 사용자가 여러 문서를 오갈 때의 학습 부담 최소화가 목적입니다.
- 모든 예제가 read 컨텍스트(SELECT/COUNT/SUM)였으므로 `getPuri("r")`을 사용했고, `migrate.mdx`만 UPDATE이므로 기존 `"w"`를 유지했습니다.

### 최소 개입 원칙

- 문서의 설명 텍스트, 구조, 예제 의도, 헤딩은 일절 변경하지 않고 코드 예제의 API 호출 패턴만 수정했습니다.
- 테이블명은 모델명에서 직관적으로 추론(UserModel → "users", OrderModel → "orders")했습니다. 이는 `examples/miomock` 등 실제 코드의 컨벤션과 일치하며 PR #160/#161에서도 동일한 추론을 적용했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가요?

- 문서 코드 예제를 그대로 복사한 사용자가 다음 에러를 만나게 됩니다:
  - TypeScript: `Expected 1 arguments, but got 0.`, `Property 'select' does not exist on type 'PuriWrapper'.`, `Property 'update' does not exist on type 'PuriWrapper'.`
- 트러블슈팅(특히 디버깅/성능)과 마이그레이션 가이드는 사용자가 실제로 문제 해결을 위해 빠르게 참조하는 문서이므로, 예제가 동작하지 않으면 문서 신뢰도가 크게 손상됩니다.
- PR #161에서 follow-up으로 명시했음에도 처리하지 않을 경우, 동일 패턴 정리 작업이 미완으로 남아 누적됩니다.

## 이 변경이 어떤 기능에 영향을 미치나요?

문서 6파일만 변경, 소스 코드 변경 없음. 런타임 동작에 영향 없음.

## 변경 영향을 확인하는 방법

- 루트 `pnpm check` (oxlint --type-aware + oxfmt --check) 통과 (0 errors, 6 warnings은 본 PR과 무관한 기존 코드의 워닝)
- `pnpm --filter sonamu-docs dev` 후 다음 페이지의 코드 예제가 컴파일 가능한 형태인지 시각 확인:
  - `/{ko,en}/troubleshooting/debugging/vitest-debug`
  - `/{ko,en}/troubleshooting/performance/caching-strategies`
  - `/{ko,en}/tools-and-cli/sonamu-cli/migrate`
- API 검증:
  - `BaseModelClass.getPuri(which: DBPreset): PuriWrapper` (`modules/sonamu/src/database/base-model.ts:58`)
  - `PuriWrapper`의 메서드는 `.from()`, `.table()`, `.transaction()`, `ub*()`만 존재 (`modules/sonamu/src/database/puri-wrapper.ts`)
- 잔여 패턴 재검색 결과: `getPuri()` 인자 누락 / `getPuri("r"|"w").(select|where|update)` 직접 체이닝은 `modules/docs` 내 코드 예제에서 0건.

## 추후 사람의 확인이 필요한 부분

- **서술형 표현은 보류**: 다음 두 위치는 코드 호출이 아닌 서술/메타 문맥의 `getPuri()` 표기이므로 이번 PR에서 손대지 않았습니다. 일반론으로 이해할 수 있지만, "정확한 시그니처로 통일"이 정책이라면 별도 PR에서 다룰 수 있습니다.
  - `modules/docs/{ko,en}/core-concepts/model/basemodel-methods.mdx:126` — `<Tip>` 안 본문의 `getPuri()` 메서드 일반 언급
  - `modules/docs/{ko,en}/database/transactions/manual-transactions.mdx:3` — frontmatter `description`의 `getPuri().transaction()` 표기
- **테이블명 추론 정확성**: 가상의 `UserModel`/`OrderModel`을 위한 테이블명을 모델명의 복수형(`users`, `orders`)으로 추론했습니다. 도큐먼트 컨벤션이 다른 표기(`user`, `order`)를 선호한다면 일괄 조정이 필요합니다.