### PR TITLE
[Nightly 2026-04-30] @stream 문서의 'WebSocket 향후 지원' 표현을 @websocket 데코레이터 안내로 정정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/advanced-features/sse/creating-sse-endpoints.mdx
+++ b/modules/docs/en/advanced-features/sse/creating-sse-endpoints.mdx
@@ -62,7 +62,8 @@ class NotificationModelClass extends BaseModelClass {
 
     **Supported types**:
     - `'sse'`: Server-Sent Events
-    - (WebSocket support planned for future)
+
+    WebSocket is provided via the dedicated `@websocket` decorator. `@stream` is for SSE only.
 
   </Tab>
 

--- a/modules/docs/en/api-reference/decorators/stream.mdx
+++ b/modules/docs/en/api-reference/decorators/stream.mdx
@@ -73,7 +73,7 @@ Specifies the streaming type.
 type: "sse"; // Server-Sent Events (currently the only option)
 ```
 
-<Info>WebSocket support may be added in the future.</Info>
+<Info>WebSocket is provided via the dedicated `@websocket` decorator. `@stream` is for SSE only and the `type` option accepts `"sse"` only.</Info>
 
 ### events
 

--- a/modules/docs/ko/advanced-features/sse/creating-sse-endpoints.mdx
+++ b/modules/docs/ko/advanced-features/sse/creating-sse-endpoints.mdx
@@ -62,7 +62,8 @@ class NotificationModelClass extends BaseModelClass {
 
     **지원 타입**:
     - `'sse'`: Server-Sent Events
-    - (향후 WebSocket 지원 예정)
+
+    WebSocket은 별도의 `@websocket` 데코레이터로 지원됩니다. `@stream`은 SSE 전용입니다.
 
   </Tab>
 

--- a/modules/docs/ko/api-reference/decorators/stream.mdx
+++ b/modules/docs/ko/api-reference/decorators/stream.mdx
@@ -73,7 +73,7 @@ class NotificationModelClass extends BaseModelClass {
 type: "sse"; // Server-Sent Events (현재 유일한 옵션)
 ```
 
-<Info>향후 WebSocket 지원이 추가될 수 있습니다.</Info>
+<Info>WebSocket은 별도의 `@websocket` 데코레이터로 지원됩니다. `@stream`은 SSE 전용이며 `type` 옵션은 `"sse"`만 받습니다.</Info>
 
 ### events
 


### PR DESCRIPTION
이 PR은 AI(Claude Code)에 의해 자동 생성된 Nightly PR입니다. 코드베이스의 ownership은 전적으로 maintainer에게 있으며, 이 PR은 검토 후 판단을 돕기 위한 제안입니다.

## 어떤 issue를 참조했으며, 왜 이 작업을 선정했나요?

[#44 - 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44)을 참조했습니다.

Issue #44의 범위 중:
> 문서와 주석이 코드와 어긋나는 경우 -> 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다.
> sonamu-docs 업데이트: ko 문서를 업데이트한 후 en도 동일하게 업데이트해야 합니다.

직전 PR #163은 `getPuri()` 패턴 정정 follow-up을 모두 정리했습니다(잔여 0건). 이번에는 다른 영역에서 사용자가 실제로 잘못된 정보를 받고 있을 가능성이 높은 항목으로, **SON-435로 `@websocket` 데코레이터가 새로 추가되었음에도 `@stream` 문서가 "WebSocket은 향후 지원될 예정"이라고 안내하고 있는 부분**을 선정했습니다.

## 무엇이 문제인가요?

`modules/sonamu/src/api/decorators.ts:64-76`에 `WebSocketDecoratorOptions`가, `decorators.ts:126`에 `DECORATOR_TYPES.WEBSOCKET`이, 그리고 `decorators.ts:134`의 중복 데코레이터 에러 메시지에 `@api, @stream, @websocket, or @upload`로 `@websocket`이 정식 데코레이터로 등록되어 있습니다. 즉 **WebSocket은 이미 별도의 `@websocket` 데코레이터로 지원됩니다.**

그런데 `@stream` 관련 문서들은 아직도 다음과 같이 안내하고 있습니다:

1. `modules/docs/{ko,en}/advanced-features/sse/creating-sse-endpoints.mdx:65`
   - ko: `- (향후 WebSocket 지원 예정)`
   - en: `- (WebSocket support planned for future)`

2. `modules/docs/{ko,en}/api-reference/decorators/stream.mdx:76`
   - ko: `<Info>향후 WebSocket 지원이 추가될 수 있습니다.</Info>`
   - en: `<Info>WebSocket support may be added in the future.</Info>`

이 표기는 사용자에게 두 가지 잘못된 신호를 줍니다:
- `@stream`의 `type` 옵션에 `"ws"` 같은 값이 추후 추가될 것이다 → 실제로는 그렇지 않을 가능성이 높음(WebSocket은 별도 데코레이터로 분리됨).
- 현재 sonamu에서 WebSocket을 쓸 수 없다 → 사실과 다름. `@websocket`으로 사용 가능.

## 변경 내역

총 4개 파일, 각 1개소.

### 1. `modules/docs/{ko,en}/advanced-features/sse/creating-sse-endpoints.mdx`

- ko: `(향후 WebSocket 지원 예정)` 제거 → \`WebSocket은 별도의 \`@websocket\` 데코레이터로 지원됩니다. \`@stream\`은 SSE 전용입니다.\` 안내로 대체
- en: 동일한 의미의 영어 표현으로 대체

### 2. `modules/docs/{ko,en}/api-reference/decorators/stream.mdx`

- ko: `<Info>향후 WebSocket 지원이 추가될 수 있습니다.</Info>` → \`<Info>WebSocket은 별도의 \`@websocket\` 데코레이터로 지원됩니다. \`@stream\`은 SSE 전용이며 \`type\` 옵션은 \`\"sse\"\`만 받습니다.</Info>\`
- en: 동일한 의미의 영어 표현으로 대체

## 어떤 접근 방식을 채택했으며, 왜 그랬나요?

### 최소 개입 원칙

- 문서의 다른 본문, 헤딩, 코드 예제, 구조는 일절 변경하지 않았습니다. 영향 범위를 4개 파일 × 1개소로 한정했습니다.
- 신규 `@websocket` 데코레이터에 대한 별도 가이드 문서(예: `api-reference/decorators/websocket.mdx`)를 만드는 것은 더 큰 분량과 검토 부담이 따르므로 이번 PR 범위에서 제외했습니다. 이번 PR은 "잘못된 안내를 제거"하는 데에만 집중합니다.

### 링크/참조 보수적으로 처리

- `@websocket` 데코레이터 가이드 페이지가 아직 없으므로 명시적 링크는 걸지 않았습니다. 별도 페이지가 추가되는 시점에 본 문구에 링크를 보강할 수 있습니다.

### 코드 주석은 손대지 않음

- `modules/sonamu/src/api/decorators.ts:56`의 \`type: \"sse\"; // | 'ws\` 주석도 outdated 신호일 수 있으나, 이는 코드 변경에 해당하므로 본 PR(문서 변경 한정)의 범위를 벗어나는 것으로 판단해 손대지 않았습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가요?

- 사용자가 sonamu에서 WebSocket을 쓰려고 docs를 검색하면 `@stream`/SSE 문서로 먼저 도달할 가능성이 높습니다. 거기서 "향후 지원 예정"을 보면 곧장 다른 라이브러리를 검토하거나, `@stream({ type: \"ws\" })` 같은 존재하지 않는 사용을 시도해 컴파일 에러를 만나게 됩니다.
- 직전 nightly PR description의 검토 패턴과 마찬가지로, **문서가 코드의 사실과 다른 경우**는 신뢰도 손상이 가장 빠르게 일어나는 영역입니다.

## 이 변경이 어떤 기능에 영향을 미치나요?

문서 4파일만 변경, 소스 코드/타입/런타임 동작에 영향 없음. mdx 안의 코드 예제도 손대지 않았습니다.

## 변경 영향을 확인하는 방법

- 루트 `pnpm check` (oxlint --type-aware + oxfmt --check) 통과 (0 errors, 6 warnings는 본 PR과 무관한 기존 코드의 워닝).
- `pnpm --filter sonamu-docs dev` 후 다음 페이지에서 \"향후 WebSocket\" / \"WebSocket support ... future\" 문구가 사라지고 `@websocket` 데코레이터로 안내되는지 시각 확인:
  - `/{ko,en}/advanced-features/sse/creating-sse-endpoints` (Tab \"type\")
  - `/{ko,en}/api-reference/decorators/stream` (### type 섹션 하단 Info 박스)
- 사실 검증:
  - `modules/sonamu/src/api/decorators.ts:64-76` (`WebSocketDecoratorOptions`)
  - `modules/sonamu/src/api/decorators.ts:126` (`DECORATOR_TYPES.WEBSOCKET`)
  - `modules/sonamu/src/api/decorators.ts:134` (중복 데코레이터 에러 메시지에 `@websocket` 포함)
  - `git log --oneline master | grep SON-435` — `@websocket` 데코레이터 및 WebSocketContext 추가, runtime 5계층 도입 등 일련의 SON-435 커밋들 확인 가능
- 잔여 \"향후 WebSocket\" / \"WebSocket support ... future\" / \"WebSocket support ... planned\" 패턴 재검색 결과: `modules/docs` 내 0건.

## 추후 사람의 확인이 필요한 부분

- **`@websocket` 데코레이터 가이드 문서 부재**: SON-435로 신규 도입된 `@websocket` 데코레이터에 대한 전용 가이드 페이지(예: `api-reference/decorators/websocket.mdx`, `advanced-features/websocket/...`)가 아직 없습니다. 이번 PR은 잘못된 안내를 제거하는 데 한정했고, 새 가이드 작성은 별도 작업으로 다루는 것이 적절해 보입니다.
- **`decorators.ts:56`의 코드 주석**: \`type: \"sse\"; // | 'ws\` 주석이 \"향후 ws 추가\"를 시사할 수 있어 향후 정정 후보이지만, 코드 변경 PR은 따로 다루는 것이 안전합니다.
- **타 문서 sse-setup.mdx의 비교 표**: `modules/docs/{ko,en}/advanced-features/sse/sse-setup.mdx`의 \"HTTP vs SSE vs WebSocket\" 비교 표는 일반론(프로토콜 비교)으로 적절한 내용이라 본 PR에서 손대지 않았습니다. 만약 \"sonamu 내 WebSocket 지원 여부\" 컬럼/주석을 추가하는 정책이라면 별도 검토 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)