### PR TITLE
[Nightly 2026-05-01] decorators.ts의 outdated 'ws' 주석 제거 및 @transactional 함수의 잘못된 @stream 에러 메시지 정정

### DIFF
--- a/modules/sonamu/src/api/decorators.ts
+++ b/modules/sonamu/src/api/decorators.ts
@@ -53,7 +53,7 @@ export type ApiDecoratorOptions = {
   compress?: CompressConfig;
 };
 export type StreamDecoratorOptions = {
-  type: "sse"; // | 'ws
+  type: "sse";
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- 이벤트 키별로 넘겨주는 값이므로 어떤 타입이든 상관없음
   events: z.ZodObject<any>;
   path?: string;

--- a/modules/sonamu/src/api/decorators.ts
+++ b/modules/sonamu/src/api/decorators.ts
@@ -386,7 +386,7 @@ export function transactional(options: TransactionalOptions = {}) {
     const modelName = target.constructor.name.match(/(.+)Class$/)?.[1];
     assert(
       modelName,
-      `modelName is required on @stream decorator on ${target.constructor.name}.${propertyKey}`,
+      `modelName is required on @transactional decorator on ${target.constructor.name}.${propertyKey}`,
     );
     const methodName = propertyKey;
 


### PR DESCRIPTION
이 PR은 AI(Claude Code)에 의해 자동 생성된 Nightly PR입니다. 코드베이스의 ownership은 전적으로 maintainer에게 있으며, 이 PR은 검토 후 판단을 돕기 위한 제안입니다.

## 어떤 issue를 참조했으며, 왜 이 작업을 선정했나요?

[#44 - 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44)을 참조했습니다.

Issue #44의 범위 중:
> 코드에 예상치 못한 동작이나 버그 등 잠재적으로 위험한 포인트가 존재하는 경우 -> 식별하고 제거해야 합니다.
> 문서와 주석이 코드와 어긋나는 경우 -> 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다.

직전 PR #164(`@stream` 문서의 'WebSocket 향후 지원' 표현 정정)의 description에서 명시한 추후 작업 후보 중 첫 번째 항목인 **`decorators.ts:56`의 코드 주석 잔재**를 정리하고, 이번 작업 과정에서 같은 파일을 정독하다 추가로 발견한 **`decorators.ts:389`의 `@transactional` 함수 에러 메시지 복붙 버그**를 함께 정정합니다.

두 항목 모두 `modules/sonamu/src/api/decorators.ts` 한 파일의 한 줄씩이며, 동작에 영향을 주지 않는 텍스트(주석/메시지) 변경입니다.

## 무엇이 문제인가요?

### 1. `decorators.ts:56` — `StreamDecoratorOptions.type`의 outdated 'ws' 주석

```ts
export type StreamDecoratorOptions = {
  type: "sse"; // | 'ws    ← 이 주석
```

이 주석은 "이 type 옵션에 추후 'ws'가 추가될 수 있다"는 신호를 줍니다. 하지만 SON-435로 WebSocket은 별도의 `@websocket` 데코레이터(`WebSocketDecoratorOptions`, `decorators.ts:64-76`)로 분리되었으므로, `@stream`의 `type` 옵션에 `'ws'`가 추가될 가능성은 사실상 없습니다. 이 주석은 사용자/유지보수자에게 잘못된 신호를 줍니다.

직전 PR #164는 동일한 안내가 있던 stream 관련 mdx 문서(`creating-sse-endpoints.mdx`, `stream.mdx`의 ko/en 4파일)를 모두 정정했고, description에서 "코드 주석은 별도 PR에서 다루는 것이 안전하다"고 명시했습니다. 본 PR이 그 follow-up입니다.

### 2. `decorators.ts:389` — `@transactional` 함수의 잘못된 `@stream` 에러 메시지

```ts
export function transactional(options: TransactionalOptions = {}) {
  ...
  return (target, propertyKey, descriptor) => {
    ...
    const modelName = target.constructor.name.match(/(.+)Class$/)?.[1];
    assert(
      modelName,
      `modelName is required on @stream decorator on ${target.constructor.name}.${propertyKey}`,
      // ← @transactional인데 @stream이라고 표기됨
    );
```

`@transactional` 데코레이터를 클래스 이름이 `*Class`로 끝나지 않는 곳에 적용하면, 실제로는 `@transactional`을 쓴 사용자에게 `@stream decorator`에 대한 에러 메시지가 던져집니다. 사용자는 잘못된 데코레이터를 의심하게 되어 디버깅이 늦어집니다.

다른 데코레이터 함수들의 동일 위치를 비교하면 이것이 복붙 실수임이 분명합니다(`decorators.ts:153,224,307,389,454`):
- line 153: `\`...on @api decorator on...\`` ✓
- line 224: `\`...on @stream decorator on...\`` ✓
- line 307: `\`...on @websocket decorator on...\`` ✓
- line 389: `\`...on @stream decorator on...\`` ← `transactional` 함수 안인데 `@stream`이라고 표기됨 (불일치)
- line 454: `\`...on @upload decorator on...\`` ✓

## 변경 내역

총 1파일, 2개소.

### `modules/sonamu/src/api/decorators.ts`

```diff
@@ -53,7 +53,7 @@ export type ApiDecoratorOptions = {
   compress?: CompressConfig;
 };
 export type StreamDecoratorOptions = {
-  type: "sse"; // | 'ws
+  type: "sse";
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- ...
   events: z.ZodObject<any>;
   path?: string;
@@ -386,7 +386,7 @@ export function transactional(options: TransactionalOptions = {}) {
     const modelName = target.constructor.name.match(/(.+)Class$/)?.[1];
     assert(
       modelName,
-      `modelName is required on @stream decorator on ${target.constructor.name}.${propertyKey}`,
+      `modelName is required on @transactional decorator on ${target.constructor.name}.${propertyKey}`,
     );
     const methodName = propertyKey;
```

## 어떤 접근 방식을 채택했으며, 왜 그랬나요?

### 최소 개입 원칙

- 주석 한 줄과 에러 메시지 텍스트만 변경. 시그니처, 로직, 동작 모두 그대로.
- 같은 파일을 정독하다 발견한 다른 일관성 결여(예: `api/stream/websocket` 함수가 `return descriptor`를 하지 않는 반면 `transactional/upload`는 한다)는 **동작에 영향을 주지 않는 cleanup**이라 본 PR에서 다루지 않았습니다(TS legacy decorators의 `__decorate` 헬퍼는 데코레이터가 undefined를 반환하면 입력 descriptor를 그대로 사용해 `Object.defineProperty`를 호출하므로, 직접 mutation으로 충분히 동작함). 이런 일관성 정정은 별도 검토가 필요한 영역으로 판단했습니다.

### 두 변경을 한 PR에 묶은 이유

- 같은 파일의 같은 영역(`decorators.ts`)에 있는 텍스트 정정.
- 둘 다 동작에 영향을 주지 않는 1라인 변경.
- 둘 다 "코드와 의도/사실이 어긋나는 신호 제거"라는 같은 동기.
- 커밋은 두 개로 분리하여 각 변경이 독립적으로 revert 가능하게 했습니다.

### 코드 행동 변경 없음 검증

- `pnpm --filter sonamu test:type` 통과(39 tests, 0 type errors)로 타입 시그니처 호환성 확인.
- 주석 제거: 컴파일 결과물에 영향 없음.
- 에러 메시지 변경: assert 조건과 throw 시점은 동일, 메시지 문자열만 다름.

## 이렇게 하지 않으면 어떤 점이 안 좋은가요?

- **outdated 주석**: 새로 합류한 개발자가 `StreamDecoratorOptions`를 보고 "stream에 ws 모드도 추가해야 하나?"라는 잘못된 작업 가설을 세울 수 있습니다. 또한 `@websocket` 데코레이터의 존재가 가려져 중복 구현 시도로 이어질 수 있습니다.
- **잘못된 에러 메시지**: `@transactional`을 잘못 사용한 사용자가 던져진 에러 메시지를 보고 `@stream`을 점검하다 시간을 낭비합니다. 이 함수의 assert는 클래스 이름이 `*Class` 패턴이 아닐 때 즉시 실패하는 경로라, 실제로 마주칠 가능성이 있는 에러입니다.

## 이 변경이 어떤 기능에 영향을 미치나요?

- 타입 정의 1곳, 에러 메시지 1곳. 런타임 동작/타입 추론 결과/생성 코드에 영향 없음.
- 다른 모듈(syncer, codegen, miomock 등)에서 이 두 라인을 직접 참조하는 곳은 없음(grep으로 확인).

## 변경 영향을 확인하는 방법

- `pnpm install` 후
  - `pnpm check` (oxlint --type-aware + oxfmt --check) 통과 (0 errors, 6 warnings는 본 PR과 무관한 기존 워닝).
  - `pnpm --filter sonamu build` 성공.
  - `pnpm --filter sonamu test:type` 통과 (39 tests, no type errors).
  - `pnpm --filter sonamu test:unit`은 master와 동일 결과(2 files / 8 tests fail). 실패 항목은 `Sonamu has not been initialized`, `import.meta.url` 처리 등 사전 존재하는 환경/초기화 이슈로 본 PR과 무관함을 master 베이스라인 비교로 확인.
- 사실 검증:
  - `decorators.ts:64-76` `WebSocketDecoratorOptions` 정의 존재.
  - `decorators.ts:126` `DECORATOR_TYPES.WEBSOCKET` 등록.
  - `decorators.ts:134` 중복 데코레이터 에러 메시지에 `@websocket` 정식 포함.
  - 변경 후 `decorators.ts`의 5개 assert 메시지(line 153, 224, 307, 389, 454)가 각각 자기 데코레이터 이름과 일치.

## 추후 사람의 확인이 필요한 부분

- **`api/stream/websocket` 함수의 `return descriptor` 누락 일관성**: 같은 파일 안에서 `api`, `stream`, `websocket` 함수는 `descriptor`를 반환하지 않고, `transactional`, `upload` 함수만 `return descriptor`를 합니다. TS legacy decorators 사양상 동작 차이는 없으나(직접 mutation으로 충분) 일관성은 깨져 있습니다. 본 PR은 동작 변경이 없음을 확실히 하기 위해 이 cleanup을 포함하지 않았습니다. 별도 PR에서 다루는 것이 안전해 보입니다.
- **`@websocket` 데코레이터 가이드 문서 부재**: 직전 PR #164에서 언급된 대로 `api-reference/decorators/websocket.mdx` 등 전용 가이드 페이지가 없습니다. 이는 신규 문서 작성으로 분량이 커서 본 PR 범위에 포함하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)