### PR TITLE
[Nightly 2026-05-04] formatter의 .json 확장자 매칭 정정 및 process-utils JSDoc을 실제 시그니처에 맞게 정정

### DIFF
--- a/modules/sonamu/src/utils/formatter.ts
+++ b/modules/sonamu/src/utils/formatter.ts
@@ -21,7 +21,7 @@ const _require = createRequire(import.meta.url);
  * 수명은 프로세스 죽을때까지 ㅋ
  */
 export const formatCode = cached(formatCodeInternal, (code, filePath) => {
-  const ext = filePath.endsWith(".tsx") ? "tsx" : filePath.endsWith("json") ? "json" : "ts";
+  const ext = filePath.endsWith(".tsx") ? "tsx" : filePath.endsWith(".json") ? "json" : "ts";
   return `${ext}:${createHash("sha1").update(code).digest("hex")}`;
 });
 
@@ -30,7 +30,7 @@ export const formatCode = cached(formatCodeInternal, (code, filePath) => {
  */
 async function formatCodeInternal(code: string, filePath: string): Promise<string> {
   // json은 포맷만 하면 됩니다.
-  if (filePath.endsWith("json")) {
+  if (filePath.endsWith(".json")) {
     return runOxfmt(code, filePath);
   }
 

--- a/modules/sonamu/src/utils/process-utils.ts
+++ b/modules/sonamu/src/utils/process-utils.ts
@@ -7,7 +7,7 @@ import chalk from "chalk";
 const execFileAsync = promisify(execFile);
 
 /**
- * exexFileSync의 비동기 버전입니다.
+ * child_process.execFile의 Promise 기반 wrapper입니다.
  * exit code가 non-zero이면 reject해요.
  */
 export async function execute(
@@ -21,11 +21,11 @@ export async function execute(
 
 /**
  * 주어진 작업을 실행합니다.
- * 주어진 프로세스 이벤트(=시그널)가 발생하였을 때에도 최대 한계(delayBeforeShutdown) 동안 작업을 기다린 후 종료합니다.
+ * 주어진 프로세스 이벤트(=시그널)가 발생하였을 때에도 최대 한계(waitForUpTo) 동안 작업을 기다린 후 종료합니다.
  * @param {() => Promise<void>} job - 실행할 작업
- * @param {event: NodeJS.Signals; delayBeforeShutdown: number} options - 옵션
- * @param {NodeJS.Signals} options.event - 프로세스 이벤트
- * @param {number} options.delayBeforeShutdown - 최대 한계 시간
+ * @param {{ whenThisHappens: NodeJS.Signals; waitForUpTo: number }} options - 옵션
+ * @param {NodeJS.Signals} options.whenThisHappens - 프로세스 이벤트
+ * @param {number} options.waitForUpTo - 최대 한계 시간
  */
 export async function runWithGracefulShutdown(
   job: () => Promise<void>,


### PR DESCRIPTION
## 이 PR은 무엇이며, 왜 만들어졌는지

이 PR은 [Nightly PR Directions (#43)](https://github.com/cartanova-ai/sonamu/issues/43)에 명시된 자동화된 야간 작업 절차에 따라 AI(Claude Code)가 자동으로 생성한 PR입니다. 작업 범위는 [#44 (내일 새벽에 AI에게 맡길 일들)](https://github.com/cartanova-ai/sonamu/issues/44)에서 지정한 우선순위(잠재적으로 위험한 포인트, 문서/주석과 코드의 불일치) 안에서 선정했습니다.

코드/주석을 직접 검토하다가, 최근 머지된 syncer 대규모 리팩토링(1e7fc5ad, d281b5aa 등) 주변의 utils 영역에서 두 가지 작은 정합성 이슈를 발견하여 다음 두 단위 작업으로 묶었어요:

1. `formatter.ts`의 JSON 확장자 매칭에서 점이 누락된 것을 정정.
2. `process-utils.ts`의 두 함수의 JSDoc이 실제 시그니처/구현과 어긋난 부분을 정정.

둘 다 동작 변경이 거의 없거나 매우 좁은 범위의 정확성 정렬이며, 큰 리팩토링은 아닙니다. 부담없이 닫으셔도 됩니다.

## 어떤 issue를 참조했고, 왜 이 작업을 골랐는지

- **참조 issue**: #43 (절차), #44 (범위/우선순위)
- **선정 이유**:
  - #44가 명시한 우선순위 중 \"코드 안의 잠재적 위험 포인트\"와 \"문서/주석과 코드의 어긋남\"에 둘 다 정확히 부합.
  - 최근 PR(#130~#165)들과 중복되지 않습니다. 최근 시기에 syncer 리팩토링이 머지되면서 새로 생긴/주변 utils 코드들의 정합성을 한번 훑어볼 가치가 있었어요.
  - 변경 라인 수가 매우 적고(2 파일, 7+/-7-), 코드 동작에 의도된 변화가 없거나 거의 없으므로 1%짜리 작은 개선의 정의에 부합.

## 어떤 접근을 왜 채택했는지

### 1) `formatter.ts` — `endsWith(\"json\")` → `endsWith(\".json\")`

`modules/sonamu/src/utils/formatter.ts:24` (캐시 키 분기), `:33` (oxfmt-only 분기) 두 곳에서 \`filePath.endsWith(\"json\")\`로 점이 누락되어 있었어요.

- 현실에서는 호출자가 \`.ts\`/\`.tsx\`/\`.json\`만 넘기므로 실제 사용에서 문제가 발생하지는 않습니다. **그래서 \"버그 수정\"이라기보단 \"정확성/일관성 정렬\"에 가깝습니다.**
- 다만 코드베이스의 다른 곳들(\`testing/data-explorer.ts:185\`, \`ui/cdd-service.ts:55, 230\`)은 모두 점을 포함한 \`.json\`을 씁니다. 이 두 곳만 어긋나 있어서, 같은 코드베이스 안에서의 일관성과 \`...XYZjson\` 같은 비정상 입력에 대한 방어 차원에서 정정합니다.
- 이렇게 하지 않으면? 입력 가정이 깨지는 시점이 오면 \`endsWith(\"json\")\`이 의도치 않은 매칭을 만들 수 있어요. 작은 변경으로 미리 막아둘 수 있습니다.

### 2) `process-utils.ts` — JSDoc을 실제 시그니처에 맞게 정정

#### 2-1. `execute` (line 10)

기존 주석:

\`\`\`
/**
 * exexFileSync의 비동기 버전입니다.
 * exit code가 non-zero이면 reject해요.
 */
\`\`\`

- \`exexFileSync\`는 오타이고, 또한 실제 구현은 \`promisify(execFile)\`이라서 sync API와 무관합니다.
- \"child_process.execFile의 Promise 기반 wrapper입니다\"로 정정.

#### 2-2. `runWithGracefulShutdown` (line 22~)

기존 JSDoc은 옵션 객체의 키 이름을 \`event\`/\`delayBeforeShutdown\`이라고 적어두었는데, 실제 외부 인터페이스는 destructure에서 `whenThisHappens`/`waitForUpTo`입니다. 즉, 호출자는 다음과 같이 써야 합니다:

\`\`\`ts
runWithGracefulShutdown(job, { whenThisHappens: \"SIGUSR2\", waitForUpTo: 20000 });
\`\`\`

- 하지만 JSDoc은 \`event\`/\`delayBeforeShutdown\`이라고 알려주고 있어 IDE 자동완성/툴팁에서 호출자에게 잘못된 이름을 노출합니다.
- 본문 안에서 destructure 별칭으로 변수명만 \`event\`/\`delayBeforeShutdown\`을 쓰는 것이라, 외부에서 보는 키 이름은 정정해야 정확합니다.

JSDoc을 실제 옵션 객체 키 이름(`whenThisHappens`/`waitForUpTo`)에 맞춰 정정했습니다.

## 이 변경이 어떤 기능에 영향을 미치는지

- **런타임 동작 영향**: 사실상 없음. \`formatter.ts\`의 \`endsWith\` 패턴 정정도 현재 호출자들이 \`.ts/.tsx/.json\` 경로만 넘기므로 결과는 같습니다.
- **개발 경험 영향**: \`process-utils.ts\`의 JSDoc은 IDE 툴팁에서 보이므로 호출자에게 더 정확한 정보가 노출됩니다.
- **테스트/빌드 영향**: 없음 (아래 검증 결과 참고).

## 영향을 바로 확인하는 방법

루트에서:

\`\`\`bash
pnpm --filter sonamu test:type    # 39 passed, type errors no errors
pnpm --filter sonamu build        # 빌드 성공
pnpm check                        # 6 warnings(기존 잔존), 0 errors
pnpm --filter miomock-api test    # 1414 passed, 0 errors
\`\`\`

모두 통과 확인했습니다. 경고 6개는 변경과 무관한 기존 잔존 경고입니다.

또한 diff가 매우 좁아서 수동 리뷰도 빠르게 가능합니다(7+/-7-, 2 파일).

## 추후 사람의 확인이 필요한 부분

- `formatter.ts`의 \`endsWith(\"json\")\` → \`endsWith(\".json\")\` 정정이 \"의도된 동작이라 둔다\"는 가능성도 0은 아닙니다. 다만 같은 코드베이스의 다른 곳들이 모두 점 포함 패턴이고, 입력 가정이 깨질 때만 차이가 나타나기 때문에 더 안전한 쪽으로 일관시키는 게 합당하다고 판단했어요. 만약 의도된 의미가 따로 있다면 본 PR을 닫아주시기 바랍니다.
- \`runWithGracefulShutdown\`의 옵션 키 이름 \`whenThisHappens\`/`waitForUpTo` 자체는 실제 호출처(현재는 sonamu 내부 사용처가 매우 좁음)에서 그대로 쓰이고 있고 변경하지 않았습니다. JSDoc만 정정한 PR입니다.

---

🤖 이 PR은 [Claude Code](https://claude.com/claude-code)가 [#43](https://github.com/cartanova-ai/sonamu/issues/43) 절차에 따라 자동 생성하였습니다.