### PR TITLE
[Nightly 2026-05-05] queries.generated.ts api 전용 환원에 맞춘 file-patterns 주석 및 auto-generation 문서(ko/en) 정정

### DIFF
--- a/modules/docs/en/core-concepts/auto-generation/syncer.mdx
+++ b/modules/docs/en/core-concepts/auto-generation/syncer.mdx
@@ -85,7 +85,7 @@ File patterns that Syncer tracks in `sonamu.lock`. Patterns are split into **inp
 
 | File Type             | Pattern                                                      | Purpose                                            |
 | --------------------- | ------------------------------------------------------------ | -------------------------------------------------- |
-| **generatedCopied**   | `src/services/**/{sonamu,queries}.generated.{ts,tsx,sso.ts}` | Target-side copies of api originals                |
+| **generatedCopied**   | `src/services/**/sonamu.generated.{ts,tsx}`                  | Target-side copies of api originals                |
 | **servicesGenerated** | `src/services/services.generated.ts`                         | API client (target-only distribution)              |
 | **sdGenerated**       | `src/i18n/**/sd.generated.ts`                                | Sonamu Dictionary (in api and targets)             |
 | **typesCopied**       | `src/services/**/*.types.ts`                                 | Copies of entity types                             |

--- a/modules/docs/en/core-concepts/auto-generation/what-gets-generated.mdx
+++ b/modules/docs/en/core-concepts/auto-generation/what-gets-generated.mdx
@@ -417,28 +417,31 @@ Files for Server-Side Rendering are auto-generated.
 
 ### 9. Queries (`queries.generated.ts`)
 
-```typescript title="web/src/queries.generated.ts (auto-generated)"
-import { queryOptions } from "@tanstack/react-query";
-import { findUserById, findManyUsers } from "./services/services.generated";
+For APIs with the `tanstack-query` client enabled, this file exports SSR-side descriptors (`SSRQuery`) grouped by model namespace. The api-side `ssr/routes.ts` uses these descriptors via `registerSSR(...)` to compose preload configs.
 
-export const userQueries = {
-  findById: (id: number) =>
-    queryOptions({
-      queryKey: ["User", "findById", id],
-      queryFn: () => findUserById(id),
-    }),
+```typescript title="api/src/application/queries.generated.ts (auto-generated)"
+import type { SSRQuery } from "sonamu/ssr";
 
-  findMany: (params?: UserListParams) =>
-    queryOptions({
-      queryKey: ["Users", "findMany", params],
-      queryFn: () => findManyUsers(params),
-    }),
-};
+function createSSRQuery(
+  modelName: string,
+  methodName: string,
+  params: any[],
+  serviceKey: [string, string],
+): SSRQuery {
+  return { modelName, methodName, params, serviceKey, __brand: "SSRQuery" } as SSRQuery;
+}
+
+export namespace UserService {
+  export const findById = (id: number): SSRQuery =>
+    createSSRQuery("UserModel", "findById", [id], ["User", "findById"]);
+}
 ```
 
 **Generated when**: Model file changes
 
 **Editable**: ❌ Auto-regenerated
+
+**Location**: An api-only asset. It is not copied into target (web/app) and is never imported directly from target code. The SSR renderer executes the descriptor server-side and only the result is hydrated on the client.
 
 ### 10. Entry Server (`entry-server.generated.tsx`)
 
@@ -502,7 +505,7 @@ export const SD = {
 | `sonamu.generated.sso.ts`    | `api/src/application/`             | Entity save        | ❌       |
 | `services.generated.ts`      | `web/src/services/`                | Model change       | ❌       |
 | `sonamu.generated.http`      | `api/`                             | Model change       | ❌       |
-| `queries.generated.ts`       | `web/src/`                         | Model change       | ❌       |
+| `queries.generated.ts`       | `api/src/application/`             | Model change       | ❌       |
 | `entry-server.generated.tsx` | `web/src/`                         | Model change       | ❌       |
 | `sd.generated.ts`            | `api/src/`, `web/src/`, `app/src/` | Entity/i18n change | ❌       |
 | `{Entity}List.tsx`           | `web/src/pages/{entity}/`          | Scaffold           | ✅       |

--- a/modules/docs/en/core-concepts/auto-generation/when-files-regenerate.mdx
+++ b/modules/docs/en/core-concepts/auto-generation/when-files-regenerate.mdx
@@ -229,20 +229,19 @@ Content-Type: application/json
 </Step>
 
 <Step title="3. queries.generated.ts">
-Query Options for SSR
+SSR Query descriptors
 
-**Location**: `web/src/queries.generated.ts`
+**Location**: `api/src/application/queries.generated.ts` (api-only — not copied to targets)
 
 **Always regenerated**: ✅
 
 ```typescript
-export const userQueries = {
-  findById: (id: number) =>
-    queryOptions({
-      queryKey: ["User", "findById", id],
-      queryFn: () => findUserById(id),
-    }),
-};
+import type { SSRQuery } from "sonamu/ssr";
+
+export namespace UserService {
+  export const findById = (id: number): SSRQuery =>
+    createSSRQuery("UserModel", "findById", [id], ["User", "findById"]);
+}
 ```
 
 </Step>

--- a/modules/docs/ko/core-concepts/auto-generation/syncer.mdx
+++ b/modules/docs/ko/core-concepts/auto-generation/syncer.mdx
@@ -85,7 +85,7 @@ Syncer가 sonamu.lock에 추적하는 파일 패턴입니다. 자산 본성에 �
 
 | 파일 타입             | 패턴                                                      | 용도                                  |
 | --------------------- | --------------------------------------------------------- | ------------------------------------- |
-| **generatedCopied**   | `src/services/**/{sonamu,queries}.generated.{ts,tsx,sso.ts}` | api 정본의 target 사본                |
+| **generatedCopied**   | `src/services/**/sonamu.generated.{ts,tsx}`               | api 정본의 target 사본                |
 | **servicesGenerated** | `src/services/services.generated.ts`                      | API 클라이언트(target 전용 분배 산출) |
 | **sdGenerated**       | `src/i18n/**/sd.generated.ts`                             | Sonamu Dictionary (api/target 모두)   |
 | **typesCopied**       | `src/services/**/*.types.ts`                              | Entity 타입 사본                      |

--- a/modules/docs/ko/core-concepts/auto-generation/what-gets-generated.mdx
+++ b/modules/docs/ko/core-concepts/auto-generation/what-gets-generated.mdx
@@ -417,28 +417,31 @@ Server-Side Rendering을 위한 파일들이 자동 생성됩니다.
 
 ### 9. Queries (`queries.generated.ts`)
 
-```typescript title="web/src/queries.generated.ts (자동 생성)"
-import { queryOptions } from "@tanstack/react-query";
-import { findUserById, findManyUsers } from "./services/services.generated";
+`tanstack-query` 클라이언트가 활성화된 API에 대해, SSR이 미리 실행할 디스크립터(`SSRQuery`)를 모델별 네임스페이스로 export합니다. api 측 `ssr/routes.ts`의 `registerSSR(...)`이 이 디스크립터를 preload 설정에 사용합니다.
 
-export const userQueries = {
-  findById: (id: number) =>
-    queryOptions({
-      queryKey: ["User", "findById", id],
-      queryFn: () => findUserById(id),
-    }),
+```typescript title="api/src/application/queries.generated.ts (자동 생성)"
+import type { SSRQuery } from "sonamu/ssr";
 
-  findMany: (params?: UserListParams) =>
-    queryOptions({
-      queryKey: ["Users", "findMany", params],
-      queryFn: () => findManyUsers(params),
-    }),
-};
+function createSSRQuery(
+  modelName: string,
+  methodName: string,
+  params: any[],
+  serviceKey: [string, string],
+): SSRQuery {
+  return { modelName, methodName, params, serviceKey, __brand: "SSRQuery" } as SSRQuery;
+}
+
+export namespace UserService {
+  export const findById = (id: number): SSRQuery =>
+    createSSRQuery("UserModel", "findById", [id], ["User", "findById"]);
+}
 ```
 
 **생성 시점**: Model 파일 변경 시
 
 **수정 가능 여부**: ❌ 자동 재생성됨
+
+**위치**: api 전용 자산입니다. target(web/app) 측으로 복사되지 않으며, 직접 import할 일이 없습니다. SSR renderer가 server-side에서 디스크립터를 실행하고 client에는 결과만 hydrate합니다.
 
 ### 10. Entry Server (`entry-server.generated.tsx`)
 
@@ -502,7 +505,7 @@ export const SD = {
 | `sonamu.generated.sso.ts`    | `api/src/application/`             | Entity 저장      | ❌        |
 | `services.generated.ts`      | `web/src/services/`                | Model 변경       | ❌        |
 | `sonamu.generated.http`      | `api/`                             | Model 변경       | ❌        |
-| `queries.generated.ts`       | `web/src/`                         | Model 변경       | ❌        |
+| `queries.generated.ts`       | `api/src/application/`             | Model 변경       | ❌        |
 | `entry-server.generated.tsx` | `web/src/`                         | Model 변경       | ❌        |
 | `sd.generated.ts`            | `api/src/`, `web/src/`, `app/src/` | Entity/i18n 변경 | ❌        |
 | `{Entity}List.tsx`           | `web/src/pages/{entity}/`          | Scaffold         | ✅        |

--- a/modules/docs/ko/core-concepts/auto-generation/when-files-regenerate.mdx
+++ b/modules/docs/ko/core-concepts/auto-generation/when-files-regenerate.mdx
@@ -229,20 +229,19 @@ Content-Type: application/json
 </Step>
 
 <Step title="3. queries.generated.ts">
-SSR용 Query Options
+SSR용 Query 디스크립터
 
-**위치**: `web/src/queries.generated.ts`
+**위치**: `api/src/application/queries.generated.ts` (api 전용 — target에 복사되지 않음)
 
 **항상 재생성**: ✅
 
 ```typescript
-export const userQueries = {
-  findById: (id: number) =>
-    queryOptions({
-      queryKey: ["User", "findById", id],
-      queryFn: () => findUserById(id),
-    }),
-};
+import type { SSRQuery } from "sonamu/ssr";
+
+export namespace UserService {
+  export const findById = (id: number): SSRQuery =>
+    createSSRQuery("UserModel", "findById", [id], ["User", "findById"]);
+}
 ```
 
 </Step>

--- a/modules/sonamu/src/syncer/file-patterns.ts
+++ b/modules/sonamu/src/syncer/file-patterns.ts
@@ -49,8 +49,8 @@ export function getChecksumPatternGroup() {
     // 또한 변경시 그 사실을 syncer가 알기는 해야 합니다(비록 별다른 처리가 없는 경우도 있지만).
     //
     // 자산 본성에 따라 위치 카테고리가 다르기 때문에, 본성별로 분리해서 표기합니다.
-    // - 양쪽-필요 자산: api에 정본이 만들어진 뒤 target에 복사됨 (sonamu.generated.*, queries.generated.ts).
-    // - api 전용 자산: api에만 만들어짐 (sonamu.generated.http).
+    // - 양쪽-필요 자산: api에 정본이 만들어진 뒤 target에 복사됨 (sonamu.generated.{ts,tsx}).
+    // - api 전용 자산: api에만 만들어짐 (sonamu.generated.http, queries.generated.ts).
     // - target 전용 자산: target에만 만들어짐 (services.generated.ts는 services.template의 :target 분배).
     //
     // 여기에는 Sonamu의 모든 sync 산출물이 있는 것은 아닙니다.


### PR DESCRIPTION
## 이 PR은 무엇이며 왜 만들어졌나요

이 PR은 cartanova-ai/sonamu issue #43 (Nightly PR Directions) 및 issue #44의 지침에 따라 AI(Claude)가 **자동으로 생성**한 nightly PR입니다.
`코드 5a7e9084` 머지 이후 syncer 영역에서 코드와 주석/문서가 어긋나는 부분이 남아 있어, 이를 1%만큼 깔끔하게 정렬하기 위해 작성되었습니다.

## 어떤 issue를 참조했고, 왜 이 작업을 골랐나요

- 참조 issue: #43 (절차/형식), #44 (작업 범위 — "문서와 주석이 코드와 어긋나는 경우 설명을 업데이트")
- 동기: 5a7e9084 fix(syncer): queries.generated.ts 분배 invariant 정정 — api 전용으로 환원
  - 위 커밋이 코드(file-patterns.ts:60의 `generatedCopied` 패턴, queries.template.ts 출력 위치, syncer-actions의 분배 호출)는 정확히 정정했지만,
  - 같은 파일의 **자산 본성 분류 주석**과 **사용자 노출 한국어/영어 문서**는 여전히 "queries.generated.ts는 web/src에 위치하며 양쪽-필요 자산"이라는 outdated 정보를 노출 중입니다.
  - 사용자가 web 프로젝트에서 `queries.generated.ts`를 찾으려다 찾지 못하거나, react-query queryOptions 형태의 잘못된 사용 패턴을 학습할 수 있는 false-positive 안내입니다.
- nightly PR(#131~#167) 흐름 및 issue #44에서 제외 지정한 영역(`puri.ts` SQL injection, `PostgresPubSub.destroy()` null 체크, `practices` 폴더)은 모두 회피했습니다.

## 어떤 접근을 골랐고 왜 그랬나요

작업을 **2개의 최소 단위 커밋**으로 분리했습니다.

1. fix(syncer): file-patterns.ts 주석에서 queries.generated.ts를 api 전용 자산으로 정정 (1파일, 코드 동작에는 영향 없는 주석 수정)
2. docs(auto-generation): queries.generated.ts api 전용 환원 반영 (ko/en 3개 mdx × 2 = 6파일)

선택한 이유:
- 코드와 문서의 변경은 같은 invariant("queries.generated.ts는 api 전용")를 다른 표면에서 반영하는 것이므로 한 PR로 묶는 것이 맥락 추적에 유리.
- 그러나 코드 변경(주석)과 문서 변경은 리뷰 포인트가 다르므로 커밋 단위는 분리.
- 코드 예제는 단순히 위치만 정정하는 게 아니라 실제 출력 형태(`SSRQuery` 디스크립터)에 맞춰 다시 적었습니다. 단순 위치 정정만 하면 코드 본문이 여전히 `react-query queryOptions` 형태로 남아 사용자에게 잘못된 사용을 유도하기 때문입니다(실제 `queries.template.ts`는 `createSSRQuery` 헬퍼와 모델별 namespace를 출력).
- entry-server.generated.tsx 예제 코드도 실제 `entry-server.template.ts`와 어긋나지만(`routeTree.gen` + `RouterProvider` 기반 SSR이 아닌 react-query loader 형태로 표기됨), **본 PR의 범위는 5a7e9084의 변경 반영에 한정**하여 entry-server 정정은 별도 작업으로 두었습니다. 후속 PR 후보입니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가요

- file-patterns.ts:51-52 주석이 같은 파일 60줄의 실제 패턴과 모순된 채 남아, 다음 작업자가 분배 정책을 잘못 이해할 수 있습니다.
- 사용자 문서(ko/en)에서 `queries.generated.ts`가 `web/src/`에 생성된다고 안내하므로, 사용자는 web 프로젝트에서 파일을 찾으려 시도하거나, 잘못된 사용 패턴(react-query queryOptions를 import하여 직접 사용)을 따라가다 실패합니다. 실제로는 api 측 `ssr/routes.ts`에서 `registerSSR(...)`을 통해 사용해야 합니다.

## 영향 범위

- 코드 변경: `modules/sonamu/src/syncer/file-patterns.ts` — **주석만** 수정 (런타임 동작 영향 없음).
- 문서 변경:
  - `modules/docs/ko/core-concepts/auto-generation/{syncer.mdx, what-gets-generated.mdx, when-files-regenerate.mdx}`
  - `modules/docs/en/core-concepts/auto-generation/{syncer.mdx, what-gets-generated.mdx, when-files-regenerate.mdx}`

## 영향을 즉시 확인하는 방법

1. 코드: `modules/sonamu/src/syncer/file-patterns.ts:51-53`을 읽고 같은 파일 :60 `generatedCopied` 패턴(`sonamu.generated.{ts,tsx}`)과 일치하는지 확인.
2. 문서:
   - `modules/docs/ko/core-concepts/auto-generation/syncer.mdx:88` → `src/services/**/sonamu.generated.{ts,tsx}` 표기.
   - `modules/docs/{ko,en}/core-concepts/auto-generation/what-gets-generated.mdx`의 "9. Queries" 섹션 — title이 `api/src/application/queries.generated.ts`이며 코드 예제가 `SSRQuery` 디스크립터 형태인지 확인. 요약표 행도 `api/src/application/`인지 확인.
   - `modules/docs/{ko,en}/core-concepts/auto-generation/when-files-regenerate.mdx`의 Step 3 위치/코드도 동일 정정.
3. 통합 회귀: 본 PR은 파일을 새로 만들지 않고 기존 파일의 표기만 변경하므로, 실제 sync 동작이 바뀌지 않습니다. 이미 수행한 검증은 아래 "검증" 섹션 참고.

## 검증

`modules/sonamu/CLAUDE.md`의 권고 검증 흐름을 따랐습니다.

- `pnpm check` (oxlint --type-aware + oxfmt --check) → 0 errors, 6 warnings(기존 코드, 본 PR 무관).
- `pnpm --filter sonamu build` → 성공.
- `pnpm --filter sonamu test:type` → 3 files / 39 tests, no type errors.
- `pnpm --filter miomock-api test` → 1414 passed / 10 skipped / 6 todo, no type errors.
- pre-commit (lefthook): oxfmt + oxlint + sonamu-typecheck 모두 통과.

## 후속/추후 사람의 확인이 필요한 부분

- `what-gets-generated.mdx`의 **10. Entry Server** 섹션 코드 예제(`web/src/entry-server.generated.tsx`)는 실제 `entry-server.template.ts` 출력(`routeTree.gen` + `Suspense` + `RouterProvider`)과 다른 react-query loader 형태로 적혀 있습니다. 본 PR 범위 밖이지만 **별도 nightly로 정정 후보**입니다.
- `using-services.mdx`의 "SSR에서 Service 사용하기" 섹션은 본 PR에서 다루지 않았으나, 위치를 모호하게 두는 형태(`api/src/application/queries.generated.ts`로 정확히 표기)라 큰 어긋남은 없다고 판단했습니다. 필요 시 후속에서 보강 가능합니다.

---

> 본 PR은 AI(Claude)가 issue #43/#44 지침에 따라 자동 생성했습니다. 사용자의 ownership을 침해하려는 의도가 없으며, 변경 단위는 최소화했고, 코드 동작은 건드리지 않았습니다. close하시거나 재구성 요청하셔도 됩니다.