### PR TITLE
[Nightly 2026-05-06] what-gets-generated 문서의 entry-server.generated.tsx 코드 예제를 실제 template 출력(render/RouterProvider)에 맞게 현행화 (ko/en 2파일)

### DIFF
--- a/modules/docs/en/core-concepts/auto-generation/what-gets-generated.mdx
+++ b/modules/docs/en/core-concepts/auto-generation/what-gets-generated.mdx
@@ -442,25 +442,54 @@ export const userQueries = {
 
 ### 10. Entry Server (`entry-server.generated.tsx`)
 
+TanStack Router-based SSR entry point. It exports a `render(url, preloadedData)` function called by the web side, not a per-route `loader`. Data prefetched during SSR (`preloadedData`) is injected via `queryClient.setQueryData(queryKey, data)`, then `dehydrate`d for client hydration.
+
 ```tsx title="web/src/entry-server.generated.tsx (auto-generated)"
-import { dehydrate, QueryClient } from "@tanstack/react-query";
-import { userQueries } from "./queries.generated";
+import { QueryClient, dehydrate } from "@tanstack/react-query";
+import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/react-router";
+import { Suspense } from "react";
+import { renderToString } from "react-dom/server";
+import { routeTree } from "./routeTree.gen";
 
-export async function loader({ params }) {
-  const queryClient = new QueryClient();
+export type PreloadedData = {
+  queryKey: any[];
+  data: any;
+};
 
-  // SSR data prefetching
-  if (params.userId) {
-    await queryClient.prefetchQuery(userQueries.findById(Number(params.userId)));
+export async function render(url: string, preloadedData: PreloadedData[] = []) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { staleTime: 5000, retry: false },
+    },
+  });
+
+  // Inject results pre-invoked during SSR into queryClient
+  for (const { queryKey, data } of preloadedData) {
+    queryClient.setQueryData(queryKey, data);
   }
 
-  return {
-    dehydratedState: dehydrate(queryClient),
-  };
+  const dehydratedState = dehydrate(queryClient);
+
+  const memoryHistory = createMemoryHistory({ initialEntries: [url] });
+  const router = createRouter({
+    routeTree,
+    context: { queryClient },
+    history: memoryHistory,
+    defaultPreload: "intent",
+  });
+  await router.load();
+
+  const appHtml = renderToString(
+    <Suspense fallback={null}>
+      <RouterProvider router={router} />
+    </Suspense>,
+  );
+
+  return { html: appHtml, dehydratedState };
 }
 ```
 
-**Generated when**: Model file changes
+**Generated when**: Once on first sync (static bootstrap asset, does not depend on inputs)
 
 **Editable**: ❌ Auto-regenerated
 
@@ -503,7 +532,7 @@ export const SD = {
 | `services.generated.ts`      | `web/src/services/`                | Model change       | ❌       |
 | `sonamu.generated.http`      | `api/`                             | Model change       | ❌       |
 | `queries.generated.ts`       | `web/src/`                         | Model change       | ❌       |
-| `entry-server.generated.tsx` | `web/src/`                         | Model change       | ❌       |
+| `entry-server.generated.tsx` | `web/src/`                         | Once on first sync | ❌       |
 | `sd.generated.ts`            | `api/src/`, `web/src/`, `app/src/` | Entity/i18n change | ❌       |
 | `{Entity}List.tsx`           | `web/src/pages/{entity}/`          | Scaffold           | ✅       |
 | `{Entity}Form.tsx`           | `web/src/pages/{entity}/`          | Scaffold           | ✅       |

--- a/modules/docs/ko/core-concepts/auto-generation/what-gets-generated.mdx
+++ b/modules/docs/ko/core-concepts/auto-generation/what-gets-generated.mdx
@@ -442,25 +442,54 @@ export const userQueries = {
 
 ### 10. Entry Server (`entry-server.generated.tsx`)
 
+TanStack Router 기반 SSR 진입점입니다. 라우트별 `loader`가 아니라, web 측에서 호출되는 `render(url, preloadedData)` 함수를 export합니다. SSR 단계에서 미리 가져온 데이터(`preloadedData`)는 `queryClient.setQueryData(queryKey, data)`로 주입한 뒤 `dehydrate`되어 client로 hydrate됩니다.
+
 ```tsx title="web/src/entry-server.generated.tsx (자동 생성)"
-import { dehydrate, QueryClient } from "@tanstack/react-query";
-import { userQueries } from "./queries.generated";
+import { QueryClient, dehydrate } from "@tanstack/react-query";
+import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/react-router";
+import { Suspense } from "react";
+import { renderToString } from "react-dom/server";
+import { routeTree } from "./routeTree.gen";
 
-export async function loader({ params }) {
-  const queryClient = new QueryClient();
+export type PreloadedData = {
+  queryKey: any[];
+  data: any;
+};
 
-  // SSR 데이터 프리페칭
-  if (params.userId) {
-    await queryClient.prefetchQuery(userQueries.findById(Number(params.userId)));
+export async function render(url: string, preloadedData: PreloadedData[] = []) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { staleTime: 5000, retry: false },
+    },
+  });
+
+  // SSR 단계에서 미리 invoke된 결과를 queryClient에 주입
+  for (const { queryKey, data } of preloadedData) {
+    queryClient.setQueryData(queryKey, data);
   }
 
-  return {
-    dehydratedState: dehydrate(queryClient),
-  };
+  const dehydratedState = dehydrate(queryClient);
+
+  const memoryHistory = createMemoryHistory({ initialEntries: [url] });
+  const router = createRouter({
+    routeTree,
+    context: { queryClient },
+    history: memoryHistory,
+    defaultPreload: "intent",
+  });
+  await router.load();
+
+  const appHtml = renderToString(
+    <Suspense fallback={null}>
+      <RouterProvider router={router} />
+    </Suspense>,
+  );
+
+  return { html: appHtml, dehydratedState };
 }
 ```
 
-**생성 시점**: Model 파일 변경 시
+**생성 시점**: 첫 sync 시 1회만 (입력에 의존하지 않는 정적 부트스트랩 자산)
 
 **수정 가능 여부**: ❌ 자동 재생성됨
 
@@ -503,7 +532,7 @@ export const SD = {
 | `services.generated.ts`      | `web/src/services/`                | Model 변경       | ❌        |
 | `sonamu.generated.http`      | `api/`                             | Model 변경       | ❌        |
 | `queries.generated.ts`       | `web/src/`                         | Model 변경       | ❌        |
-| `entry-server.generated.tsx` | `web/src/`                         | Model 변경       | ❌        |
+| `entry-server.generated.tsx` | `web/src/`                         | 첫 sync 시 1회   | ❌        |
 | `sd.generated.ts`            | `api/src/`, `web/src/`, `app/src/` | Entity/i18n 변경 | ❌        |
 | `{Entity}List.tsx`           | `web/src/pages/{entity}/`          | Scaffold         | ✅        |
 | `{Entity}Form.tsx`           | `web/src/pages/{entity}/`          | Scaffold         | ✅        |


### PR DESCRIPTION
## 이 PR은 무엇이며 왜 만들어졌나요

이 PR은 cartanova-ai/sonamu issue #43 (Nightly PR Directions) 및 issue #44의 지침에 따라 AI(Claude)가 자동으로 생성한 nightly PR입니다.
사용자 ownership을 침해하지 않도록 변경 단위를 최소화했고, 코드 동작은 일절 건드리지 않았으며 문서(mdx)만 수정했습니다.

## 어떤 issue를 참조했고, 왜 이 작업을 골랐나요

- 참조 issue: #43(절차/형식), #44(작업 범위 — "문서와 주석이 코드와 어긋나는 경우 설명을 업데이트", "한국어 문서 갱신 후 영어 문서도 동일하게 업데이트")
- 이 작업은 직전 nightly PR #168의 description에서 명시적으로 "별도 nightly로 정정 후보"로 남겨둔 항목을 후속 처리하는 것입니다.
- 동기: \`modules/docs/{ko,en}/core-concepts/auto-generation/what-gets-generated.mdx\` 의 "10. Entry Server" 섹션 코드 예제가 실제 \`modules/sonamu/src/template/implementations/entry-server.template.ts\` 의 출력과 어긋난 채 남아 있었습니다.
  - 문서: 라우트별 \`loader({ params })\` + \`prefetchQuery(userQueries.findById(...))\` 형태
  - 실제 출력: 모듈 export로 \`render(url, preloadedData)\` 함수 (\`createRouter\` + \`RouterProvider\` + \`Suspense\` + \`routeTree.gen\`)
- 사용자가 이 섹션을 보고 \`entry-server.generated.tsx\` 의 진입 형태/시그니처/import 경로를 잘못 학습할 수 있는 false-positive 안내였습니다. 같은 저장소의 \`ssr-setup.mdx\`, \`preloading-data.mdx\`, \`hydration-strategies.mdx\` 는 이미 새 시그니처(\`render(url, preloadedData)\`)로 일관되게 적혀 있어 이 섹션만 외톨이로 outdated였습니다.
- issue #44 에서 제외 지정한 영역(\`puri.ts\` SQL injection, \`PostgresPubSub.destroy()\` null 체크, \`practices\` 폴더)은 모두 회피했습니다.

## 어떤 접근을 골랐고 왜 그랬나요

- 코드 예제를 실제 \`entry-server.template.ts\` 의 출력과 정확히 동일한 패턴(import 라인, \`PreloadedData\` 타입, \`render(url, preloadedData)\` 시그니처, \`setQueryData\` 주입, \`createMemoryHistory\` + \`createRouter\` + \`router.load()\` + \`Suspense > RouterProvider\` 렌더링)으로 다시 적었습니다.
- 같은 문서 내 다른 SSR 페이지(\`ssr-setup.mdx\`)와 표기 톤을 일치시키되, what-gets-generated.mdx 는 "어떤 파일이 만들어지는가" 카탈로그라는 성격을 고려해 코드 위 짧은 설명문 한 줄을 덧붙여 \`render(url, preloadedData)\` 라는 진입 형태와 \`preloadedData → setQueryData → dehydrate\` 흐름을 한눈에 파악할 수 있게 했습니다.
- "생성 파일 요약표" 의 \`entry-server.generated.tsx\` 행에서 "생성 시점: Model 변경"을 "첫 sync 시 1회(부트스트랩 자산)" 로 정정했습니다. 이는 같은 docs 디렉터리의 \`when-files-regenerate.mdx:253\`/\`:471\` 에 이미 명시된 정책("입력에 의존하지 않는 정적 부트스트랩 자산. 첫 sync에서만 생성")과 정합시키기 위함입니다.
- 한국어/영어 두 파일을 한 커밋으로 묶었습니다. 실제 변경의 의도가 두 파일에서 동일하기 때문에 분리하면 오히려 추적이 번잡해진다고 판단했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가요

- 사용자는 \`entry-server.generated.tsx\` 가 라우트별 \`loader\` 를 export 한다고 오해해, 라우트 파일에서 import 하거나 라우트 정의에 매핑하려다 실패합니다. 실제로는 web 측 SSR 진입에서 \`render(url, preloadedData)\` 로 호출되는 단일 함수입니다.
- 직전 PR #168 에서 9. Queries 섹션은 정정되었으나 10. Entry Server 만 outdated 인 채로 남으면, 같은 SSR 단원 안에서 두 번 연속으로 사용자에게 "어느 쪽이 맞는지" 혼란을 줍니다.

## 영향 범위

- 문서 변경만:
  - \`modules/docs/ko/core-concepts/auto-generation/what-gets-generated.mdx\`
  - \`modules/docs/en/core-concepts/auto-generation/what-gets-generated.mdx\`
- 코드/런타임 동작/생성 산출물에 영향 없음.

## 영향을 즉시 확인하는 방법

1. 두 mdx 파일의 "10. Entry Server (\`entry-server.generated.tsx\`)" 섹션 코드 블록이 \`modules/sonamu/src/template/implementations/entry-server.template.ts\` 의 \`render()\` 본문(import 라인 포함)과 일치하는지 확인.
2. 같은 두 mdx 파일의 "생성 파일 요약표" 에서 \`entry-server.generated.tsx\` 행의 "생성 시점" 컬럼이 "첫 sync 시 1회 / Once on first sync" 로 표기되는지 확인.
3. 같은 디렉터리 \`when-files-regenerate.mdx\` 의 부트스트랩 자산 설명과 표기가 일관되는지 확인.

## 검증

\`modules/sonamu/CLAUDE.md\`/\`modules/docs/CLAUDE.md\` 의 권고 검증 흐름을 따랐습니다.

- \`pnpm check\` (oxlint --type-aware + oxfmt --check) → 0 errors, 6 warnings (기존 코드, 본 PR 무관).
- \`pnpm --filter sonamu build\` → 성공.
- \`pnpm --filter sonamu test:type\` → 3 files / 39 tests, no type errors.
- \`pnpm --filter miomock-api test\` → 1414 passed / 10 skipped / 6 todo, no type errors.
- pre-commit (lefthook): 변경이 mdx 만이라 oxfmt/oxlint/typecheck 모두 skip(no matching staged files) — 정상 흐름.

## 후속/추후 사람의 확인이 필요한 부분

- 본 PR 은 \`what-gets-generated.mdx\` 의 코드 블록을 실제 template 출력에 맞춘 것에 한정되어 있습니다. \`hydration-strategies.mdx\`/\`preloading-data.mdx\` 의 동일 시그니처 표기와 자연스럽게 정합되지만, 만약 다른 SSR 문서에서 outdated \`loader({params})\` 패턴이 추가로 발견되면 별도 nightly로 정리 후보입니다(이번 PR 에서는 검색 결과 추가 발견 사항 없었습니다).

---

> 본 PR 은 AI(Claude)가 issue #43/#44 지침에 따라 자동 생성했습니다. 사용자의 ownership 을 침해하려는 의도가 없으며, 변경 단위는 최소화했고, 코드 동작은 건드리지 않았습니다. close하시거나 재구성 요청하셔도 됩니다.