### PR TITLE
[Nightly 2026-05-07] @upload 데코레이터 미존재 mode 옵션 사용 예제 정정 (ko/en) 및 outdated syncFromWatcher 명칭을 실제 메서드명 hmrAndSync로 동기화

### DIFF
--- a/examples/miomock/api/src/sonamu-test/syncer.test.ts
+++ b/examples/miomock/api/src/sonamu-test/syncer.test.ts
@@ -176,10 +176,10 @@ describe("Syncer", () => {
   });
 
   // ============================================
-  // 2. syncFromWatcher - Watcher 이벤트 처리
+  // 2. hmrAndSync - Watcher 이벤트 처리
   // sonamu 패키지 내부에서 import하므로 vi.mock 적용 안됨 skip 처리
   // ============================================
-  describe("syncFromWatcher", () => {
+  describe("hmrAndSync", () => {
     // 목적: model 파일 변경 시 doSyncActions가 호출되어 http 파일이 생성되고, autoload가 실행되어 모듈이 재로드되는지 확인
     test("change 이벤트 (model 파일) → 파일 생성 및 모듈 재로드", async () => {
       const modelPath = join(

--- a/modules/docs/en/advanced-features/ai-agents/using-ai-sdk.mdx
+++ b/modules/docs/en/advanced-features/ai-agents/using-ai-sdk.mdx
@@ -307,7 +307,7 @@ console.log(result.segments);
 ### File Upload + Speech Recognition
 
 ```typescript
-import { BaseModelClass, upload, api } from "sonamu";
+import { BaseModelClass, upload } from "sonamu";
 import { rtzr } from "sonamu/ai/providers/rtzr";
 
 class TranscriptionModelClass extends BaseModelClass {
@@ -395,7 +395,7 @@ console.log(result.text);
 ### Image Upload + Analysis
 
 ```typescript
-import { BaseModelClass, upload, api } from "sonamu";
+import { BaseModelClass, upload } from "sonamu";
 import { openai } from "@ai-sdk/openai";
 import { generateText } from "ai";
 

--- a/modules/docs/en/advanced-features/ai-agents/using-ai-sdk.mdx
+++ b/modules/docs/en/advanced-features/ai-agents/using-ai-sdk.mdx
@@ -311,8 +311,7 @@ import { BaseModelClass, upload, api } from "sonamu";
 import { rtzr } from "sonamu/ai/providers/rtzr";
 
 class TranscriptionModelClass extends BaseModelClass {
-  @upload({ mode: "single" })
-  @api({ httpMethod: "POST" })
+  @upload()
   async transcribeAudio() {
     const { bufferedFiles } = Sonamu.getContext();
     const file = bufferedFiles?.[0];
@@ -401,8 +400,7 @@ import { openai } from "@ai-sdk/openai";
 import { generateText } from "ai";
 
 class ImageAnalysisModelClass extends BaseModelClass {
-  @upload({ mode: "single" })
-  @api({ httpMethod: "POST" })
+  @upload()
   async analyzeImage() {
     const { bufferedFiles } = Sonamu.getContext();
     const file = bufferedFiles?.[0];

--- a/modules/docs/en/api-reference/context/sonamu-context.mdx
+++ b/modules/docs/en/api-reference/context/sonamu-context.mdx
@@ -148,7 +148,7 @@ class PostModelClass extends BaseModelClass {
 bufferedFiles?: BufferedFile[]
 ```
 
-List of files uploaded in buffer mode. This property exists when the `@upload` decorator is applied with the default mode (buffer) or `mode: "buffer"` configuration.
+List of files uploaded in buffer mode. This property exists when the `@upload` decorator is applied with the default (`consume: "buffer"`) or `@upload({ consume: "buffer" })` configuration.
 
 Each file is loaded in memory, allowing flexible operations like MD5 calculation or image processing.
 

--- a/modules/docs/en/core-concepts/model/api-decorator.mdx
+++ b/modules/docs/en/core-concepts/model/api-decorator.mdx
@@ -130,7 +130,7 @@ async save(params: UserSaveParams[]): Promise<number[]> {
   httpMethod: "POST",
   clients: ["axios-multipart"],
 })
-@upload({ mode: "single" })
+@upload()
 async uploadAvatar(): Promise<{ url: string }> {
   // ...
 }

--- a/modules/docs/ko/advanced-features/ai-agents/using-ai-sdk.mdx
+++ b/modules/docs/ko/advanced-features/ai-agents/using-ai-sdk.mdx
@@ -307,7 +307,7 @@ console.log(result.segments);
 ### 파일 업로드 + 음성 인식
 
 ```typescript
-import { BaseModelClass, upload, api } from "sonamu";
+import { BaseModelClass, upload } from "sonamu";
 import { rtzr } from "sonamu/ai/providers/rtzr";
 
 class TranscriptionModelClass extends BaseModelClass {
@@ -395,7 +395,7 @@ console.log(result.text);
 ### 이미지 업로드 + 분석
 
 ```typescript
-import { BaseModelClass, upload, api } from "sonamu";
+import { BaseModelClass, upload } from "sonamu";
 import { openai } from "@ai-sdk/openai";
 import { generateText } from "ai";
 

--- a/modules/docs/ko/api-reference/context/sonamu-context.mdx
+++ b/modules/docs/ko/api-reference/context/sonamu-context.mdx
@@ -148,7 +148,7 @@ class PostModelClass extends BaseModelClass {
 bufferedFiles?: BufferedFile[]
 ```
 
-Buffer 모드로 업로드된 파일 목록입니다. `@upload` 데코레이터가 적용된 메서드에서, 기본 모드(buffer) 또는 `mode: "buffer"`로 설정된 경우에 존재합니다.
+Buffer 모드로 업로드된 파일 목록입니다. `@upload` 데코레이터가 적용된 메서드에서, 기본값(`consume: "buffer"`) 또는 `@upload({ consume: "buffer" })`로 설정된 경우에 존재합니다.
 
 각 파일은 메모리에 로드된 상태로, MD5 계산이나 이미지 처리 등 유연한 작업이 가능합니다.
 

--- a/modules/sonamu/src/skills/sonamu/testing-devrunner.md
+++ b/modules/sonamu/src/skills/sonamu/testing-devrunner.md
@@ -116,7 +116,7 @@ For trace data details: see `naite.md`
 
 ### HMR Integration — Automatic Vitest Module Graph Invalidation on Source Changes
 
-When a source file is modified, `syncFromWatcher` in the syncer triggers both of the following simultaneously:
+When a source file is modified, `hmrAndSync` in the syncer triggers both of the following simultaneously:
 
 1. Server HMR cache invalidation (`hot.invalidateFile`)
 2. Vitest module graph invalidation (`Sonamu.devVitestManager.invalidateFiles([filePath])`)

--- a/modules/sonamu/src/syncer/syncer.ts
+++ b/modules/sonamu/src/syncer/syncer.ts
@@ -47,13 +47,13 @@ export class Syncer {
 
   /**
    * 체크섬이 변경된 부분에 대해 싱크를 진행합니다.
-   * dev 서버가 처음 떴을 때, sonamu sync 할 때 실행됩니다. 이후에는 syncFromWatcher 경로를 타요.
+   * dev 서버가 처음 떴을 때, sonamu sync 할 때 실행됩니다. 이후에는 hmrAndSync 경로를 타요.
    * @returns
    */
   async sync(): Promise<void> {
     // 초기 부트스트랩! 얘네들은 idempotent하고 가볍기 때문에 무지성 실행해도 됩니다.
     // 얘네들은 sonamu.lock에 들어가지도 않고 따라서 HMR 경로를 타지도 않는 친구들입니다.
-    // 그래서 아무 때나 그냥 돌려주면 되는데, syncFromWatcher에서 매번 하는 것은 낭비이니 여기서 한 번만 합니다.
+    // 그래서 아무 때나 그냥 돌려주면 되는데, hmrAndSync에서 매번 하는 것은 낭비이니 여기서 한 번만 합니다.
     await SyncerActions.actionCopySharedToTargetsIfNotExists();
     await SyncerActions.actionGenerateSsrEntryServerIfNotExists();
 

--- a/modules/sonamu/src/testing/dev-vitest-manager.ts
+++ b/modules/sonamu/src/testing/dev-vitest-manager.ts
@@ -159,7 +159,7 @@ export class DevVitestManager {
 
   /**
    * 변경된 파일을 Vitest 모듈 그래프에서 무효화합니다.
-   * syncFromWatcher에서 호출되어 다음 테스트 실행 시 최신 코드를 사용하도록 합니다.
+   * hmrAndSync에서 호출되어 다음 테스트 실행 시 최신 코드를 사용하도록 합니다.
    */
   invalidateFiles(filePaths: string[]): void {
     if (!this.vitest || this.closed) {


### PR DESCRIPTION
## 무엇 / 누가 / 왜

이 PR은 cartanova-dev 계정에서 동작하는 AI(Claude)가 issue [#43](https://github.com/cartanova-ai/sonamu/issues/43) Nightly PR Directions 및 issue [#44](https://github.com/cartanova-ai/sonamu/issues/44)의 작업 지침에 따라 자동 생성한 것입니다. 두 issue 모두 "코드와 문서/주석이 어긋나는 경우 정정"을 명시적으로 작업 대상으로 지목하고 있습니다.

이번 사이클에서는 명백히 검증 가능하고 영향 범위가 작은 두 가지 정합성 정정 항목을 묶어 한 PR로 처리했습니다.

## 무엇을 어떻게 바꿨고, 왜인가?

### 1. `@upload` 데코레이터 문서의 미존재 `mode` 옵션 사용 예제 정정

**현상**: 영문 문서 일부에 `@upload({ mode: \"single\" })` 또는 `mode: \"buffer\"`와 같은 표기가 있는데, 실제 `UploadDecoratorOptions`에는 `mode` 필드 자체가 존재하지 않습니다(`modules/sonamu/src/api/decorators.ts:91-95`). 옵션은 `consume: \"buffer\" | \"stream\"`이며, `\"buffer\"`가 기본값입니다.

**근거**:
- `UploadDecoratorOptions = { guards?, description?, limits? } & (BufferUploadOptions | StreamUploadOptions)`
- `BufferUploadOptions = { consume: \"buffer\" }`, `StreamUploadOptions = { consume: \"stream\"; destination; keyGenerator? }`
- `upload(options: UploadDecoratorOptions = { consume: \"buffer\" })`
- 한국어 문서 대부분(예: `ko/core-concepts/model/api-decorator.mdx`, `ko/advanced-features/ai-agents/using-ai-sdk.mdx`)은 이미 `@upload()` 단독 사용으로 올바르게 작성되어 있어, 영문 문서를 한국어 정합본에 맞춥니다.

**수정 파일**:
- `en/core-concepts/model/api-decorator.mdx`: `@upload({ mode: \"single\" })` → `@upload()`
- `en/advanced-features/ai-agents/using-ai-sdk.mdx` (2곳): 한국어본과 동일한 `@upload()` 단독 사용으로 정렬
- `en/api-reference/context/sonamu-context.mdx`: `mode: \"buffer\"` 표현을 `consume: \"buffer\"`로 정정
- `ko/api-reference/context/sonamu-context.mdx`: 한글본도 동일 표현 오류가 있어 함께 정정

### 2. outdated 메서드명 `syncFromWatcher`를 실제 이름 `hmrAndSync`로 동기화

**현상**: watcher 사이클이 syncer의 `hmrAndSync` 메서드로 응집되면서 `syncFromWatcher`라는 이전 이름은 코드에서 사라졌으나, 일부 주석/skill 문서/테스트 라벨에 옛 이름이 그대로 남아 있습니다. `.mdx` 사용자 문서는 이미 `hmrAndSync`로 정리되어 있어 본 PR에서는 변경하지 않습니다.

**수정 파일**:
- `modules/sonamu/src/syncer/syncer.ts`: `sync()` JSDoc과 본문 주석 2곳
- `modules/sonamu/src/testing/dev-vitest-manager.ts`: `invalidateFiles()` JSDoc 1곳
- `modules/sonamu/src/skills/sonamu/testing-devrunner.md`: HMR 통합 설명 1곳
- `examples/miomock/api/src/sonamu-test/syncer.test.ts`: describe 블록 라벨/주석. 실제 본문은 이미 `syncer.hmrAndSync(...)`를 호출하고 있어 라벨만 정렬

`docs/plans/`, `docs/ssr/` 등 historical 스냅샷 문서는 변경 시점의 정확성이 가치이므로 의도적으로 그대로 둡니다.

## 이렇게 하지 않으면

- 사용자가 영문 문서의 `@upload({ mode: \"single\" })`를 그대로 따라 코드 작성 시 실제로는 무시되는 옵션 객체를 넘기게 되며, 다른 옵션(예: `consume: \"stream\"` + `destination`)을 함께 의도하더라도 타입 시스템이 혼동을 잡아주지 못할 수 있습니다.
- 코드 리딩 시 주석에 등장하는 `syncFromWatcher`라는 식별자를 잡아 grep해도 실재 메서드를 찾을 수 없어 onboarding 마찰을 일으킵니다.

## 영향 범위

- 런타임 동작 변경 없음 — 모든 변경이 문서, 코드 주석, describe 라벨에 한정됩니다.
- 기존 외부 참조 호환성에 영향 없음 — `@upload`의 실제 옵션 시그니처는 그대로이며 문서만 정정합니다.

## 확인 방법

- `pnpm --filter sonamu test:type` — 39 tests 통과, 타입 에러 0
- `pnpm --filter sonamu build` — 성공
- `pnpm check` (oxlint + oxfmt) — 0 errors (기존 6 warnings 동일)
- `git grep -n syncFromWatcher modules/ examples/` — `dist/` 빌드 산출물 외 잔존 없음
- `git grep -n 'mode: \"single\"' modules/docs` — 매치 없음
- 사용자 검증 팁: `examples/miomock/api/src/sonamu-test/syncer.test.ts`의 `describe(\"hmrAndSync\", ...)` 본문이 그대로 `syncer.hmrAndSync(...)`를 호출하므로, 통합 테스트 실행 시 동일하게 통과합니다.

## 추후 사람의 확인이 필요한 부분

- `using-ai-sdk.mdx` 영문본의 두 예제에서 `@upload({ mode: \"single\" }) + @api({ httpMethod: \"POST\" })` 두 줄을 한국어본 정합본에 맞춰 `@upload()` 단독으로 정리했습니다. `@upload` 자체가 독립 데코레이터로 동작하며 다른 영문 문서들도 단독 사용 패턴이 표준이라 본 정정이 안전하다고 판단했지만, 의도적으로 영문본에서만 `@api`와 결합 사례를 보이려 했던 것이라면 알려주시면 영어 문서만 다시 조정하겠습니다.
- `pnpm --filter miomock-api test`는 DB 컨테이너가 필요해 본 nightly 환경에서 실행하지 않았습니다. describe 라벨 변경은 본문 호출(`syncer.hmrAndSync(...)`) 자체를 변경하지 않으므로 회귀 위험은 없다고 판단합니다.