### PR TITLE
[Nightly 2026-05-08] template.ts의 deprecated Template.autoload/find 자취 정정 (에러 메시지/주석/가짜 @param)

### DIFF
--- a/modules/sonamu/src/template/template.ts
+++ b/modules/sonamu/src/template/template.ts
@@ -27,7 +27,7 @@ export abstract class Template {
 
   /**
    * 템플릿 구현체가 있는 디렉토리의 모든 템플릿을 로드합니다.
-   * 템플릿이 필요(Template.find)해지기 전에 최소 한 번 호출해주셔야 합니다.
+   * 템플릿이 필요(TemplateManager.get)해지기 전에 최소 한 번 호출해주셔야 합니다.
    * @deprecated TemplateManager.autoload() 사용 권장
    */
   public static async autoload() {
@@ -71,7 +71,7 @@ export abstract class Template {
     const instance = Template.templates.get(key);
     if (!instance) {
       throw new Error(
-        `Template ${key} not found. It might be because you tried to find a template before loading all templates. Did you call Template.autoload()?`,
+        `Template ${key} not found. It might be because you tried to find a template before loading all templates. Did you call TemplateManager.autoload()?`,
       );
     }
     return instance;
@@ -108,7 +108,6 @@ export abstract class Template {
    * 이 템플릿이 필요로 하는 i18n dict 키를 반환합니다.
    * 스캐폴딩 시 여러 템플릿의 키를 모아서 한 번에 처리합니다.
    *
-   * @param options - 템플릿 옵션
    * @returns 필요한 dict 키 배열 또는 null (i18n 불필요 시)
    */
   public getRequiredDictKeys(): string[] | null {


### PR DESCRIPTION
## 이 PR은 무엇이며 왜 만들어졌나요

이 PR은 cartanova-dev 계정에서 동작하는 AI(Claude)가 issue [#43](https://github.com/cartanova-ai/sonamu/issues/43) Nightly PR Directions 및 issue [#44](https://github.com/cartanova-ai/sonamu/issues/44)의 작업 지침에 따라 자동 생성한 nightly PR입니다. 두 issue 모두 "코드와 문서/주석이 어긋나는 경우 정정"을 명시적으로 작업 대상으로 지목하고 있습니다.

이번 사이클에서는 영향 범위가 매우 좁고(주석/에러 메시지 문구), 검증이 명확한 **단일 파일** 정합성 정정으로 한정했습니다.

## 어떤 issue를 참조했고, 왜 이 작업을 골랐나요

- 참조 issue: #43(절차/형식), #44(작업 범위 — "문서와 주석이 코드와 어긋나는 경우", "잠재적으로 위험한 포인트 식별")
- 동기:
  - `Template.autoload()`/`Template.find()`는 모두 `@deprecated TemplateManager.{autoload,get}() 사용 권장`이 표기된 메서드입니다(`modules/sonamu/src/template/template.ts:31, :66`).
  - 그런데 `Template.find()`이 던지는 not-found 에러 메시지(`:74`)가 사용자에게 **deprecated 메서드인 `Template.autoload()`를 호출하라고 잘못 안내**합니다. 같은 에러를 만나는 사용자가 안내대로 `Template.autoload()`를 호출하면 동작은 하지만 권장되지 않은 경로(deprecated)를 따라가게 됩니다.
  - 같은 클래스의 `autoload()` JSDoc(`:30`)도 본문에서 `Template.find` 라는 deprecated 식별자를 가리키고 있어 같은 false positive 안내가 두 곳에 잔존합니다.
  - `getRequiredDictKeys()`(`:114`)의 JSDoc(`:111`)에는 `@param options - 템플릿 옵션`이 적혀 있으나, **시그니처에는 매개변수가 없습니다.** 모든 오버라이드 구현(`view_form/view_search_input/model/view_list.template.ts`)도 매개변수 없는 시그니처입니다. 명백한 JSDoc 형식 오류입니다.
- 이 영역은 issue #44가 제외 지정한 영역(`puri.ts` SQL injection, `PostgresPubSub.destroy()` null 체크, `practices` 폴더)과 무관합니다.
- 이전 nightly PR(#150~#170) 흐름과도 중복되지 않습니다(#170은 `syncFromWatcher → hmrAndSync`/`@upload mode` 정정, #168은 `queries.generated.ts` 분배 invariant 등).

## 어떤 접근을 골랐고 왜 그랬나요

같은 파일에서 같은 주제(deprecated된 `Template.*` 자취 정리 + JSDoc 정확성)이므로 **단일 커밋으로 묶었습니다.**

1. `template.ts:74` 에러 메시지에서 `Did you call Template.autoload()?` → `Did you call TemplateManager.autoload()?`
   - 권장 인터페이스인 `TemplateManager.autoload()`는 실제로 `modules/sonamu/src/api/sonamu.ts:299`에서 부트스트랩 시 호출되고, `TemplateManager` 자체는 `syncer/syncer.ts`, `syncer/code-generator.ts`, `ui/api.ts` 등에서 일관되게 사용됩니다. `Template.*` 정적 메서드는 새 코드베이스에서 호출처가 없습니다.
2. `template.ts:30` JSDoc 본문에서 `필요(Template.find)해지기 전에` → `필요(TemplateManager.get)해지기 전에`
   - 같은 deprecated 식별자를 가리키던 부분을 권장 인터페이스로 정렬.
3. `template.ts:111` JSDoc에서 가짜 `@param options - 템플릿 옵션` 라인 제거
   - 실제 시그니처(`getRequiredDictKeys(): string[] | null`)와 정합.

`@deprecated` 표기 자체와 `Template.autoload()`/`Template.find()` 정적 메서드의 존재 자체는 **본 PR 범위 밖**입니다. `Template._getTemplatesMap()` 등을 통한 internal 하위호환 경로가 `TemplateManager.autoload()`/`register()` 안에서 사용되고 있어, 단순 제거는 별도 신중한 정리가 필요합니다.

또한 `docs/template-manager.md`는 마이그레이션 가이드(Before/After 비교) 형태이므로 의도적으로 그대로 둡니다. `modules/docs/{ko,en}/`의 사용자 노출 문서에는 `Template.autoload`/`Template.find`/`getRequiredDictKeys` 언급이 없음을 grep으로 확인했습니다(없으니 동기화할 ko/en 페어가 없습니다).

## 이렇게 하지 않으면 어떤 점이 안 좋은가요

- 사용자가 not-found 에러를 만났을 때 안내대로 `Template.autoload()`를 호출 → deprecated 메서드를 호출하게 되어, 코드 리뷰 단계에서 다시 정정해야 하는 작은 마찰이 생깁니다. IDE의 strikethrough 표시와도 충돌합니다.
- `getRequiredDictKeys`의 가짜 `@param`은 IDE 툴팁/자동완성에서 호출자에게 존재하지 않는 매개변수를 안내합니다. 오버라이드를 작성하는 사람이 시그니처를 잘못 따라갈 수 있습니다.

## 영향 범위

- 단일 파일: `modules/sonamu/src/template/template.ts`
- 변경 라인: 2 insertions, 3 deletions (총 5라인)
- **런타임 동작 영향 없음** — 에러 메시지 문구와 JSDoc 주석만 변경.
- 외부 인터페이스(`Template`/`TemplateManager`의 시그니처)는 그대로.

## 영향을 즉시 확인하는 방법

1. `git diff master..HEAD -- modules/sonamu/src/template/template.ts` 으로 5줄 diff 직접 확인.
2. `Template.find("non-existent-key" as any)` 호출 시 던져지는 에러 메시지가 `TemplateManager.autoload()` 안내로 바뀌었는지 확인.
3. IDE에서 `getRequiredDictKeys()` 호버 시 가짜 `options` 매개변수 표시가 사라졌는지 확인.

## 검증

`modules/sonamu/CLAUDE.md`의 권고 검증 흐름을 따랐습니다.

- `pnpm check` (oxlint --type-aware + oxfmt --check) → 0 errors, 6 warnings(기존 코드, 본 PR 무관).
- `pnpm --filter sonamu build` → 성공.
- `pnpm --filter sonamu test:type` → 3 files / 39 tests, no type errors.
- `pnpm --filter miomock-api test` → 1414 passed / 10 skipped / 6 todo, no type errors.
- pre-commit (lefthook): oxfmt + oxlint + sonamu-typecheck 모두 통과(staged file: template.ts).

## 추후 사람의 확인이 필요한 부분

- `Template.autoload()`/`Template.find()` 정적 메서드 자체의 제거 여부 — `Template._getTemplatesMap()`/`_clearTemplates()` 가 `TemplateManager` 내부에서 하위호환 동기화 용도로 사용되고 있어, 본 PR 범위에서는 다루지 않았습니다. 별도 nightly에서 `TemplateManager` 일원화 작업으로 다룰 수 있는 후보입니다.
- `getRequiredDictKeys()`의 베이스 클래스 시그니처를 매개변수 없이 유지할지, 아니면 일부 오버라이드(예: 향후 `TemplateOptions[TemplateKey]`를 받아 동적으로 키 산출)를 위해 매개변수를 받도록 확장할지는 설계 결정 사항입니다. 현재는 모든 오버라이드가 매개변수 없는 정적 키 배열을 반환하므로 본 PR에서는 시그니처에 맞춰 JSDoc만 정렬했습니다.

---

> 본 PR은 AI(Claude)가 issue #43/#44 지침에 따라 자동 생성했습니다. 사용자의 ownership을 침해하려는 의도가 없으며, 변경 단위는 최소화했고, 코드 동작은 건드리지 않았습니다. close하시거나 재구성 요청하셔도 됩니다.