### PR TITLE
[Nightly 2026-05-11] sonamu-context.mdx의 createSSE 사용 예제에서 @api()+@stream 동시 사용 제거 및 ZodObject 전달로 정정 (ko/en 2파일)

### DIFF
--- a/modules/docs/en/api-reference/context/sonamu-context.mdx
+++ b/modules/docs/en/api-reference/context/sonamu-context.mdx
@@ -70,20 +70,18 @@ Function for creating Server-Sent Events (SSE) streams. Enables creating type-sa
 ```typescript
 import { z } from "zod";
 
+const ProcessEventsSchema = z.object({
+  progress: z.object({ percent: z.number() }),
+  complete: z.object({ result: z.string() }),
+});
+
 class MyModelClass extends BaseModelClass {
-  @api()
   @stream({
     type: "sse",
-    events: z.object({
-      progress: z.object({ percent: z.number() }),
-      complete: z.object({ result: z.string() }),
-    }),
+    events: ProcessEventsSchema,
   })
   async processData(ctx: Context) {
-    const sse = ctx.createSSE({
-      progress: z.object({ percent: z.number() }),
-      complete: z.object({ result: z.string() }),
-    });
+    const sse = ctx.createSSE(ProcessEventsSchema);
 
     // Send progress
     await sse.publish("progress", { percent: 50 });

--- a/modules/docs/ko/api-reference/context/sonamu-context.mdx
+++ b/modules/docs/ko/api-reference/context/sonamu-context.mdx
@@ -70,20 +70,18 @@ Server-Sent Events(SSE) 스트림을 생성하는 함수입니다. Zod 스키마
 ```typescript
 import { z } from "zod";
 
+const ProcessEventsSchema = z.object({
+  progress: z.object({ percent: z.number() }),
+  complete: z.object({ result: z.string() }),
+});
+
 class MyModelClass extends BaseModelClass {
-  @api()
   @stream({
     type: "sse",
-    events: z.object({
-      progress: z.object({ percent: z.number() }),
-      complete: z.object({ result: z.string() }),
-    }),
+    events: ProcessEventsSchema,
   })
   async processData(ctx: Context) {
-    const sse = ctx.createSSE({
-      progress: z.object({ percent: z.number() }),
-      complete: z.object({ result: z.string() }),
-    });
+    const sse = ctx.createSSE(ProcessEventsSchema);
 
     // 진행률 전송
     await sse.publish("progress", { percent: 50 });


### PR DESCRIPTION
## 이 PR은 무엇인가요?

이 PR은 `Nightly PR Directions`(#43) 가이드라인에 따라 AI(slack-vibecoder 봇 → Claude Code)가 코드베이스 점검 일과의 일부로 자동 생성한 변경입니다. 작성자는 `cartanova-dev`(CartaNova) 계정이며, 작업 범위는 `nightly` 라벨이 붙은 이슈 #43, #44 의 description을 따랐습니다.

목표는 "앱이 1%만 나아지게 하기"입니다. 코드베이스에 영향이 작고 효과가 확실한 단일 단위 작업을 골랐습니다.

## 왜 이 작업을 선정했나요?

이슈 #44의 작업 범위 중 **"문서와 주석이 코드와 어긋나는 경우 → 설명을 업데이트"** 항목에 해당하는, 사용자가 문서를 그대로 따라하면 즉시 빌드/런타임 에러를 만나게 되는 명백한 불일치를 찾았습니다.

대상 파일: `modules/docs/ko|en/api-reference/context/sonamu-context.mdx`의 `createSSE` 섹션 사용 예제 (라인 73~96).

### 어떤 불일치인가요?

기존 예제는 다음과 같았습니다.

```typescript
class MyModelClass extends BaseModelClass {
  @api()
  @stream({
    type: "sse",
    events: z.object({
      progress: z.object({ percent: z.number() }),
      complete: z.object({ result: z.string() }),
    }),
  })
  async processData(ctx: Context) {
    const sse = ctx.createSSE({
      progress: z.object({ percent: z.number() }),
      complete: z.object({ result: z.string() }),
    });
    ...
  }
}
```

두 가지 명백한 문제가 있습니다.

**1. `@api()` + `@stream` 동시 사용은 빌드/런타임 에러**

`modules/sonamu/src/api/decorators.ts`의 `checkSingleDecorator`(라인 130~139)는 한 메서드에 `@api`/`@stream`/`@websocket`/`@upload` 중 **단 하나**만 허용하며, 둘 이상이 붙으면 명시적으로 에러를 던집니다.

- `modules/docs/ko|en/api-reference/decorators/stream.mdx` 라인 342~347은 동일 패턴을 **"❌ 에러 발생"** 예제로 보여줍니다.
- `modules/docs/ko|en/api-reference/decorators/api.mdx` 라인 403~408도 동일하게 **"❌ 에러"** 예제로 명시합니다.
- 그런데 `sonamu-context.mdx`만 같은 패턴을 정상 사용 예제로 보여주고 있어 다른 문서들과 모순됩니다.

**2. `ctx.createSSE(...)`에 ZodObject가 아닌 plain object 전달**

`Context.createSSE`의 시그니처는 `<T extends ZodObject>(events: T) => ...`(`modules/sonamu/src/api/context.ts` 라인 36)인데, 기존 예제는 `z.object(...)`로 감싸지 않은 plain object를 전달하고 있어 타입 에러가 발생합니다. `stream.mdx`의 기본 사용법은 `NotificationEventsSchema` 변수를 외부에서 `z.object({...})`로 정의한 뒤 사용하므로, 그 패턴과 어긋납니다.

## 어떤 접근 방식을 채택했고, 왜 그렇게 했나요?

스키마를 `ProcessEventsSchema` 변수로 한 번 정의해 `@stream`의 `events`와 `ctx.createSSE` 인자에 동일하게 전달하도록 정정했습니다.

- `@api()`를 제거하면 두 문제 중 첫 번째(중복 데코레이터)가 해결됩니다.
- 외부 변수 추출로 두 번째 문제(plain object → ZodObject)가 해결되며, 동시에 `@stream`이 검사하는 이벤트 타입과 `createSSE`가 생성하는 이벤트 타입이 **타입 레벨에서 한 곳에 묶이게** 되어, 두 곳의 schema가 어긋날 위험까지 함께 차단됩니다.
- 이 형태는 `stream.mdx`의 기본 사용법(`NotificationEventsSchema` 패턴)과 **이미 일관**되므로, 문서 전체 톤·스타일을 흩뜨리지 않습니다.

### 이렇게 하지 않으면 무엇이 안 좋은가요?

문서를 그대로 복사한 사용자가 즉시 두 종류의 에러(중복 데코레이터 런타임 에러, ZodObject 타입 에러)를 만나게 됩니다. `createSSE` 섹션은 SSE 초심자가 가장 먼저 보게 되는 위치라 진입 장벽이 큽니다.

## 이 변경이 영향을 미치는 기능

- 문서(`sonamu-docs`) 출력의 `Context > createSSE` 섹션 코드 예제만 바뀝니다.
- 소스코드(`modules/sonamu` 등) 동작에는 어떤 영향도 없습니다.

## 영향을 바로 확인하는 방법

1. `pnpm --filter sonamu-docs dev`로 로컬 docs 서버를 띄운 뒤 `/api-reference/context/sonamu-context` 페이지의 `createSSE` 섹션 예제 블록을 확인.
2. 표시된 예제 코드를 그대로 모델 클래스에 붙여넣어, `pnpm --filter sonamu test:type` 및 부트 시점에 `checkSingleDecorator` 에러가 발생하지 않는지 확인.

## 검증

- 변경 파일: `modules/docs/{ko,en}/api-reference/context/sonamu-context.mdx` (코드 블록 텍스트만 변경).
- 루트 `pnpm check`(oxlint + oxfmt) 통과: 0 errors. (.mdx 코드블록은 lint 대상 외이며, 변경 자체가 텍스트 수정이라 다른 패키지에 영향 없음.)
- 다른 곳에 동일 결함이 더 있는지도 같은 grep 패턴으로 살펴봤습니다(`@api()` + `@stream`/`@websocket`/`@upload` 정상 예제). 결과는 아래의 "추후 확인이 필요한 부분"에 정리합니다.

## 추후 사람의 확인이 필요한 부분

스코프를 좁히기 위해 이번 PR에는 포함하지 **않은** 후속 후보가 있습니다. 동일한 종류의 결함일 수 있으나, 정정안의 정답이 단번에 자명하지 않아 별도 PR로 분리하는 편이 안전해 보입니다.

- `modules/docs/{ko,en}/advanced-features/compress/per-api-control.mdx` 라인 549~554의 "✅ 스트리밍" 예제는 `@stream({ type: 'sse', events: ... }) @api({ compress: false })`를 정상 예제로 보여줍니다. 같은 `checkSingleDecorator` 규칙에 따라 런타임 에러를 일으킵니다. 단, `StreamDecoratorOptions`에 `compress`가 없어 SSE에 압축 비활성화를 어떻게 표현해야 하는지(아예 표현 불필요한지) 코드 차원의 정책 확인이 먼저 필요합니다.
- 위와 같은 맥락에서, `compress/performance-optimization.mdx`의 "❌ SSE 압축" 예제 다음에 제시되는 대안 패턴도 정책 확인 후 일괄 정리하는 편이 좋아 보입니다.

위 두 항목은 사용자가 동작/문서 정책을 한 번 확정해주신 뒤 별도 nightly PR로 다루는 것을 제안드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)