### PR TITLE
SON-465 WebSocket Telemetry 모듈 도입

### DIFF
--- a/modules/create-sonamu/template/src/packages/web/src/services/sonamu.shared.ts
+++ b/modules/create-sonamu/template/src/packages/web/src/services/sonamu.shared.ts
@@ -329,6 +329,7 @@ export type WebSocketChannelOptions = {
   retry?: number;
   retryInterval?: number;
   protocols?: string | string[];
+  traceProvider?: () => string | undefined;
 };
 export type WebSocketChannelState<TSend extends Record<string, any>> = {
   isConnected: boolean;
@@ -354,7 +355,7 @@ export function useWebSocketChannel<
   handlers: EventHandlers<TReceive>,
   options: WebSocketChannelOptions = {},
 ): WebSocketChannelState<TSend> {
-  const { enabled = true, retry = 3, retryInterval = 3000, protocols } = options;
+  const { enabled = true, retry = 3, retryInterval = 3000, protocols, traceProvider } = options;
 
   const [state, setState] = useState({
     isConnected: false,
@@ -395,6 +396,11 @@ export function useWebSocketChannel<
       return;
     }
 
+    const traceparent = traceProvider?.();
+    if (traceparent) {
+      socket.send(JSON.stringify({ event, data, meta: { traceparent } }));
+      return;
+    }
     socket.send(JSON.stringify({ event, data }));
   };
 

--- a/modules/sonamu/src/api/__tests__/sonamu.websocket.test.ts
+++ b/modules/sonamu/src/api/__tests__/sonamu.websocket.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it } from "vitest";
 
 import { type AnyWebSocketConnection } from "../../stream/ws";
+import { type WebSocketTelemetryConnectionContext } from "../../stream/ws-telemetry";
 import { type WebSocketContext } from "../context";
 import { Sonamu } from "../sonamu";
 
 describe("Sonamu websocket context scoping", () => {
   it("restores websocket context inside deferred message handlers", async () => {
-    const messageHandlers = new Map<string, (data: unknown) => void | Promise<void>>();
+    const messageHandlers = new Map<
+      string,
+      (
+        data: unknown,
+        telemetryContext?: WebSocketTelemetryConnectionContext,
+      ) => void | Promise<void>
+    >();
 
     const rawWs = {
       id: "ws-1",
@@ -17,7 +24,7 @@ describe("Sonamu websocket context scoping", () => {
       close() {},
       onClose() {},
       onMessage(event, handler) {
-        messageHandlers.set(String(event), handler as (data: unknown) => void | Promise<void>);
+        messageHandlers.set(String(event), handler);
       },
       publish() {},
       waitForClose() {
@@ -30,14 +37,11 @@ describe("Sonamu websocket context scoping", () => {
     } satisfies AnyWebSocketConnection;
 
     let context: WebSocketContext | null = null;
-    const scopedWs = (
-      Sonamu as unknown as {
-        createScopedWebSocketConnection(
-          ws: AnyWebSocketConnection,
-          getContext: () => WebSocketContext | null,
-        ): AnyWebSocketConnection;
-      }
-    ).createScopedWebSocketConnection(rawWs, () => context);
+    const createScopedWebSocketConnection: (
+      ws: AnyWebSocketConnection,
+      getContext: () => WebSocketContext | null,
+    ) => AnyWebSocketConnection = Reflect.get(Sonamu, "createScopedWebSocketConnection");
+    const scopedWs = createScopedWebSocketConnection.call(Sonamu, rawWs, () => context);
 
     context = {
       transport: "ws",
@@ -60,5 +64,75 @@ describe("Sonamu websocket context scoping", () => {
     });
 
     expect(seenTransport).toBe("ws");
+  });
+
+  it("passes message trace context to scoped websocket message handlers", async () => {
+    const messageHandlers = new Map<
+      string,
+      (
+        data: unknown,
+        telemetryContext?: WebSocketTelemetryConnectionContext,
+      ) => void | Promise<void>
+    >();
+
+    const rawWs = {
+      id: "ws-1",
+      namespace: "chat",
+      transport: "ws" as const,
+      closed: false,
+      publishUntyped() {},
+      close() {},
+      onClose() {},
+      onMessage(event, handler) {
+        messageHandlers.set(String(event), handler);
+      },
+      publish() {},
+      waitForClose() {
+        return Promise.resolve();
+      },
+      join() {},
+      leave() {},
+      setUserId() {},
+      clearUserId() {},
+    } satisfies AnyWebSocketConnection;
+
+    let context: WebSocketContext | null = null;
+    const createScopedWebSocketConnection: (
+      ws: AnyWebSocketConnection,
+      getContext: () => WebSocketContext | null,
+    ) => AnyWebSocketConnection = Reflect.get(Sonamu, "createScopedWebSocketConnection");
+    const scopedWs = createScopedWebSocketConnection.call(Sonamu, rawWs, () => context);
+
+    context = {
+      transport: "ws",
+      request: {} as WebSocketContext["request"],
+      headers: {},
+      ws: scopedWs,
+      naiteStore: new Map(),
+      locale: "ko",
+      user: null,
+      session: null,
+    };
+
+    const messageTraceContext: WebSocketTelemetryConnectionContext = {
+      traceId: "trace-1",
+      spanId: "span-1",
+      parentSpanId: "parent-1",
+      sampled: true,
+    };
+    let seenTraceContext: WebSocketTelemetryConnectionContext | undefined;
+
+    scopedWs.onMessage("joinRoom", async (_data, telemetryContext) => {
+      seenTraceContext = telemetryContext;
+    });
+
+    await messageHandlers.get("joinRoom")?.(
+      {
+        roomId: "room-1",
+      },
+      messageTraceContext,
+    );
+
+    expect(seenTraceContext).toEqual(messageTraceContext);
   });
 });

--- a/modules/sonamu/src/api/sonamu.ts
+++ b/modules/sonamu/src/api/sonamu.ts
@@ -1220,6 +1220,9 @@ class SonamuClass {
       get closed() {
         return ws.closed;
       },
+      get userId() {
+        return ws.userId;
+      },
       transport: "ws",
       publishUntyped(event, data) {
         ws.publishUntyped(event, data);
@@ -1242,6 +1245,7 @@ class SonamuClass {
               level: "debug",
               connectionId: ws.id,
               namespace: ws.namespace,
+              userId: ws.userId,
               detail: { event: eventName },
               ...traceContext,
             });
@@ -1254,6 +1258,7 @@ class SonamuClass {
                 level: "debug",
                 connectionId: ws.id,
                 namespace: ws.namespace,
+                userId: ws.userId,
                 detail: { event: eventName },
                 ...traceContext,
               });
@@ -1264,6 +1269,7 @@ class SonamuClass {
                 status: "unset",
                 connectionId: ws.id,
                 namespace: ws.namespace,
+                userId: ws.userId,
                 attributes: { event: eventName },
                 ...traceContext,
               });
@@ -1275,6 +1281,7 @@ class SonamuClass {
                 level: "error",
                 connectionId: ws.id,
                 namespace: ws.namespace,
+                userId: ws.userId,
                 detail: { event: eventName },
                 ...traceContext,
               });
@@ -1285,6 +1292,7 @@ class SonamuClass {
                 status: "error",
                 connectionId: ws.id,
                 namespace: ws.namespace,
+                userId: ws.userId,
                 attributes: { event: eventName },
                 errorType: error instanceof Error ? error.name : typeof error,
                 ...traceContext,

--- a/modules/sonamu/src/api/sonamu.ts
+++ b/modules/sonamu/src/api/sonamu.ts
@@ -31,6 +31,10 @@ import { type KeyGenerator } from "../storage/types";
 import { UploadedFile } from "../storage/uploaded-file";
 import { createMockSSEFactory } from "../stream/sse";
 import { WebSocketRuntime, type WebSocketConnection, type WebSocketEventMap } from "../stream/ws";
+import {
+  type TelemetryContextProvider,
+  type WebSocketTelemetryConnectionContext,
+} from "../stream/ws-telemetry";
 import { type Syncer } from "../syncer/syncer";
 import { type WorkflowManager } from "../tasks/workflow-manager";
 import { type DevVitestManager } from "../testing/dev-vitest-manager";
@@ -1055,6 +1059,21 @@ class SonamuClass {
   ): Promise<void> {
     const matchedApi = this.findMatchedApi(request);
     if (!matchedApi?.websocketOptions) {
+      const traceContext = this.websocketRuntime.telemetryController.createConnectionContext({
+        headers: request.headers,
+      });
+      this.websocketRuntime.telemetryController.emit({
+        name: "ws.connection.rejected",
+        level: "warn",
+        detail: {
+          reason: "routeNotFound",
+          path: request.url,
+        },
+        traceId: traceContext.traceId,
+        spanId: traceContext.spanId,
+        parentSpanId: traceContext.parentSpanId,
+        sampled: traceContext.sampled,
+      });
       socket.close(1008, "WebSocket route not found");
       return;
     }
@@ -1078,8 +1097,13 @@ class SonamuClass {
       const socket = connection.socket;
       let wsContext: WebSocketContext | null = null;
       let rawWs: ReturnType<WebSocketRuntime["registerConnection"]> | null = null;
+      let preRegisterPhase: "guard" | "query" | "register" | "handler" = "guard";
+      let traceContext: WebSocketTelemetryConnectionContext = {};
 
       try {
+        traceContext = this.websocketRuntime.telemetryController.createConnectionContext({
+          headers: request.headers,
+        });
         runGuards({
           guards: api.options.guards,
           config,
@@ -1087,7 +1111,9 @@ class SonamuClass {
           api,
         });
 
+        preRegisterPhase = "query";
         const reqBody = await this.parseWebSocketRequestParams(api, request);
+        preRegisterPhase = "register";
         rawWs = this.websocketRuntime.registerConnection(socket, {
           outEvents: api.websocketOptions!.outEvents,
           inEvents: api.websocketOptions!.inEvents,
@@ -1095,11 +1121,16 @@ class SonamuClass {
           heartbeat: api.websocketOptions!.heartbeat,
           maxPayload: api.websocketOptions!.maxPayload,
           active: false,
+          traceId: traceContext.traceId,
+          spanId: traceContext.spanId,
+          parentSpanId: traceContext.parentSpanId,
+          sampled: traceContext.sampled,
         });
 
         const scopedWs = this.createScopedWebSocketConnection(rawWs, () => wsContext);
         wsContext = await this.createWebSocketContext(config, request, scopedWs);
         this.websocketRuntime.activateConnection(rawWs.id);
+        preRegisterPhase = "handler";
 
         const { ApiParamType } = await import("../types/types");
         const args = api.parameters.map((param) => {
@@ -1115,6 +1146,22 @@ class SonamuClass {
         });
       } catch (error) {
         const closeDescriptor = resolveWebSocketCloseDescriptor(error);
+        if (!rawWs) {
+          this.websocketRuntime.telemetryController.emit({
+            name: "ws.connection.rejected",
+            level: closeDescriptor.logLevel === "warn" ? "warn" : "error",
+            detail: {
+              reason: preRegisterPhase,
+              code: closeDescriptor.code,
+              path: api.path,
+            },
+            traceId: traceContext.traceId,
+            spanId: traceContext.spanId,
+            parentSpanId: traceContext.parentSpanId,
+            sampled: traceContext.sampled,
+          });
+        }
+
         if (rawWs) {
           rawWs.close(closeDescriptor.code, closeDescriptor.reason);
         } else if (socket.readyState < 2) {
@@ -1153,6 +1200,7 @@ class SonamuClass {
     ws: WebSocketConnection<TOut, TIn>,
     getContext: () => WebSocketContext | null,
   ): WebSocketConnection<TOut, TIn> {
+    const telemetryController = this._websocketRuntime?.telemetryController;
     const runInContext = <T>(callback: () => T): T => {
       const context = getContext();
       if (!context) {
@@ -1183,7 +1231,68 @@ class SonamuClass {
         ws.onClose(() => runInContext(callback));
       },
       onMessage(event, handler) {
-        ws.onMessage(event, (data) => runInContext(() => handler(data)));
+        ws.onMessage(event, (data, messageTraceContext) =>
+          runInContext(async () => {
+            const eventName = String(event);
+            const traceContext = messageTraceContext ?? getWebSocketTelemetryContext(ws);
+            const startedAt = performance.now();
+
+            telemetryController?.emit({
+              name: "ws.handler.started",
+              level: "debug",
+              connectionId: ws.id,
+              namespace: ws.namespace,
+              detail: { event: eventName },
+              ...traceContext,
+            });
+
+            try {
+              const result = await handler(data, messageTraceContext);
+              const durationMs = performance.now() - startedAt;
+              telemetryController?.emit({
+                name: "ws.handler.completed",
+                level: "debug",
+                connectionId: ws.id,
+                namespace: ws.namespace,
+                detail: { event: eventName },
+                ...traceContext,
+              });
+              telemetryController?.recordSpan({
+                operationName: "ws.message.process",
+                kind: "internal",
+                durationMs,
+                status: "unset",
+                connectionId: ws.id,
+                namespace: ws.namespace,
+                attributes: { event: eventName },
+                ...traceContext,
+              });
+              return result;
+            } catch (error) {
+              const durationMs = performance.now() - startedAt;
+              telemetryController?.emit({
+                name: "ws.handler.failed",
+                level: "error",
+                connectionId: ws.id,
+                namespace: ws.namespace,
+                detail: { event: eventName },
+                ...traceContext,
+              });
+              telemetryController?.recordSpan({
+                operationName: "ws.message.process",
+                kind: "internal",
+                durationMs,
+                status: "error",
+                connectionId: ws.id,
+                namespace: ws.namespace,
+                attributes: { event: eventName },
+                errorType: error instanceof Error ? error.name : typeof error,
+                ...traceContext,
+              });
+              throw error;
+            }
+          }),
+        );
       },
       publish(event, data) {
         ws.publish(event, data);
@@ -1839,17 +1948,37 @@ class SonamuClass {
     const { BaseModel } = await import("../database/base-model");
     // 먼저 처리해야함.
     await BaseModel.destroy();
-    // 프로세스 종료 시 살아있는 WS 연결을 먼저 정리해 이후 다른 리소스 해제 과정에서 잔여 callback이 튀지 않게 함
+    // WebSocket shutdown first to flush telemetry
+    if (this._websocketRuntime) {
+      await this._websocketRuntime.shutdown();
+    }
+    this._websocketRuntime = null;
+    // Then shut down remaining resources in parallel
     await Promise.allSettled([
-      this._websocketRuntime?.shutdown() ?? Promise.resolve(),
       this._workflows?.destroy() ?? Promise.resolve(),
       this._cache?.disconnect() ?? Promise.resolve(),
       this._devVitestManager?.shutdown() ?? Promise.resolve(),
       this.watcher?.close() ?? Promise.resolve(),
-      logtapeDispose(),
     ]);
-    this._websocketRuntime = null;
+    // LogTape dispose after WS shutdown so telemetry records are flushed first
+    await logtapeDispose();
   }
+}
+
+function getWebSocketTelemetryContext(
+  ws: WebSocketConnection<WebSocketEventMap, WebSocketEventMap>,
+): WebSocketTelemetryConnectionContext {
+  if (!isTelemetryContextProvider(ws)) {
+    return {};
+  }
+
+  return ws.getTelemetryContext();
+}
+
+function isTelemetryContextProvider(
+  ws: WebSocketConnection<WebSocketEventMap, WebSocketEventMap>,
+): ws is WebSocketConnection<WebSocketEventMap, WebSocketEventMap> & TelemetryContextProvider {
+  return "getTelemetryContext" in ws && typeof ws.getTelemetryContext === "function";
 }
 
 export const Sonamu = new SonamuClass();

--- a/modules/sonamu/src/shared/app.shared.ts.txt
+++ b/modules/sonamu/src/shared/app.shared.ts.txt
@@ -365,6 +365,7 @@ export type WebSocketChannelOptions = {
   retryInterval?: number;
   protocols?: string | string[];
   headers?: Record<string, string>;
+  traceProvider?: () => string | undefined;
 };
 export type WebSocketChannelState<TSend extends Record<string, any>> = {
   isConnected: boolean;
@@ -606,7 +607,7 @@ export function useWebSocketChannel<
   handlers: EventHandlers<TReceive>,
   options: WebSocketChannelOptions = {},
 ): WebSocketChannelState<TSend> {
-  const { enabled = true, retry = 3, retryInterval = 3000, protocols, headers } = options;
+  const { enabled = true, retry = 3, retryInterval = 3000, protocols, headers, traceProvider } = options;
 
   const [state, setState] = useState<Omit<WebSocketChannelState<TSend>, "send" | "close">>({
     isConnected: false,
@@ -647,12 +648,12 @@ export function useWebSocketChannel<
       return;
     }
 
-    socket.send(
-      JSON.stringify({
-        event,
-        data,
-      }),
-    );
+    const traceparent = traceProvider?.();
+    if (traceparent) {
+      socket.send(JSON.stringify({ event, data, meta: { traceparent } }));
+      return;
+    }
+    socket.send(JSON.stringify({ event, data }));
   };
 
   const connect = () => {

--- a/modules/sonamu/src/shared/web.shared.ts.txt
+++ b/modules/sonamu/src/shared/web.shared.ts.txt
@@ -331,6 +331,7 @@ export type WebSocketChannelOptions = {
   retry?: number;
   retryInterval?: number;
   protocols?: string | string[];
+  traceProvider?: () => string | undefined;
 };
 export type WebSocketChannelState<TSend extends Record<string, any>> = {
   isConnected: boolean;
@@ -575,7 +576,7 @@ export function useWebSocketChannel<
   handlers: EventHandlers<TReceive>,
   options: WebSocketChannelOptions = {},
 ): WebSocketChannelState<TSend> {
-  const { enabled = true, retry = 3, retryInterval = 3000, protocols } = options;
+  const { enabled = true, retry = 3, retryInterval = 3000, protocols, traceProvider } = options;
 
   const [state, setState] = useState<Omit<WebSocketChannelState<TSend>, "send" | "close">>({
     isConnected: false,
@@ -616,12 +617,12 @@ export function useWebSocketChannel<
       return;
     }
 
-    socket.send(
-      JSON.stringify({
-        event,
-        data,
-      }),
-    );
+    const traceparent = traceProvider?.();
+    if (traceparent) {
+      socket.send(JSON.stringify({ event, data, meta: { traceparent } }));
+      return;
+    }
+    socket.send(JSON.stringify({ event, data }));
   };
 
   const connect = () => {

--- a/modules/sonamu/src/stream/__tests__/ws-telemetry.test.ts
+++ b/modules/sonamu/src/stream/__tests__/ws-telemetry.test.ts
@@ -1,0 +1,821 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type WebSocketMetricInput,
+  type WebSocketSpanInput,
+  type WebSocketTelemetryController,
+  type WebSocketTelemetryEventInput,
+  type WebSocketTelemetryEventRecord,
+  type WebSocketTelemetryEventSink,
+  type WebSocketTelemetryMetricRecord,
+  type WebSocketTelemetryMetricSink,
+  type WebSocketTelemetryMetricSource,
+  type WebSocketTelemetrySpanRecord,
+  type WebSocketTelemetrySpanSink,
+  NoopWebSocketTelemetryController,
+  createWebSocketTelemetryController,
+} from "../ws-telemetry";
+import { InMemoryEventStore, InMemoryMetricStore, InMemorySpanStore } from "../ws-telemetry-memory";
+
+// -- Test helpers --
+
+const TEST_RUNTIME_METADATA = { runtimeId: "test-runtime", nodeId: "test-node" };
+
+class EventCollectorSink implements WebSocketTelemetryEventSink {
+  records: WebSocketTelemetryEventRecord[] = [];
+  emit(record: WebSocketTelemetryEventRecord): void {
+    this.records.push(record);
+  }
+}
+
+class MetricCollectorSink implements WebSocketTelemetryMetricSink {
+  records: WebSocketTelemetryMetricRecord[] = [];
+  emit(record: WebSocketTelemetryMetricRecord): void {
+    this.records.push(record);
+  }
+}
+
+class SpanCollectorSink implements WebSocketTelemetrySpanSink {
+  records: WebSocketTelemetrySpanRecord[] = [];
+  emit(record: WebSocketTelemetrySpanRecord): void {
+    this.records.push(record);
+  }
+}
+
+class ThrowingMetricSink implements WebSocketTelemetryMetricSink {
+  emit(_record: WebSocketTelemetryMetricRecord): void {
+    throw new Error("metric sink explosion");
+  }
+}
+
+class ThrowingEventSink implements WebSocketTelemetryEventSink {
+  emit(_record: WebSocketTelemetryEventRecord): void {
+    throw new Error("event sink explosion");
+  }
+}
+
+class RejectingEventSink implements WebSocketTelemetryEventSink {
+  emit(_record: WebSocketTelemetryEventRecord): Promise<void> {
+    return Promise.reject(new Error("async event sink explosion"));
+  }
+}
+
+class DeferredEventSink implements WebSocketTelemetryEventSink {
+  records: WebSocketTelemetryEventRecord[] = [];
+  private readonly promises: Array<Promise<void>> = [];
+  private readonly resolvers: Array<() => void> = [];
+
+  emit(record: WebSocketTelemetryEventRecord): Promise<void> {
+    this.records.push(record);
+    const promise = new Promise<void>((resolve) => {
+      this.resolvers.push(resolve);
+    });
+    this.promises.push(promise);
+    return promise;
+  }
+
+  resolveAll(): void {
+    for (const resolve of this.resolvers.splice(0)) {
+      resolve();
+    }
+  }
+}
+
+class HangingEventSink implements WebSocketTelemetryEventSink {
+  records: WebSocketTelemetryEventRecord[] = [];
+  emit(record: WebSocketTelemetryEventRecord): void {
+    this.records.push(record);
+  }
+  shutdown(_options?: { timeoutMs?: number }): Promise<void> {
+    // Never resolves — exercises the per-sink shutdown timeout.
+    return new Promise(() => {});
+  }
+}
+
+class TrackingEventSink implements WebSocketTelemetryEventSink {
+  records: WebSocketTelemetryEventRecord[] = [];
+  shutdownCalled = false;
+  emit(record: WebSocketTelemetryEventRecord): void {
+    this.records.push(record);
+  }
+  shutdown(_options?: { timeoutMs?: number }): void {
+    this.shutdownCalled = true;
+  }
+}
+
+function makeEventInput(
+  overrides: Partial<WebSocketTelemetryEventInput> = {},
+): WebSocketTelemetryEventInput {
+  return {
+    name: "test.event",
+    level: "info",
+    ...overrides,
+  };
+}
+
+function makeMetricInput(overrides: Partial<WebSocketMetricInput> = {}): WebSocketMetricInput {
+  return {
+    name: "test.metric",
+    kind: "counter",
+    value: 1,
+    ...overrides,
+  };
+}
+
+function makeSpanInput(overrides: Partial<WebSocketSpanInput> = {}): WebSocketSpanInput {
+  return {
+    operationName: "test.op",
+    kind: "internal",
+    durationMs: 50,
+    status: "unset",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// -- T1~T4: redactor chaining --
+
+describe("redactor chaining", () => {
+  it("T1 defaults.redactor applies to all three signal records", () => {
+    const eventSink = new EventCollectorSink();
+    const metricSink = new MetricCollectorSink();
+    const spanSink = new SpanCollectorSink();
+
+    const controller = createWebSocketTelemetryController(
+      {
+        defaults: {
+          redactor: (record) => {
+            if (record.type === "event") {
+              return { ...record, attributes: { ...record.attributes, marked: "shared" } };
+            }
+            if (record.type === "metric") {
+              return { ...record, tags: { ...record.tags, marked: "shared" } };
+            }
+            return { ...record, attributes: { ...record.attributes, marked: "shared" } };
+          },
+        },
+        events: { sinks: [eventSink] },
+        metrics: { sinks: [metricSink], collectionEnabled: false },
+        spans: { sinks: [spanSink] },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "t1.event" }));
+    controller.recordMetric(makeMetricInput({ name: "t1.metric" }));
+    controller.recordSpan(makeSpanInput({ operationName: "t1.span" }));
+
+    expect(eventSink.records).toHaveLength(1);
+    expect(eventSink.records[0].attributes?.marked).toBe("shared");
+    expect(metricSink.records).toHaveLength(1);
+    expect(metricSink.records[0].tags?.marked).toBe("shared");
+    expect(spanSink.records).toHaveLength(1);
+    expect(spanSink.records[0].attributes?.marked).toBe("shared");
+  });
+
+  it("T2 defaults.redactor runs before per-signal redactor", () => {
+    const eventSink = new EventCollectorSink();
+    const order: string[] = [];
+
+    const controller = createWebSocketTelemetryController(
+      {
+        defaults: {
+          redactor: (record) => {
+            if (record.type !== "event") return record;
+            order.push("defaults");
+            return {
+              ...record,
+              attributes: { ...record.attributes, stage: "defaults" },
+            };
+          },
+        },
+        events: {
+          sinks: [eventSink],
+          redactor: (record) => {
+            order.push(`events:${record.attributes?.stage ?? "none"}`);
+            return {
+              ...record,
+              attributes: { ...record.attributes, stage: "events" },
+            };
+          },
+        },
+        metrics: { collectionEnabled: false },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "t2.chain" }));
+
+    expect(order).toEqual(["defaults", "events:defaults"]);
+    expect(eventSink.records).toHaveLength(1);
+    expect(eventSink.records[0].attributes?.stage).toBe("events");
+  });
+
+  it("T3 per-signal redactor null disables defaults for that signal only", () => {
+    const eventSink = new EventCollectorSink();
+    const metricSink = new MetricCollectorSink();
+    const spanSink = new SpanCollectorSink();
+
+    const controller = createWebSocketTelemetryController(
+      {
+        defaults: {
+          redactor: (record) => {
+            if (record.type === "event") {
+              return { ...record, attributes: { ...record.attributes, marked: "shared" } };
+            }
+            if (record.type === "metric") {
+              return { ...record, tags: { ...record.tags, marked: "shared" } };
+            }
+            return { ...record, attributes: { ...record.attributes, marked: "shared" } };
+          },
+        },
+        events: { sinks: [eventSink] },
+        metrics: { sinks: [metricSink], redactor: null, collectionEnabled: false },
+        spans: { sinks: [spanSink] },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "t3.event" }));
+    controller.recordMetric(makeMetricInput({ name: "t3.metric" }));
+    controller.recordSpan(makeSpanInput({ operationName: "t3.span" }));
+
+    expect(eventSink.records[0].attributes?.marked).toBe("shared");
+    expect(metricSink.records[0].tags?.marked).toBeUndefined();
+    expect(spanSink.records[0].attributes?.marked).toBe("shared");
+  });
+
+  it("T4 redactor returning mismatched record.type is dropped with internal event", () => {
+    const eventSink = new EventCollectorSink();
+    const metricSink = new MetricCollectorSink();
+
+    const controller = createWebSocketTelemetryController(
+      {
+        defaults: {
+          redactor: (record) => {
+            if (record.type === "event") {
+              // 의도적으로 type을 변경해서 type-mismatch defensive drop을 유도.
+              const mismatched: WebSocketTelemetryMetricRecord = {
+                timestamp: record.timestamp,
+                runtimeId: record.runtimeId,
+                nodeId: record.nodeId,
+                type: "metric",
+                name: record.name,
+                kind: "counter",
+                value: 0,
+              };
+              return mismatched;
+            }
+            return record;
+          },
+        },
+        events: { sinks: [eventSink] },
+        metrics: { sinks: [metricSink], collectionEnabled: false },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "t4.original" }));
+
+    // 본래 event는 drop되어야 한다.
+    const originals = eventSink.records.filter((record) => record.name === "t4.original");
+    expect(originals).toHaveLength(0);
+
+    // type-mismatch 내부 event가 events pipeline으로 발행되어야 한다.
+    const mismatchEvents = eventSink.records.filter(
+      (record) => record.name === "ws.telemetry.redactor.type_mismatch",
+    );
+    expect(mismatchEvents.length).toBeGreaterThanOrEqual(1);
+    expect(mismatchEvents[0].level).toBe("warn");
+
+    // metric sink로는 새지 않아야 한다 (drop).
+    expect(metricSink.records.filter((record) => record.name === "t4.original")).toHaveLength(0);
+  });
+});
+
+// -- T5~T6: signal routing --
+
+describe("signal routing", () => {
+  it("T5 each signal sink receives only its own record type", () => {
+    const eventSink = new EventCollectorSink();
+    const metricSink = new MetricCollectorSink();
+    const spanSink = new SpanCollectorSink();
+
+    const controller = createWebSocketTelemetryController(
+      {
+        events: { sinks: [eventSink] },
+        metrics: { sinks: [metricSink], collectionEnabled: false },
+        spans: { sinks: [spanSink] },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "t5.event" }));
+    controller.recordMetric(makeMetricInput({ name: "t5.metric" }));
+    controller.recordSpan(makeSpanInput({ operationName: "t5.span" }));
+
+    expect(eventSink.records).toHaveLength(1);
+    expect(eventSink.records[0].type).toBe("event");
+    expect(eventSink.records[0].name).toBe("t5.event");
+
+    expect(metricSink.records).toHaveLength(1);
+    expect(metricSink.records[0].type).toBe("metric");
+    expect(metricSink.records[0].name).toBe("t5.metric");
+
+    expect(spanSink.records).toHaveLength(1);
+    expect(spanSink.records[0].type).toBe("span");
+    expect(spanSink.records[0].operationName).toBe("t5.span");
+  });
+
+  it("T6 InMemory*Store query returns only its own type and controller exposes get*Store getters", () => {
+    const controller = createWebSocketTelemetryController(
+      {
+        metrics: { collectionEnabled: false },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "t6.event" }));
+    controller.recordMetric(makeMetricInput({ name: "t6.metric" }));
+    controller.recordSpan(makeSpanInput({ operationName: "t6.span" }));
+
+    const eventStore = controller.getEventStore();
+    const metricStore = controller.getMetricStore();
+    const spanStore = controller.getSpanStore();
+
+    expect(eventStore).toBeInstanceOf(InMemoryEventStore);
+    expect(metricStore).toBeInstanceOf(InMemoryMetricStore);
+    expect(spanStore).toBeInstanceOf(InMemorySpanStore);
+
+    const events = eventStore?.query({}) ?? [];
+    const metrics = metricStore?.query({}) ?? [];
+    const spans = spanStore?.query({}) ?? [];
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events.every((record) => record.type === "event")).toBe(true);
+    expect(events.some((record) => record.name === "t6.event")).toBe(true);
+
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0].type).toBe("metric");
+    expect(metrics[0].name).toBe("t6.metric");
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].type).toBe("span");
+    expect(spans[0].operationName).toBe("t6.span");
+  });
+});
+
+// -- T7: signal-independent maxRecords --
+
+describe("limits", () => {
+  it("T7 events/metrics maxRecords are independent and fall back to defaults then InMemory default", () => {
+    const controller = createWebSocketTelemetryController(
+      {
+        events: { maxRecords: 10 },
+        metrics: { maxRecords: 5, collectionEnabled: false },
+        // spans는 미지정 → InMemory 기본값(10000) 적용
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    for (let i = 0; i < 12; i++) {
+      controller.emit(makeEventInput({ name: `t7.event.${i}` }));
+    }
+    for (let i = 0; i < 12; i++) {
+      controller.recordMetric(makeMetricInput({ name: `t7.metric.${i}` }));
+    }
+    for (let i = 0; i < 12; i++) {
+      controller.recordSpan(makeSpanInput({ operationName: `t7.span.${i}` }));
+    }
+
+    const events = controller.getEventStore()?.query({}) ?? [];
+    const metrics = controller.getMetricStore()?.query({}) ?? [];
+    const spans = controller.getSpanStore()?.query({}) ?? [];
+
+    expect(events.length).toBeLessThanOrEqual(10);
+    // 가장 최근 emit된 record가 살아있는지(ring buffer 동작) 확인.
+    expect(events.some((record) => record.name === "t7.event.11")).toBe(true);
+
+    expect(metrics).toHaveLength(5);
+    expect(metrics.some((record) => record.name === "t7.metric.11")).toBe(true);
+
+    // spans는 InMemory 기본값(10000)을 사용하므로 12개 모두 보관됨.
+    expect(spans).toHaveLength(12);
+  });
+});
+
+// -- T8 / T11: rate limit independence and metric bypass --
+
+describe("rate limit", () => {
+  it("T8 events.maxRecordsPerSecond is independent of metrics/spans buckets", () => {
+    const eventSink = new EventCollectorSink();
+    const metricSink = new MetricCollectorSink();
+    const spanSink = new SpanCollectorSink();
+
+    const controller = createWebSocketTelemetryController(
+      {
+        events: {
+          sinks: [eventSink],
+          // alwaysRecordLevels를 비워 sampling skip→skipRateLimit 우회를 막는다.
+          sampling: { maxRecordsPerSecond: 1, alwaysRecordLevels: [] },
+        },
+        metrics: { sinks: [metricSink], collectionEnabled: false },
+        spans: { sinks: [spanSink] },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    for (let i = 0; i < 3; i++) {
+      controller.emit(makeEventInput({ name: `t8.event.${i}`, level: "info" }));
+    }
+    for (let i = 0; i < 3; i++) {
+      controller.recordMetric(makeMetricInput({ name: `t8.metric.${i}` }));
+    }
+    for (let i = 0; i < 3; i++) {
+      controller.recordSpan(makeSpanInput({ operationName: `t8.span.${i}` }));
+    }
+
+    // events 버킷이 1이므로 첫 emit만 통과해야 한다.
+    expect(eventSink.records).toHaveLength(1);
+    expect(eventSink.records[0].name).toBe("t8.event.0");
+
+    // metrics/spans는 영향 없이 모두 통과.
+    expect(metricSink.records).toHaveLength(3);
+    expect(spanSink.records).toHaveLength(3);
+  });
+
+  it("T11 metric outcome=failed and .dropped name pattern bypass rate limit", () => {
+    const metricSink = new MetricCollectorSink();
+    const controller = createWebSocketTelemetryController(
+      {
+        metrics: {
+          sinks: [metricSink],
+          sampling: { maxRecordsPerSecond: 1 },
+          collectionEnabled: false,
+        },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    // 첫 normal metric은 토큰 1개 소진.
+    controller.recordMetric(makeMetricInput({ name: "t11.normal.first" }));
+    // 두번째 normal metric은 토큰 부족으로 drop.
+    controller.recordMetric(makeMetricInput({ name: "t11.normal.second" }));
+    // outcome=failed metric은 우회.
+    controller.recordMetric(makeMetricInput({ name: "t11.with.tag", tags: { outcome: "failed" } }));
+    // .dropped 패턴 이름도 우회.
+    controller.recordMetric(makeMetricInput({ name: "ws.something.dropped" }));
+
+    const names = metricSink.records.map((record) => record.name);
+    expect(names).toContain("t11.normal.first");
+    expect(names).not.toContain("t11.normal.second");
+    expect(names).toContain("t11.with.tag");
+    expect(names).toContain("ws.something.dropped");
+  });
+});
+
+// -- T9 / T10: sampling --
+
+describe("sampling", () => {
+  it("T9 alwaysRecordLevels bypass sampling while defaultRate=0 drops other levels", () => {
+    const eventSink = new EventCollectorSink();
+    const controller = createWebSocketTelemetryController(
+      {
+        events: {
+          sinks: [eventSink],
+          sampling: { defaultRate: 0, alwaysRecordLevels: ["error"] },
+        },
+        metrics: { collectionEnabled: false },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "t9.error", level: "error" }));
+    controller.emit(makeEventInput({ name: "t9.info", level: "info" }));
+
+    const names = eventSink.records.map((record) => record.name);
+    expect(names).toContain("t9.error");
+    expect(names).not.toContain("t9.info");
+  });
+
+  it("T10 span with status=error bypasses sampling even when defaultRate=0", () => {
+    const spanSink = new SpanCollectorSink();
+    const controller = createWebSocketTelemetryController(
+      {
+        spans: { sinks: [spanSink], sampling: { defaultRate: 0 } },
+        metrics: { collectionEnabled: false },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.recordSpan(makeSpanInput({ operationName: "t10.error", status: "error" }));
+    controller.recordSpan(makeSpanInput({ operationName: "t10.unset", status: "unset" }));
+
+    const ops = spanSink.records.map((record) => record.operationName);
+    expect(ops).toContain("t10.error");
+    expect(ops).not.toContain("t10.unset");
+  });
+});
+
+// -- T12: getMetricsSnapshot aggregation --
+
+describe("metrics snapshot", () => {
+  it("T12 getMetricsSnapshot aggregates dropped/sinkFailures across pipelines", () => {
+    const throwingMetricSink = new ThrowingMetricSink();
+    const controller = createWebSocketTelemetryController(
+      {
+        // events redactor가 null을 반환해 drop을 발생시킨다.
+        events: {
+          redactor: (_record) => null,
+        },
+        metrics: { sinks: [throwingMetricSink], collectionEnabled: false },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "t12.dropped" }));
+    controller.recordMetric(makeMetricInput({ name: "t12.failure" }));
+
+    const snapshot = controller.getMetricsSnapshot();
+    expect(snapshot.telemetryDroppedRecords).toBeGreaterThanOrEqual(1);
+    expect(snapshot.telemetrySinkFailures).toBeGreaterThanOrEqual(1);
+    expect(snapshot.timestamp).toBeGreaterThan(0);
+  });
+});
+
+// -- T13: registerMetricSource unsubscribe --
+
+describe("metric source", () => {
+  it("T13 registerMetricSource returns working unsubscribe", () => {
+    const controller = createWebSocketTelemetryController(
+      {
+        metrics: { collectionEnabled: false },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    const source: WebSocketTelemetryMetricSource = {
+      collect: () => ({ activeConnections: 7 }),
+    };
+
+    const unsubscribe = controller.registerMetricSource(source);
+    expect(typeof unsubscribe).toBe("function");
+
+    const snapshotBefore = controller.getMetricsSnapshot();
+    expect(snapshotBefore.activeConnections).toBe(7);
+
+    unsubscribe();
+
+    const snapshotAfter = controller.getMetricsSnapshot();
+    expect(snapshotAfter.activeConnections).toBe(0);
+  });
+});
+
+// -- T14: periodic metric collection --
+
+describe("metric collection", () => {
+  it("T14 collectionEnabled with sampleIntervalMs emits gauge to metrics sink periodically", () => {
+    vi.useFakeTimers();
+    const metricSink = new MetricCollectorSink();
+    const controller = createWebSocketTelemetryController(
+      {
+        metrics: {
+          sinks: [metricSink],
+          collectionEnabled: true,
+          sampleIntervalMs: 10,
+        },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+    controller.registerMetricSource({
+      collect: () => ({ activeConnections: 3 }),
+    });
+
+    vi.advanceTimersByTime(50);
+
+    const gauges = metricSink.records.filter(
+      (record) => record.name === "ws.connections.active" && record.kind === "gauge",
+    );
+    expect(gauges.length).toBeGreaterThanOrEqual(1);
+    expect(gauges[0].value).toBe(3);
+  });
+
+  it("uses controller-wide dropped and sink failure counts in periodic gauge snapshots", async () => {
+    vi.useFakeTimers();
+    const metricSink = new MetricCollectorSink();
+    const throwingEventSink = new ThrowingEventSink();
+
+    const controller = createWebSocketTelemetryController(
+      {
+        events: {
+          sinks: [throwingEventSink],
+          redactor: (record) => {
+            if (record.name === "periodic.dropped.event") return null;
+            return record;
+          },
+        },
+        metrics: {
+          sinks: [metricSink],
+          collectionEnabled: true,
+          sampleIntervalMs: 10,
+        },
+        spans: {
+          redactor: (record) => {
+            if (record.operationName === "periodic.dropped.span") return null;
+            return record;
+          },
+        },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "periodic.dropped.event" }));
+    controller.emit(makeEventInput({ name: "periodic.failed.event" }));
+    controller.recordSpan(makeSpanInput({ operationName: "periodic.dropped.span" }));
+    vi.advanceTimersByTime(10);
+    await Promise.resolve();
+
+    const gauges = metricSink.records.filter(
+      (record) => record.name === "ws.connections.active" && record.kind === "gauge",
+    );
+    expect(gauges.length).toBeGreaterThanOrEqual(1);
+    expect(gauges[0].snapshot?.telemetryDroppedRecords).toBeGreaterThanOrEqual(2);
+    expect(gauges[0].snapshot?.telemetrySinkFailures).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("sink failures", () => {
+  it("emits ws.telemetry.sink.failed for sync and async emit failures", async () => {
+    const observerSink = new EventCollectorSink();
+    const controller = createWebSocketTelemetryController(
+      {
+        events: {
+          sinks: [new ThrowingEventSink(), new RejectingEventSink(), observerSink],
+        },
+        metrics: { collectionEnabled: false },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "sink.failure.target" }));
+    await Promise.resolve();
+
+    const failureRecords = observerSink.records.filter(
+      (record) => record.name === "ws.telemetry.sink.failed",
+    );
+    expect(failureRecords).toHaveLength(2);
+    expect(failureRecords.map((record) => record.detail?.phase)).toEqual(["emit", "emit"]);
+    expect(failureRecords.map((record) => record.detail?.signal)).toEqual(["event", "event"]);
+    expect(controller.getMetricsSnapshot().telemetrySinkFailures).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("sink backpressure", () => {
+  it("limits per-sink in-flight emits and drops non-critical records beyond the limit", async () => {
+    const deferredSink = new DeferredEventSink();
+    const observerSink = new EventCollectorSink();
+    const controller = createWebSocketTelemetryController(
+      {
+        events: {
+          sinks: [deferredSink, observerSink],
+          maxInFlightEmits: 2,
+          sampling: { alwaysRecordLevels: [] },
+        },
+        metrics: { collectionEnabled: false },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    controller.emit(makeEventInput({ name: "backpressure.one", level: "info" }));
+    controller.emit(makeEventInput({ name: "backpressure.two", level: "info" }));
+    controller.emit(makeEventInput({ name: "backpressure.three", level: "info" }));
+    controller.emit(makeEventInput({ name: "backpressure.critical", level: "error" }));
+
+    expect(deferredSink.records.map((record) => record.name)).toEqual([
+      "backpressure.one",
+      "backpressure.two",
+      "backpressure.critical",
+    ]);
+    expect(observerSink.records.map((record) => record.name)).toEqual([
+      "backpressure.one",
+      "backpressure.two",
+      "backpressure.three",
+      "backpressure.critical",
+    ]);
+    expect(observerSink.records.some((record) => record.name === "backpressure.three")).toBe(true);
+    expect(controller.getMetricsSnapshot().telemetryDroppedRecords).toBeGreaterThanOrEqual(1);
+
+    deferredSink.resolveAll();
+    await Promise.resolve();
+  });
+});
+
+// -- T15 / T16: shutdown --
+
+describe("shutdown", () => {
+  it("T15 sink shutdown timeout is isolated and emits ws.telemetry.shutdown.timeout event", async () => {
+    const hangingEventSink = new HangingEventSink();
+    const observerSink = new EventCollectorSink();
+
+    const controller = createWebSocketTelemetryController(
+      {
+        events: { sinks: [hangingEventSink, observerSink] },
+        metrics: { collectionEnabled: false },
+        shutdownTimeoutMs: 20,
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    await controller.shutdown();
+
+    // hanging sink는 timeout, observer sink는 정상 종료.
+    // sinkFailureCount는 metrics snapshot에서 1 이상.
+    const snapshot = controller.getMetricsSnapshot();
+    expect(snapshot.telemetrySinkFailures).toBeGreaterThanOrEqual(1);
+
+    // ws.telemetry.shutdown.timeout 이벤트가 events pipeline으로 발행되어야 함.
+    const timeoutRecords = observerSink.records.filter(
+      (record) => record.name === "ws.telemetry.shutdown.timeout",
+    );
+    expect(timeoutRecords.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("T16 emit/recordMetric/recordSpan after shutdown are silent drops", async () => {
+    const eventSink = new TrackingEventSink();
+    const metricSink = new MetricCollectorSink();
+    const spanSink = new SpanCollectorSink();
+
+    const controller = createWebSocketTelemetryController(
+      {
+        events: { sinks: [eventSink] },
+        metrics: { sinks: [metricSink], collectionEnabled: false },
+        spans: { sinks: [spanSink] },
+      },
+      TEST_RUNTIME_METADATA,
+    );
+
+    await controller.shutdown();
+
+    const eventCountBefore = eventSink.records.length;
+    const metricCountBefore = metricSink.records.length;
+    const spanCountBefore = spanSink.records.length;
+
+    expect(() => controller.emit(makeEventInput({ name: "t16.late" }))).not.toThrow();
+    expect(() => controller.recordMetric(makeMetricInput({ name: "t16.late" }))).not.toThrow();
+    expect(() => controller.recordSpan(makeSpanInput({ operationName: "t16.late" }))).not.toThrow();
+
+    expect(eventSink.records.length).toBe(eventCountBefore);
+    expect(metricSink.records.length).toBe(metricCountBefore);
+    expect(spanSink.records.length).toBe(spanCountBefore);
+  });
+});
+
+// -- T17: trace context --
+
+describe("trace context", () => {
+  it("T17 createConnectionContext preserves traceparent extraction/generation", () => {
+    const controller = createWebSocketTelemetryController(true, TEST_RUNTIME_METADATA);
+
+    const extracted = controller.createConnectionContext({
+      headers: {
+        traceparent: "00-4bf92f3577b16d8a2e3e24ff02e6c998-00f067aa0ba902b7-01",
+      },
+    });
+    expect(extracted.traceId).toBe("4bf92f3577b16d8a2e3e24ff02e6c998");
+    expect(extracted.parentSpanId).toBe("00f067aa0ba902b7");
+    expect(extracted.sampled).toBe(true);
+    expect(extracted.spanId).toMatch(/^[0-9a-f]{16}$/);
+    // 새 spanId는 추출된 parentSpanId와 달라야 함.
+    expect(extracted.spanId).not.toBe(extracted.parentSpanId);
+
+    const generated = controller.createConnectionContext();
+    expect(generated.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(generated.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(generated.parentSpanId).toBeUndefined();
+  });
+});
+
+// -- T18 / T19: option resolution --
+
+describe("options", () => {
+  it("T18 controller option combined with other options throws", () => {
+    const custom: WebSocketTelemetryController = new NoopWebSocketTelemetryController();
+    expect(() =>
+      createWebSocketTelemetryController({ controller: custom, events: {} }, TEST_RUNTIME_METADATA),
+    ).toThrow();
+  });
+
+  it("T19 enabled=false yields NoopController and undefined get*Store", () => {
+    const controller = createWebSocketTelemetryController(
+      { enabled: false },
+      TEST_RUNTIME_METADATA,
+    );
+    expect(controller).toBeInstanceOf(NoopWebSocketTelemetryController);
+    expect(controller.getEventStore()).toBeUndefined();
+    expect(controller.getMetricStore()).toBeUndefined();
+    expect(controller.getSpanStore()).toBeUndefined();
+  });
+});

--- a/modules/sonamu/src/stream/__tests__/ws.test.ts
+++ b/modules/sonamu/src/stream/__tests__/ws.test.ts
@@ -113,7 +113,292 @@ describe("WebSocketRuntime", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(handler).toHaveBeenCalledWith({ roomId: "alpha" });
+    expect(handler).toHaveBeenCalledWith({ roomId: "alpha" }, expect.any(Object));
+  });
+
+  it("passes message trace context from meta.traceparent to handlers", async () => {
+    const runtime = createWebSocketRuntime({ telemetry: true });
+    const socket = new FakeWebSocket();
+    const connection = runtime.registerConnection(asWebSocket(socket), {
+      outEvents: OutEvents,
+      inEvents: InEvents,
+      namespace: "chat",
+    });
+    let capturedTrace:
+      | {
+          traceId?: string;
+          parentSpanId?: string;
+          sampled?: boolean;
+        }
+      | undefined;
+
+    connection.onMessage("joinRoom", (_data, telemetryContext) => {
+      capturedTrace = telemetryContext;
+    });
+
+    socket.emit(
+      "message",
+      JSON.stringify({
+        event: "joinRoom",
+        data: { roomId: "alpha" },
+        meta: {
+          traceparent: "00-4bf92f3577b16d8a2e3e24ff02e6c998-00f067aa0ba902b7-01",
+        },
+      }),
+    );
+
+    await waitForAsyncQueue();
+
+    expect(capturedTrace).toMatchObject({
+      traceId: "4bf92f3577b16d8a2e3e24ff02e6c998",
+      parentSpanId: "00f067aa0ba902b7",
+      sampled: true,
+    });
+  });
+
+  it("falls back to connection trace when message trace propagation is disabled", async () => {
+    const runtime = createWebSocketRuntime({
+      telemetry: { trace: { propagateMessageTrace: false } },
+    });
+    const socket = new FakeWebSocket();
+    const connection = runtime.registerConnection(asWebSocket(socket), {
+      outEvents: OutEvents,
+      inEvents: InEvents,
+      namespace: "chat",
+      traceId: "11111111111111111111111111111111",
+      spanId: "2222222222222222",
+      sampled: false,
+    });
+    let capturedTrace:
+      | {
+          traceId?: string;
+          parentSpanId?: string;
+          sampled?: boolean;
+        }
+      | undefined;
+
+    connection.onMessage("joinRoom", (_data, telemetryContext) => {
+      capturedTrace = telemetryContext;
+    });
+
+    socket.emit(
+      "message",
+      JSON.stringify({
+        event: "joinRoom",
+        data: { roomId: "alpha" },
+        meta: {
+          traceparent: "00-4bf92f3577b16d8a2e3e24ff02e6c998-00f067aa0ba902b7-01",
+        },
+      }),
+    );
+
+    await waitForAsyncQueue();
+
+    expect(capturedTrace).toMatchObject({
+      traceId: "11111111111111111111111111111111",
+      parentSpanId: "2222222222222222",
+      sampled: false,
+    });
+  });
+
+  it("records ok status for normal close codes", () => {
+    const runtime = createWebSocketRuntime({
+      telemetry: { trace: { recordConnectionLifetimeSpan: true } },
+    });
+    const socket = new FakeWebSocket();
+    const connection = runtime.registerConnection(asWebSocket(socket), {
+      outEvents: OutEvents,
+      inEvents: InEvents,
+      namespace: "chat",
+      traceId: "11111111111111111111111111111111",
+      spanId: "2222222222222222",
+      parentSpanId: "3333333333333333",
+      sampled: true,
+    });
+
+    connection.close(1000, "done");
+
+    const spanStore = runtime.telemetryController.getSpanStore();
+    const lifetimeSpans = spanStore?.query({ operationName: "ws.connection.lifetime" }) ?? [];
+
+    expect(lifetimeSpans).toHaveLength(1);
+    expect(lifetimeSpans[0]).toMatchObject({
+      operationName: "ws.connection.lifetime",
+      kind: "server",
+      status: "ok",
+      connectionId: connection.id,
+      namespace: "chat",
+      traceId: "11111111111111111111111111111111",
+      spanId: "2222222222222222",
+      parentSpanId: "3333333333333333",
+      sampled: true,
+    });
+    expect(lifetimeSpans[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("records error status for non-normal close codes", () => {
+    const runtime = createWebSocketRuntime({
+      telemetry: { trace: { recordConnectionLifetimeSpan: true } },
+    });
+    const socket = new FakeWebSocket();
+    const connection = runtime.registerConnection(asWebSocket(socket), {
+      outEvents: OutEvents,
+      inEvents: InEvents,
+      namespace: "chat",
+    });
+
+    connection.close(1011, "internal error");
+
+    const spanStore = runtime.telemetryController.getSpanStore();
+    const lifetimeSpans = spanStore?.query({ operationName: "ws.connection.lifetime" }) ?? [];
+
+    expect(lifetimeSpans).toHaveLength(1);
+    expect(lifetimeSpans[0]).toMatchObject({
+      operationName: "ws.connection.lifetime",
+      kind: "server",
+      status: "error",
+      connectionId: connection.id,
+      namespace: "chat",
+    });
+    expect(lifetimeSpans[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("records unset status when close code is unknown", () => {
+    const runtime = createWebSocketRuntime({
+      telemetry: { trace: { recordConnectionLifetimeSpan: true } },
+    });
+    const socket = new FakeWebSocket();
+    const connection = runtime.registerConnection(asWebSocket(socket), {
+      outEvents: OutEvents,
+      inEvents: InEvents,
+      namespace: "chat",
+    });
+
+    // Peer-initiated close without a code reaches handleClose with code=undefined.
+    socket.emit("close");
+
+    const spanStore = runtime.telemetryController.getSpanStore();
+    const lifetimeSpans = spanStore?.query({ operationName: "ws.connection.lifetime" }) ?? [];
+
+    expect(lifetimeSpans).toHaveLength(1);
+    expect(lifetimeSpans[0]).toMatchObject({
+      operationName: "ws.connection.lifetime",
+      kind: "server",
+      status: "unset",
+      connectionId: connection.id,
+      namespace: "chat",
+    });
+    expect(lifetimeSpans[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("uses extracted handshake parent when connection span generation is disabled", async () => {
+    const runtime = createWebSocketRuntime({
+      telemetry: {
+        trace: {
+          generateConnectionTrace: false,
+          propagateMessageTrace: false,
+        },
+      },
+    });
+    const socket = new FakeWebSocket();
+    const handshakeContext = runtime.telemetryController.createConnectionContext({
+      headers: {
+        traceparent: "00-4bf92f3577b16d8a2e3e24ff02e6c998-00f067aa0ba902b7-01",
+      },
+    });
+    const connection = runtime.registerConnection(asWebSocket(socket), {
+      outEvents: OutEvents,
+      inEvents: InEvents,
+      namespace: "chat",
+      ...handshakeContext,
+    });
+    let capturedTrace:
+      | {
+          traceId?: string;
+          spanId?: string;
+          parentSpanId?: string;
+          sampled?: boolean;
+        }
+      | undefined;
+
+    connection.onMessage("joinRoom", (_data, telemetryContext) => {
+      capturedTrace = telemetryContext;
+    });
+
+    socket.emit(
+      "message",
+      JSON.stringify({
+        event: "joinRoom",
+        data: { roomId: "alpha" },
+      }),
+    );
+
+    await waitForAsyncQueue();
+
+    expect(handshakeContext).toMatchObject({
+      traceId: "4bf92f3577b16d8a2e3e24ff02e6c998",
+      parentSpanId: "00f067aa0ba902b7",
+      sampled: true,
+    });
+    expect(handshakeContext.spanId).toBeUndefined();
+    expect(capturedTrace).toMatchObject({
+      traceId: "4bf92f3577b16d8a2e3e24ff02e6c998",
+      parentSpanId: "00f067aa0ba902b7",
+      sampled: true,
+    });
+    expect(capturedTrace?.spanId).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("emits skipped registry mutation telemetry for missing connections", () => {
+    const runtime = createWebSocketRuntime({ telemetry: true });
+
+    runtime.activateConnection("missing-connection");
+    runtime.registry.join("missing-connection", "room-1");
+    runtime.registry.leave("missing-connection", "room-1");
+    runtime.registry.setUserId("missing-connection", "user-1");
+    runtime.registry.clearUserId("missing-connection");
+
+    const store = runtime.telemetryController.getEventStore();
+    const skippedEvents = store?.query({ name: "ws.registry.mutation.skipped" }) ?? [];
+
+    expect(skippedEvents).toHaveLength(5);
+    expect(skippedEvents.map((record) => record.detail)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: "activate",
+          reason: "connectionMissing",
+        }),
+        expect.objectContaining({
+          operation: "join",
+          reason: "connectionMissing",
+          roomId: "room-1",
+        }),
+        expect.objectContaining({
+          operation: "leave",
+          reason: "connectionMissing",
+          roomId: "room-1",
+        }),
+        expect.objectContaining({
+          operation: "setUserId",
+          reason: "connectionMissing",
+          userId: "user-1",
+        }),
+        expect.objectContaining({
+          operation: "clearUserId",
+          reason: "connectionMissing",
+        }),
+      ]),
+    );
+    expect(
+      skippedEvents.every(
+        (record) => record.connectionId === "missing-connection" && record.level === "debug",
+      ),
+    ).toBe(true);
+    expect(store?.query({ name: "ws.connection.activated" })).toHaveLength(0);
+    expect(store?.query({ name: "ws.room.joined" })).toHaveLength(0);
+    expect(store?.query({ name: "ws.room.left" })).toHaveLength(0);
+    expect(store?.query({ name: "ws.user.bound" })).toHaveLength(0);
+    expect(store?.query({ name: "ws.user.cleared" })).toHaveLength(0);
   });
 
   it("keeps inactive connections out of registry fan-out until activated", async () => {
@@ -182,6 +467,50 @@ describe("WebSocketRuntime", () => {
 
     expect(runtime.registry.getRoomMembers("room-1")).toHaveLength(1);
     expect(runtime.registry.getConnectionCount("chat")).toBe(1);
+  });
+
+  it("emits runtime telemetry for room/user bindings and outbound queue flow", async () => {
+    const runtime = createWebSocketRuntime({ telemetry: true });
+    const socket = new FakeWebSocket();
+    const connection = runtime.registerConnection(asWebSocket(socket), {
+      outEvents: OutEvents,
+      inEvents: InEvents,
+      namespace: "chat",
+      traceId: "11111111111111111111111111111111",
+      spanId: "2222222222222222",
+    });
+
+    connection.join("room-1");
+    connection.leave("room-1");
+    connection.setUserId("user-1");
+    connection.clearUserId();
+
+    expect(() => connection.publishUntyped("missing", {})).toThrow("Unknown websocket event");
+    expect(() => connection.publishUntyped("onReady", { ok: "nope" })).toThrow(
+      "Invalid websocket event payload",
+    );
+
+    connection.publish("onReady", { ok: true });
+
+    const store = runtime.telemetryController.getEventStore();
+    const events = store?.query({}) ?? [];
+    const names = events.map((record) => record.name);
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "ws.room.joined",
+        "ws.room.left",
+        "ws.user.bound",
+        "ws.user.cleared",
+        "ws.publish.rejected",
+        "ws.publish.queued",
+      ]),
+    );
+    expect(events.find((record) => record.name === "ws.room.joined")).toMatchObject({
+      connectionId: connection.id,
+      namespace: "chat",
+      traceId: "11111111111111111111111111111111",
+    });
   });
 
   it("keeps room fan-out isolated by namespace", async () => {
@@ -416,6 +745,38 @@ describe("WebSocketRuntime", () => {
     }
 
     expect(socket.closedWith?.code).toBe(1013);
+  });
+
+  it("reports local connection and delivery pending gauge sources", async () => {
+    const runtime = createWebSocketRuntime({ telemetry: true });
+    const socket = new FakeWebSocket();
+    socket.bufferedAmount = 2_000_000;
+    const connection = runtime.registerConnection(asWebSocket(socket), {
+      outEvents: OutEvents,
+      inEvents: InEvents,
+      namespace: "chat",
+    });
+
+    socket.emit(
+      "message",
+      JSON.stringify({
+        event: "joinRoom",
+        data: { roomId: "alpha" },
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    connection.publish("onReady", { ok: true });
+    runtime.broadcast("onReady", { ok: true }, "chat");
+
+    const snapshot = runtime.telemetryController.getMetricsSnapshot();
+
+    expect(snapshot.pendingInboundMessages).toBe(1);
+    expect(snapshot.pendingOutboundMessages).toBeGreaterThanOrEqual(1);
+    expect(snapshot.socketBufferedBytes).toBe(2_000_000);
+    expect(snapshot.pendingFanOutJobs).toBe(1);
+    expect(snapshot.pendingFanOutTargets).toBe(1);
   });
 
   it("preserves broadcast order across chunked fan-out batches", async () => {

--- a/modules/sonamu/src/stream/index.ts
+++ b/modules/sonamu/src/stream/index.ts
@@ -3,5 +3,8 @@ export * from "./ws-audience";
 export * from "./ws-cluster-bus";
 export * from "./ws-core";
 export * from "./ws-presence-store";
+export * from "./ws-telemetry";
+export * from "./ws-telemetry-memory";
+export * from "./ws-telemetry-trace";
 export * from "./ws";
 export * from "./ws-registry";

--- a/modules/sonamu/src/stream/ws-core.ts
+++ b/modules/sonamu/src/stream/ws-core.ts
@@ -5,6 +5,8 @@ export interface ManagedWebSocketConnection {
   id: string;
   namespace: string;
   closed: boolean;
+  // setUserId/clearUserId 호출로 갱신됨. telemetry emit 사이트에서 hot path lookup을 피하기 위해 connection에 캐싱한다
+  readonly userId?: string;
   publishUntyped(event: string, data: unknown): void;
   close(code?: number, reason?: string): void;
 }

--- a/modules/sonamu/src/stream/ws-delivery.ts
+++ b/modules/sonamu/src/stream/ws-delivery.ts
@@ -270,6 +270,8 @@ export class WebSocketDeliveryEngine {
         name: "ws.fanout.publish.failed",
         level: "error",
         connectionId: connection.id,
+        namespace: connection.namespace,
+        userId: connection.userId,
         detail: { event },
       });
       connection.close(1011, "WebSocket publish failed");

--- a/modules/sonamu/src/stream/ws-delivery.ts
+++ b/modules/sonamu/src/stream/ws-delivery.ts
@@ -5,6 +5,10 @@ import { type WebSocketAudienceResolver } from "./ws-audience-resolver";
 import { type WebSocketClusterBus, type WebSocketClusterEnvelope } from "./ws-cluster-bus";
 import { type ManagedWebSocketConnection } from "./ws-core";
 import { type WebSocketLocalConnectionStore } from "./ws-local-connection-store";
+import {
+  NoopWebSocketTelemetryController,
+  type WebSocketTelemetryController,
+} from "./ws-telemetry";
 
 // fan-out을 event loop tick 단위로 나눠 한 번에 긴 동기 루프를 만들지 않게 함
 const FAN_OUT_BATCH_SIZE = 250;
@@ -18,6 +22,8 @@ export class WebSocketDeliveryEngine {
   }> = [];
   private fanOutFlushScheduled = false;
   private readonly unsubscribe: () => void;
+  private readonly telemetry: WebSocketTelemetryController;
+  private readonly unregisterMetricSource: () => void;
 
   constructor(
     private readonly options: {
@@ -25,23 +31,45 @@ export class WebSocketDeliveryEngine {
       localConnections: WebSocketLocalConnectionStore;
       audienceResolver: WebSocketAudienceResolver;
       clusterBus: WebSocketClusterBus;
+      telemetryController?: WebSocketTelemetryController;
     },
   ) {
+    this.telemetry = this.options.telemetryController ?? new NoopWebSocketTelemetryController();
     this.unsubscribe = this.options.clusterBus.subscribe((envelope) => {
       this.handleClusterEnvelope(envelope);
+    });
+    this.unregisterMetricSource = this.telemetry.registerMetricSource({
+      collect: () => this.getTelemetrySnapshot(),
     });
   }
 
   publishToAudience(audience: WebSocketAudience, event: string, data: unknown): void {
     const routingPlan = this.options.audienceResolver.resolve(audience);
     const localTargets = this.options.localConnections.getConnections(routingPlan.localSessionIds);
+
+    this.telemetry.emit({
+      name: "ws.fanout.resolved",
+      level: "debug",
+      detail: {
+        localTargetCount: localTargets.length,
+        remoteNodeCount: routingPlan.remoteNodeIds.length,
+      },
+    });
+    this.telemetry.recordMetric({
+      name: "sonamu.ws.fanout.targets",
+      kind: "histogram",
+      value: localTargets.length + routingPlan.remoteNodeIds.length,
+      unit: "1",
+      tags: { audience_type: audience.type },
+    });
+
     this.enqueueFanOut(localTargets, event, data);
 
     if (routingPlan.remoteNodeIds.length === 0) {
       return;
     }
 
-    void this.options.clusterBus.publish({
+    const envelope: WebSocketClusterEnvelope = {
       id: randomUUID(),
       sourceNodeId: this.options.nodeId,
       targetNodeIds: routingPlan.remoteNodeIds,
@@ -49,16 +77,72 @@ export class WebSocketDeliveryEngine {
       event,
       data,
       emittedAt: Date.now(),
-    });
+    };
+
+    const publishStartedAt = performance.now();
+    Promise.resolve(this.options.clusterBus.publish(envelope))
+      .then(() => {
+        const durationMs = performance.now() - publishStartedAt;
+        this.telemetry.emit({
+          name: "ws.cluster.envelope.published",
+          level: "debug",
+          detail: { event, targetNodeCount: routingPlan.remoteNodeIds.length },
+        });
+        this.telemetry.recordSpan({
+          operationName: "ws.cluster.publish",
+          kind: "producer",
+          durationMs,
+          status: "unset",
+          attributes: {
+            event,
+            targetNodeCount: routingPlan.remoteNodeIds.length,
+          },
+        });
+      })
+      .catch((error: unknown) => {
+        const durationMs = performance.now() - publishStartedAt;
+        this.telemetry.emit({
+          name: "ws.cluster.envelope.failed",
+          level: "error",
+          detail: { event },
+        });
+        this.telemetry.recordSpan({
+          operationName: "ws.cluster.publish",
+          kind: "producer",
+          durationMs,
+          status: "error",
+          attributes: { event },
+          errorType: error instanceof Error ? error.name : typeof error,
+        });
+      });
   }
 
   async shutdown(): Promise<void> {
+    this.unregisterMetricSource();
     this.unsubscribe();
     await this.options.clusterBus.shutdown();
   }
 
+  getTelemetrySnapshot(): { pendingFanOutJobs: number; pendingFanOutTargets: number } {
+    let pendingFanOutTargets = 0;
+
+    for (const job of this.pendingFanOutJobs) {
+      pendingFanOutTargets += Math.max(job.targets.length - job.cursor, 0);
+    }
+
+    return {
+      pendingFanOutJobs: this.pendingFanOutJobs.length,
+      pendingFanOutTargets,
+    };
+  }
+
   private handleClusterEnvelope(envelope: WebSocketClusterEnvelope): void {
     if (envelope.sourceNodeId === this.options.nodeId) {
+      this.telemetry.emit({
+        name: "ws.cluster.envelope.ignored",
+        level: "debug",
+        detail: { reason: "selfSource", event: envelope.event },
+      });
       return;
     }
 
@@ -67,15 +151,36 @@ export class WebSocketDeliveryEngine {
       envelope.targetNodeIds.length > 0 &&
       !envelope.targetNodeIds.includes(this.options.nodeId)
     ) {
+      this.telemetry.emit({
+        name: "ws.cluster.envelope.ignored",
+        level: "debug",
+        detail: { reason: "targetMismatch", event: envelope.event },
+      });
       return;
     }
 
+    const startedAt = performance.now();
+    this.telemetry.emit({
+      name: "ws.cluster.envelope.received",
+      level: "debug",
+      detail: { event: envelope.event, sourceNodeId: envelope.sourceNodeId },
+    });
+
     const routingPlan = this.options.audienceResolver.resolve(envelope.audience);
-    this.enqueueFanOut(
-      this.options.localConnections.getConnections(routingPlan.localSessionIds),
-      envelope.event,
-      envelope.data,
-    );
+    const localTargets = this.options.localConnections.getConnections(routingPlan.localSessionIds);
+    this.enqueueFanOut(localTargets, envelope.event, envelope.data);
+
+    this.telemetry.recordSpan({
+      operationName: "ws.cluster.receive",
+      kind: "consumer",
+      durationMs: performance.now() - startedAt,
+      status: "unset",
+      attributes: {
+        event: envelope.event,
+        sourceNodeId: envelope.sourceNodeId,
+        localTargetCount: localTargets.length,
+      },
+    });
   }
 
   private enqueueFanOut(targets: ManagedWebSocketConnection[], event: string, data: unknown): void {
@@ -88,6 +193,11 @@ export class WebSocketDeliveryEngine {
       event,
       data,
       cursor: 0,
+    });
+    this.telemetry.emit({
+      name: "ws.fanout.enqueued",
+      level: "debug",
+      detail: { targetCount: targets.length, event },
     });
     this.scheduleFanOutFlush();
   }
@@ -105,24 +215,48 @@ export class WebSocketDeliveryEngine {
   }
 
   private flushFanOutJobs(): void {
+    const startedAt = performance.now();
     let processed = 0;
+    let status: "unset" | "error" = "unset";
+    let errorType: string | undefined;
 
-    while (this.pendingFanOutJobs.length > 0 && processed < FAN_OUT_BATCH_SIZE) {
-      const job = this.pendingFanOutJobs[0];
+    try {
+      while (this.pendingFanOutJobs.length > 0 && processed < FAN_OUT_BATCH_SIZE) {
+        const job = this.pendingFanOutJobs[0];
 
-      while (job.cursor < job.targets.length && processed < FAN_OUT_BATCH_SIZE) {
-        this.safePublish(job.targets[job.cursor], job.event, job.data);
-        job.cursor += 1;
-        processed += 1;
+        while (job.cursor < job.targets.length && processed < FAN_OUT_BATCH_SIZE) {
+          this.safePublish(job.targets[job.cursor], job.event, job.data);
+          job.cursor += 1;
+          processed += 1;
+        }
+
+        if (job.cursor >= job.targets.length) {
+          this.pendingFanOutJobs.shift();
+        }
       }
+    } catch (error) {
+      status = "error";
+      errorType = error instanceof Error ? error.name : typeof error;
+      throw error;
+    } finally {
+      const durationMs = performance.now() - startedAt;
+      this.telemetry.emit({
+        name: "ws.fanout.flushed",
+        level: "debug",
+        detail: { processedCount: processed },
+      });
+      this.telemetry.recordSpan({
+        operationName: "ws.fanout.dispatch",
+        kind: "internal",
+        durationMs,
+        status,
+        attributes: { processedCount: processed },
+        errorType,
+      });
 
-      if (job.cursor >= job.targets.length) {
-        this.pendingFanOutJobs.shift();
+      if (this.pendingFanOutJobs.length > 0) {
+        this.scheduleFanOutFlush();
       }
-    }
-
-    if (this.pendingFanOutJobs.length > 0) {
-      this.scheduleFanOutFlush();
     }
   }
 
@@ -132,6 +266,12 @@ export class WebSocketDeliveryEngine {
         connection.publishUntyped(event, data);
       }
     } catch {
+      this.telemetry.emit({
+        name: "ws.fanout.publish.failed",
+        level: "error",
+        connectionId: connection.id,
+        detail: { event },
+      });
       connection.close(1011, "WebSocket publish failed");
     }
   }

--- a/modules/sonamu/src/stream/ws-local-connection-store.ts
+++ b/modules/sonamu/src/stream/ws-local-connection-store.ts
@@ -1,4 +1,8 @@
 import { type ManagedWebSocketConnection } from "./ws-core";
+import {
+  type WebSocketTelemetryConnectionSnapshot,
+  type TelemetryInspectableConnection,
+} from "./ws-telemetry";
 
 export class WebSocketLocalConnectionStore {
   private readonly connections = new Map<string, ManagedWebSocketConnection>();
@@ -36,9 +40,38 @@ export class WebSocketLocalConnectionStore {
     return targets;
   }
 
+  getTelemetrySnapshot(): WebSocketTelemetryConnectionSnapshot {
+    const snapshot: WebSocketTelemetryConnectionSnapshot = {
+      pendingInboundMessages: 0,
+      pendingOutboundMessages: 0,
+      socketBufferedBytes: 0,
+    };
+
+    for (const connection of this.connections.values()) {
+      if (!isTelemetryInspectableConnection(connection)) {
+        continue;
+      }
+
+      const connectionSnapshot = connection.getTelemetrySnapshot();
+      snapshot.pendingInboundMessages += connectionSnapshot.pendingInboundMessages;
+      snapshot.pendingOutboundMessages += connectionSnapshot.pendingOutboundMessages;
+      snapshot.socketBufferedBytes += connectionSnapshot.socketBufferedBytes;
+    }
+
+    return snapshot;
+  }
+
   closeAll(code?: number, reason?: string): void {
     for (const connection of this.connections.values()) {
       connection.close(code, reason);
     }
   }
+}
+
+function isTelemetryInspectableConnection(
+  connection: ManagedWebSocketConnection,
+): connection is ManagedWebSocketConnection & TelemetryInspectableConnection {
+  return (
+    "getTelemetrySnapshot" in connection && typeof connection.getTelemetrySnapshot === "function"
+  );
 }

--- a/modules/sonamu/src/stream/ws-registry.ts
+++ b/modules/sonamu/src/stream/ws-registry.ts
@@ -14,6 +14,12 @@ import {
   type WebSocketPresenceStore,
   type WebSocketSessionPresence,
 } from "./ws-presence-store";
+import {
+  type TelemetryContextProvider,
+  NoopWebSocketTelemetryController,
+  type WebSocketTelemetryConnectionContext,
+  type WebSocketTelemetryController,
+} from "./ws-telemetry";
 
 export type {
   ManagedWebSocketConnection,
@@ -27,6 +33,7 @@ export type WebSocketRegistryOptions = {
   nodeId?: string;
   presenceStore?: WebSocketPresenceStore;
   clusterBus?: WebSocketClusterBus;
+  telemetryController?: WebSocketTelemetryController;
 };
 
 export class WebSocketRegistry {
@@ -36,11 +43,14 @@ export class WebSocketRegistry {
   readonly clusterBus: WebSocketClusterBus;
   readonly audienceResolver: WebSocketAudienceResolver;
   readonly deliveryEngine: WebSocketDeliveryEngine;
+  readonly telemetryController: WebSocketTelemetryController;
 
   constructor(options: WebSocketRegistryOptions = {}) {
     this.nodeId = options.nodeId ?? "local";
     this.presenceStore = options.presenceStore ?? new InMemoryWebSocketPresenceStore();
     this.clusterBus = options.clusterBus ?? new NoopWebSocketClusterBus();
+    this.telemetryController =
+      options.telemetryController ?? new NoopWebSocketTelemetryController();
     this.audienceResolver = new WebSocketAudienceResolver({
       nodeId: this.nodeId,
       presenceStore: this.presenceStore,
@@ -50,6 +60,22 @@ export class WebSocketRegistry {
       localConnections: this.localConnections,
       audienceResolver: this.audienceResolver,
       clusterBus: this.clusterBus,
+      telemetryController: this.telemetryController,
+    });
+
+    this.telemetryController.registerMetricSource({
+      collect: (_now) => {
+        const stats = this.presenceStore.getStats();
+        const localSnapshot = this.localConnections.getTelemetrySnapshot();
+        return {
+          activeConnections: stats.totalConnections,
+          activeConnectionsByNamespace: stats.byNamespace,
+          roomCount: stats.totalRooms,
+          pendingInboundMessages: localSnapshot.pendingInboundMessages,
+          pendingOutboundMessages: localSnapshot.pendingOutboundMessages,
+          socketBufferedBytes: localSnapshot.socketBufferedBytes,
+        };
+      },
     });
   }
 
@@ -58,21 +84,66 @@ export class WebSocketRegistry {
     active: boolean = true,
   ): WebSocketConnectionMeta {
     this.localConnections.register(connection);
-    return this.presenceStore.register({
+    const meta = this.presenceStore.register({
       sessionId: connection.id,
       nodeId: this.nodeId,
       namespace: connection.namespace,
       active,
     });
+    this.telemetryController.emit({
+      name: "ws.connection.registered",
+      level: "info",
+      connectionId: connection.id,
+      namespace: connection.namespace,
+      ...getConnectionTelemetryContext(connection),
+    });
+    this.telemetryController.recordMetric({
+      name: "sonamu.ws.connections",
+      kind: "counter",
+      value: 1,
+      unit: "1",
+      tags: { outcome: "registered", namespace: connection.namespace },
+    });
+    return meta;
   }
 
   activate(connectionId: string): void {
+    if (!this.presenceStore.getConnection(connectionId)) {
+      this.emitMutationSkipped(connectionId, { operation: "activate" });
+      return;
+    }
+
     this.presenceStore.activate(connectionId);
+    this.telemetryController.emit({
+      name: "ws.connection.activated",
+      level: "info",
+      connectionId,
+      ...getConnectionTelemetryContext(this.localConnections.getConnection(connectionId)),
+    });
   }
 
   unregister(connectionId: string): void {
-    this.presenceStore.unregister(connectionId);
+    const telemetryContext = getConnectionTelemetryContext(
+      this.localConnections.getConnection(connectionId),
+    );
+    const meta = this.presenceStore.unregister(connectionId);
     this.localConnections.unregister(connectionId);
+    this.telemetryController.emit({
+      name: "ws.connection.unregistered",
+      level: "debug",
+      connectionId,
+      namespace: meta?.namespace,
+      ...telemetryContext,
+    });
+    if (meta) {
+      this.telemetryController.recordMetric({
+        name: "sonamu.ws.connections",
+        kind: "counter",
+        value: 1,
+        unit: "1",
+        tags: { outcome: "unregistered", namespace: meta.namespace },
+      });
+    }
   }
 
   touch(connectionId: string): void {
@@ -80,19 +151,92 @@ export class WebSocketRegistry {
   }
 
   setUserId(connectionId: string, userId: WebSocketUserId): void {
+    if (!this.presenceStore.getConnection(connectionId)) {
+      this.emitMutationSkipped(connectionId, { operation: "setUserId", userId });
+      return;
+    }
+
     this.presenceStore.setUserId(connectionId, userId);
+    const meta = this.presenceStore.getConnection(connectionId);
+    this.telemetryController.emit({
+      name: "ws.user.bound",
+      level: "debug",
+      connectionId,
+      namespace: meta?.namespace,
+      detail: { userId },
+      ...getConnectionTelemetryContext(this.localConnections.getConnection(connectionId)),
+    });
   }
 
   clearUserId(connectionId: string): void {
+    const meta = this.presenceStore.getConnection(connectionId);
+    if (!meta) {
+      this.emitMutationSkipped(connectionId, { operation: "clearUserId" });
+      return;
+    }
+
+    const userId = meta.userId;
     this.presenceStore.clearUserId(connectionId);
+    this.telemetryController.emit({
+      name: "ws.user.cleared",
+      level: "debug",
+      connectionId,
+      namespace: meta.namespace,
+      detail: userId !== undefined ? { userId } : undefined,
+      ...getConnectionTelemetryContext(this.localConnections.getConnection(connectionId)),
+    });
   }
 
   join(connectionId: string, roomId: WebSocketRoomId): void {
+    if (!this.presenceStore.getConnection(connectionId)) {
+      this.emitMutationSkipped(connectionId, { operation: "join", roomId });
+      return;
+    }
+
     this.presenceStore.join(connectionId, roomId);
+    const meta = this.presenceStore.getConnection(connectionId);
+    this.telemetryController.emit({
+      name: "ws.room.joined",
+      level: "debug",
+      connectionId,
+      namespace: meta?.namespace,
+      detail: { roomId },
+      ...getConnectionTelemetryContext(this.localConnections.getConnection(connectionId)),
+    });
   }
 
   leave(connectionId: string, roomId: WebSocketRoomId): void {
+    const meta = this.presenceStore.getConnection(connectionId);
+    if (!meta) {
+      this.emitMutationSkipped(connectionId, { operation: "leave", roomId });
+      return;
+    }
+
     this.presenceStore.leave(connectionId, roomId);
+    this.telemetryController.emit({
+      name: "ws.room.left",
+      level: "debug",
+      connectionId,
+      namespace: meta.namespace,
+      detail: { roomId },
+      ...getConnectionTelemetryContext(this.localConnections.getConnection(connectionId)),
+    });
+  }
+
+  private emitMutationSkipped(
+    connectionId: string,
+    detail: {
+      operation: "activate" | "setUserId" | "clearUserId" | "join" | "leave";
+      roomId?: WebSocketRoomId;
+      userId?: WebSocketUserId;
+    },
+  ): void {
+    this.telemetryController.emit({
+      name: "ws.registry.mutation.skipped",
+      level: "debug",
+      connectionId,
+      detail: { ...detail, reason: "connectionMissing" },
+    });
   }
 
   broadcast(event: string, data: unknown, namespace?: string): void {
@@ -135,4 +279,22 @@ export class WebSocketRegistry {
     this.closeAll(code, reason);
     await this.deliveryEngine.shutdown();
   }
+}
+
+function getConnectionTelemetryContext(
+  connection: ManagedWebSocketConnection | undefined,
+): WebSocketTelemetryConnectionContext {
+  if (!connection || !isTelemetryContextProvider(connection)) {
+    return {};
+  }
+
+  return connection.getTelemetryContext();
+}
+
+function isTelemetryContextProvider(
+  connection: ManagedWebSocketConnection,
+): connection is ManagedWebSocketConnection & TelemetryContextProvider {
+  return (
+    "getTelemetryContext" in connection && typeof connection.getTelemetryContext === "function"
+  );
 }

--- a/modules/sonamu/src/stream/ws-registry.ts
+++ b/modules/sonamu/src/stream/ws-registry.ts
@@ -95,6 +95,7 @@ export class WebSocketRegistry {
       level: "info",
       connectionId: connection.id,
       namespace: connection.namespace,
+      userId: connection.userId,
       ...getConnectionTelemetryContext(connection),
     });
     this.telemetryController.recordMetric({
@@ -103,6 +104,7 @@ export class WebSocketRegistry {
       value: 1,
       unit: "1",
       tags: { outcome: "registered", namespace: connection.namespace },
+      userId: connection.userId,
     });
     return meta;
   }
@@ -114,18 +116,21 @@ export class WebSocketRegistry {
     }
 
     this.presenceStore.activate(connectionId);
+    const connection = this.localConnections.getConnection(connectionId);
     this.telemetryController.emit({
       name: "ws.connection.activated",
       level: "info",
       connectionId,
-      ...getConnectionTelemetryContext(this.localConnections.getConnection(connectionId)),
+      userId: connection?.userId,
+      ...getConnectionTelemetryContext(connection),
     });
   }
 
   unregister(connectionId: string): void {
-    const telemetryContext = getConnectionTelemetryContext(
-      this.localConnections.getConnection(connectionId),
-    );
+    const connection = this.localConnections.getConnection(connectionId);
+    const telemetryContext = getConnectionTelemetryContext(connection);
+    const userId =
+      connection?.userId ?? formatUserId(this.presenceStore.getConnection(connectionId)?.userId);
     const meta = this.presenceStore.unregister(connectionId);
     this.localConnections.unregister(connectionId);
     this.telemetryController.emit({
@@ -133,6 +138,7 @@ export class WebSocketRegistry {
       level: "debug",
       connectionId,
       namespace: meta?.namespace,
+      userId,
       ...telemetryContext,
     });
     if (meta) {
@@ -142,6 +148,7 @@ export class WebSocketRegistry {
         value: 1,
         unit: "1",
         tags: { outcome: "unregistered", namespace: meta.namespace },
+        userId,
       });
     }
   }
@@ -163,6 +170,7 @@ export class WebSocketRegistry {
       level: "debug",
       connectionId,
       namespace: meta?.namespace,
+      userId: String(userId),
       detail: { userId },
       ...getConnectionTelemetryContext(this.localConnections.getConnection(connectionId)),
     });
@@ -182,6 +190,7 @@ export class WebSocketRegistry {
       level: "debug",
       connectionId,
       namespace: meta.namespace,
+      userId: formatUserId(userId),
       detail: userId !== undefined ? { userId } : undefined,
       ...getConnectionTelemetryContext(this.localConnections.getConnection(connectionId)),
     });
@@ -195,13 +204,15 @@ export class WebSocketRegistry {
 
     this.presenceStore.join(connectionId, roomId);
     const meta = this.presenceStore.getConnection(connectionId);
+    const connection = this.localConnections.getConnection(connectionId);
     this.telemetryController.emit({
       name: "ws.room.joined",
       level: "debug",
       connectionId,
       namespace: meta?.namespace,
+      userId: connection?.userId ?? formatUserId(meta?.userId),
       detail: { roomId },
-      ...getConnectionTelemetryContext(this.localConnections.getConnection(connectionId)),
+      ...getConnectionTelemetryContext(connection),
     });
   }
 
@@ -213,13 +224,15 @@ export class WebSocketRegistry {
     }
 
     this.presenceStore.leave(connectionId, roomId);
+    const connection = this.localConnections.getConnection(connectionId);
     this.telemetryController.emit({
       name: "ws.room.left",
       level: "debug",
       connectionId,
       namespace: meta.namespace,
+      userId: connection?.userId ?? formatUserId(meta.userId),
       detail: { roomId },
-      ...getConnectionTelemetryContext(this.localConnections.getConnection(connectionId)),
+      ...getConnectionTelemetryContext(connection),
     });
   }
 
@@ -289,6 +302,11 @@ function getConnectionTelemetryContext(
   }
 
   return connection.getTelemetryContext();
+}
+
+// telemetry record의 userId는 string 정규화 — presence store는 number | string 그대로 보관함
+function formatUserId(userId: WebSocketUserId | undefined): string | undefined {
+  return userId === undefined ? undefined : String(userId);
 }
 
 function isTelemetryContextProvider(

--- a/modules/sonamu/src/stream/ws-registry.ts
+++ b/modules/sonamu/src/stream/ws-registry.ts
@@ -30,7 +30,8 @@ export type {
 export type WebSocketConnectionMeta = WebSocketSessionPresence;
 
 export type WebSocketRegistryOptions = {
-  nodeId?: string;
+  // 분산 환경에서 노드 간 라우팅 식별자로 쓰이므로 반드시 호출 측(WebSocketRuntime)에서 결정해 넘긴다
+  nodeId: string;
   presenceStore?: WebSocketPresenceStore;
   clusterBus?: WebSocketClusterBus;
   telemetryController?: WebSocketTelemetryController;
@@ -45,8 +46,8 @@ export class WebSocketRegistry {
   readonly deliveryEngine: WebSocketDeliveryEngine;
   readonly telemetryController: WebSocketTelemetryController;
 
-  constructor(options: WebSocketRegistryOptions = {}) {
-    this.nodeId = options.nodeId ?? "local";
+  constructor(options: WebSocketRegistryOptions) {
+    this.nodeId = options.nodeId;
     this.presenceStore = options.presenceStore ?? new InMemoryWebSocketPresenceStore();
     this.clusterBus = options.clusterBus ?? new NoopWebSocketClusterBus();
     this.telemetryController =

--- a/modules/sonamu/src/stream/ws-telemetry-memory.ts
+++ b/modules/sonamu/src/stream/ws-telemetry-memory.ts
@@ -1,0 +1,283 @@
+import {
+  type WebSocketTelemetryEventQueryFilter,
+  type WebSocketTelemetryEventRecord,
+  type WebSocketTelemetryEventSink,
+  type WebSocketTelemetryEventStore,
+  type WebSocketTelemetryMetricQueryFilter,
+  type WebSocketTelemetryMetricRecord,
+  type WebSocketTelemetryMetricSink,
+  type WebSocketTelemetryMetricStore,
+  type WebSocketTelemetrySpanQueryFilter,
+  type WebSocketTelemetrySpanRecord,
+  type WebSocketTelemetrySpanSink,
+  type WebSocketTelemetrySpanStore,
+} from "./ws-telemetry";
+
+type InMemoryStoreOptions = {
+  maxRecords?: number;
+  maxBytes?: number;
+};
+
+const DEFAULT_MAX_RECORDS = 10_000;
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024; // 10 MiB
+const CRITICAL_LEVEL_MIN_RESERVE = 100; // warn/error/closed/rejected를 위해 예약하는 최소 record 수
+
+type EstimateBytes<TRecord> = (record: TRecord) => number;
+type IsCritical<TRecord> = (record: TRecord) => boolean;
+
+/**
+ * 3개의 신호별 InMemory store가 공유하는 ring buffer helper.
+ * 외부로 export하지 않는다.
+ */
+class InMemoryRingBuffer<TRecord extends { timestamp: number }> {
+  private readonly records: TRecord[] = [];
+  private readonly maxRecords: number;
+  private readonly maxBytes: number;
+  private readonly estimateBytes: EstimateBytes<TRecord>;
+  private readonly isCritical: IsCritical<TRecord>;
+  private currentBytes = 0;
+
+  constructor(
+    options: InMemoryStoreOptions,
+    estimateBytes: EstimateBytes<TRecord>,
+    isCritical: IsCritical<TRecord>,
+  ) {
+    this.maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+    this.maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+    this.estimateBytes = estimateBytes;
+    this.isCritical = isCritical;
+  }
+
+  push(record: TRecord): void {
+    const recordSize = this.estimateBytes(record);
+    const incomingCritical = this.isCritical(record);
+
+    // 용량을 초과하는 동안 evict 수행
+    while (
+      (this.records.length >= this.maxRecords || this.currentBytes + recordSize > this.maxBytes) &&
+      this.records.length > 0
+    ) {
+      if (!this.evictOne(incomingCritical)) {
+        return;
+      }
+    }
+
+    this.records.push(record);
+    this.currentBytes += recordSize;
+  }
+
+  filter(predicate: (record: TRecord) => boolean, limit?: number): TRecord[] {
+    const matched: TRecord[] = [];
+    for (const record of this.records) {
+      if (predicate(record)) matched.push(record);
+    }
+    if (limit !== undefined && limit > 0 && matched.length > limit) {
+      return matched.slice(-limit);
+    }
+    return matched;
+  }
+
+  clear(): void {
+    this.records.length = 0;
+    this.currentBytes = 0;
+  }
+
+  private evictOne(incomingCritical: boolean): boolean {
+    const criticalCount = this.countCriticalRecords();
+    const criticalReserve = Math.min(CRITICAL_LEVEL_MIN_RESERVE, this.maxRecords);
+
+    // 우선 non-critical record부터 evict 시도
+    for (let i = 0; i < this.records.length; i++) {
+      if (!this.isCritical(this.records[i])) {
+        const removed = this.records.splice(i, 1);
+        this.currentBytes -= this.estimateBytes(removed[0]);
+        return true;
+      }
+    }
+
+    // 모든 record가 critical인 경우. 들어오는 record가 critical이라면 오래된 critical record를 대체할 수 있으나,
+    // non-critical record는 진단용으로 예약된 최소량을 침범해서는 안 됨.
+    if (incomingCritical || criticalCount > criticalReserve) {
+      const removed = this.records.shift();
+      if (removed) {
+        this.currentBytes -= this.estimateBytes(removed);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  private countCriticalRecords(): number {
+    let count = 0;
+    for (const record of this.records) {
+      if (this.isCritical(record)) count += 1;
+    }
+    return count;
+  }
+}
+
+function applyTimeWindow<TRecord extends { timestamp: number }>(
+  record: TRecord,
+  since: number | undefined,
+  until: number | undefined,
+): boolean {
+  if (since !== undefined && record.timestamp < since) return false;
+  if (until !== undefined && record.timestamp > until) return false;
+  return true;
+}
+
+function estimateEventBytes(record: WebSocketTelemetryEventRecord): number {
+  let size = 200;
+  if (record.payloadPreview !== undefined) {
+    try {
+      size += Buffer.byteLength(JSON.stringify(record.payloadPreview), "utf-8");
+    } catch {
+      size += 100;
+    }
+  }
+  if (record.detail) {
+    try {
+      size += Buffer.byteLength(JSON.stringify(record.detail), "utf-8");
+    } catch {
+      size += 100;
+    }
+  }
+  return size;
+}
+
+function isEventCritical(record: WebSocketTelemetryEventRecord): boolean {
+  if (record.level === "warn" || record.level === "error") return true;
+  if (record.name.includes("closed") || record.name.includes("rejected")) return true;
+  return false;
+}
+
+function estimateMetricBytes(_record: WebSocketTelemetryMetricRecord): number {
+  return 200;
+}
+
+function isMetricCritical(_record: WebSocketTelemetryMetricRecord): boolean {
+  return false;
+}
+
+function estimateSpanBytes(_record: WebSocketTelemetrySpanRecord): number {
+  return 200;
+}
+
+function isSpanCritical(record: WebSocketTelemetrySpanRecord): boolean {
+  return record.status === "error";
+}
+
+export class InMemoryEventStore implements WebSocketTelemetryEventStore {
+  readonly sink: WebSocketTelemetryEventSink;
+
+  private readonly buffer: InMemoryRingBuffer<WebSocketTelemetryEventRecord>;
+
+  constructor(options: InMemoryStoreOptions = {}) {
+    this.buffer = new InMemoryRingBuffer<WebSocketTelemetryEventRecord>(
+      options,
+      estimateEventBytes,
+      isEventCritical,
+    );
+
+    // has-a 관계: store가 sink를 구현하는 것이 아니라 sink를 보유함
+    this.sink = {
+      emit: (record: WebSocketTelemetryEventRecord): void => {
+        this.buffer.push(record);
+      },
+    };
+  }
+
+  query(filter: WebSocketTelemetryEventQueryFilter): WebSocketTelemetryEventRecord[] {
+    return this.buffer.filter((record) => {
+      if (filter.name !== undefined && record.name !== filter.name) return false;
+      if (filter.level !== undefined && record.level !== filter.level) return false;
+      if (filter.connectionId !== undefined && record.connectionId !== filter.connectionId)
+        return false;
+      if (filter.namespace !== undefined && record.namespace !== filter.namespace) return false;
+      if (filter.traceId !== undefined && record.traceId !== filter.traceId) return false;
+      if (!applyTimeWindow(record, filter.since, filter.until)) return false;
+      return true;
+    }, filter.limit);
+  }
+
+  clear(): void {
+    this.buffer.clear();
+  }
+}
+
+export class InMemoryMetricStore implements WebSocketTelemetryMetricStore {
+  readonly sink: WebSocketTelemetryMetricSink;
+
+  private readonly buffer: InMemoryRingBuffer<WebSocketTelemetryMetricRecord>;
+
+  constructor(options: InMemoryStoreOptions = {}) {
+    this.buffer = new InMemoryRingBuffer<WebSocketTelemetryMetricRecord>(
+      options,
+      estimateMetricBytes,
+      isMetricCritical,
+    );
+
+    this.sink = {
+      emit: (record: WebSocketTelemetryMetricRecord): void => {
+        this.buffer.push(record);
+      },
+    };
+  }
+
+  query(filter: WebSocketTelemetryMetricQueryFilter): WebSocketTelemetryMetricRecord[] {
+    return this.buffer.filter((record) => {
+      if (filter.name !== undefined && record.name !== filter.name) return false;
+      if (filter.kind !== undefined && record.kind !== filter.kind) return false;
+      if (filter.connectionId !== undefined && record.connectionId !== filter.connectionId)
+        return false;
+      if (filter.namespace !== undefined && record.namespace !== filter.namespace) return false;
+      if (filter.traceId !== undefined && record.traceId !== filter.traceId) return false;
+      if (!applyTimeWindow(record, filter.since, filter.until)) return false;
+      return true;
+    }, filter.limit);
+  }
+
+  clear(): void {
+    this.buffer.clear();
+  }
+}
+
+export class InMemorySpanStore implements WebSocketTelemetrySpanStore {
+  readonly sink: WebSocketTelemetrySpanSink;
+
+  private readonly buffer: InMemoryRingBuffer<WebSocketTelemetrySpanRecord>;
+
+  constructor(options: InMemoryStoreOptions = {}) {
+    this.buffer = new InMemoryRingBuffer<WebSocketTelemetrySpanRecord>(
+      options,
+      estimateSpanBytes,
+      isSpanCritical,
+    );
+
+    this.sink = {
+      emit: (record: WebSocketTelemetrySpanRecord): void => {
+        this.buffer.push(record);
+      },
+    };
+  }
+
+  query(filter: WebSocketTelemetrySpanQueryFilter): WebSocketTelemetrySpanRecord[] {
+    return this.buffer.filter((record) => {
+      if (filter.operationName !== undefined && record.operationName !== filter.operationName)
+        return false;
+      if (filter.kind !== undefined && record.kind !== filter.kind) return false;
+      if (filter.status !== undefined && record.status !== filter.status) return false;
+      if (filter.connectionId !== undefined && record.connectionId !== filter.connectionId)
+        return false;
+      if (filter.namespace !== undefined && record.namespace !== filter.namespace) return false;
+      if (filter.traceId !== undefined && record.traceId !== filter.traceId) return false;
+      if (!applyTimeWindow(record, filter.since, filter.until)) return false;
+      return true;
+    }, filter.limit);
+  }
+
+  clear(): void {
+    this.buffer.clear();
+  }
+}

--- a/modules/sonamu/src/stream/ws-telemetry-memory.ts
+++ b/modules/sonamu/src/stream/ws-telemetry-memory.ts
@@ -159,6 +159,7 @@ export class InMemoryEventStore implements WebSocketTelemetryEventStore {
       if (filter.level !== undefined && record.level !== filter.level) return false;
       if (filter.connectionId !== undefined && record.connectionId !== filter.connectionId)
         return false;
+      if (filter.userId !== undefined && record.userId !== filter.userId) return false;
       if (filter.namespace !== undefined && record.namespace !== filter.namespace) return false;
       if (filter.traceId !== undefined && record.traceId !== filter.traceId) return false;
       if (!applyTimeWindow(record, filter.since, filter.until)) return false;
@@ -195,6 +196,7 @@ export class InMemoryMetricStore implements WebSocketTelemetryMetricStore {
       if (filter.kind !== undefined && record.kind !== filter.kind) return false;
       if (filter.connectionId !== undefined && record.connectionId !== filter.connectionId)
         return false;
+      if (filter.userId !== undefined && record.userId !== filter.userId) return false;
       if (filter.namespace !== undefined && record.namespace !== filter.namespace) return false;
       if (filter.traceId !== undefined && record.traceId !== filter.traceId) return false;
       if (!applyTimeWindow(record, filter.since, filter.until)) return false;
@@ -230,6 +232,7 @@ export class InMemorySpanStore implements WebSocketTelemetrySpanStore {
       if (filter.status !== undefined && record.status !== filter.status) return false;
       if (filter.connectionId !== undefined && record.connectionId !== filter.connectionId)
         return false;
+      if (filter.userId !== undefined && record.userId !== filter.userId) return false;
       if (filter.namespace !== undefined && record.namespace !== filter.namespace) return false;
       if (filter.traceId !== undefined && record.traceId !== filter.traceId) return false;
       if (!applyTimeWindow(record, filter.since, filter.until)) return false;

--- a/modules/sonamu/src/stream/ws-telemetry-memory.ts
+++ b/modules/sonamu/src/stream/ws-telemetry-memory.ts
@@ -20,56 +20,66 @@ type InMemoryStoreOptions = {
 
 const DEFAULT_MAX_RECORDS = 10_000;
 const DEFAULT_MAX_BYTES = 10 * 1024 * 1024; // 10 MiB
-const CRITICAL_LEVEL_MIN_RESERVE = 100; // warn/error/closed/rejected를 위해 예약하는 최소 record 수
 
 type EstimateBytes<TRecord> = (record: TRecord) => number;
-type IsCritical<TRecord> = (record: TRecord) => boolean;
 
-/**
- * 3개의 신호별 InMemory store가 공유하는 ring buffer helper.
- * 외부로 export하지 않는다.
- */
+// 단일 FIFO ring buffer. critical/non-critical 우선순위는 두지 않는다 —
+// 인메모리 store는 휘발성 디버깅 용도이므로 critical 보존이 필요하면
+// 별도의 영속 sink를 등록해서 처리한다.
 class InMemoryRingBuffer<TRecord extends { timestamp: number }> {
-  private readonly records: TRecord[] = [];
-  private readonly maxRecords: number;
+  private readonly slots: Array<TRecord | undefined>;
+  private readonly slotBytes: number[];
+  private readonly capacity: number;
   private readonly maxBytes: number;
   private readonly estimateBytes: EstimateBytes<TRecord>;
-  private readonly isCritical: IsCritical<TRecord>;
+  private head = 0;
+  private count = 0;
   private currentBytes = 0;
 
-  constructor(
-    options: InMemoryStoreOptions,
-    estimateBytes: EstimateBytes<TRecord>,
-    isCritical: IsCritical<TRecord>,
-  ) {
-    this.maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+  constructor(options: InMemoryStoreOptions, estimateBytes: EstimateBytes<TRecord>) {
+    this.capacity = options.maxRecords ?? DEFAULT_MAX_RECORDS;
     this.maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
     this.estimateBytes = estimateBytes;
-    this.isCritical = isCritical;
+    this.slots = new Array(this.capacity);
+    this.slotBytes = new Array(this.capacity).fill(0);
   }
 
   push(record: TRecord): void {
-    const recordSize = this.estimateBytes(record);
-    const incomingCritical = this.isCritical(record);
+    if (this.capacity <= 0) return;
 
-    // 용량을 초과하는 동안 evict 수행
-    while (
-      (this.records.length >= this.maxRecords || this.currentBytes + recordSize > this.maxBytes) &&
-      this.records.length > 0
-    ) {
-      if (!this.evictOne(incomingCritical)) {
-        return;
-      }
+    const recordSize = this.estimateBytes(record);
+    // 단일 record가 maxBytes를 넘으면 받아들이지 않는다.
+    if (recordSize > this.maxBytes) return;
+
+    if (this.count === this.capacity) {
+      // 가장 오래된 슬롯을 덮어쓴다.
+      this.currentBytes -= this.slotBytes[this.head];
+      this.slots[this.head] = record;
+      this.slotBytes[this.head] = recordSize;
+      this.currentBytes += recordSize;
+      this.head = (this.head + 1) % this.capacity;
+    } else {
+      const tail = (this.head + this.count) % this.capacity;
+      this.slots[tail] = record;
+      this.slotBytes[tail] = recordSize;
+      this.currentBytes += recordSize;
+      this.count += 1;
     }
 
-    this.records.push(record);
-    this.currentBytes += recordSize;
+    while (this.currentBytes > this.maxBytes && this.count > 1) {
+      this.currentBytes -= this.slotBytes[this.head];
+      this.slots[this.head] = undefined;
+      this.slotBytes[this.head] = 0;
+      this.head = (this.head + 1) % this.capacity;
+      this.count -= 1;
+    }
   }
 
   filter(predicate: (record: TRecord) => boolean, limit?: number): TRecord[] {
     const matched: TRecord[] = [];
-    for (const record of this.records) {
-      if (predicate(record)) matched.push(record);
+    for (let i = 0; i < this.count; i++) {
+      const record = this.slots[(this.head + i) % this.capacity];
+      if (record !== undefined && predicate(record)) matched.push(record);
     }
     if (limit !== undefined && limit > 0 && matched.length > limit) {
       return matched.slice(-limit);
@@ -78,42 +88,13 @@ class InMemoryRingBuffer<TRecord extends { timestamp: number }> {
   }
 
   clear(): void {
-    this.records.length = 0;
+    for (let i = 0; i < this.capacity; i++) {
+      this.slots[i] = undefined;
+      this.slotBytes[i] = 0;
+    }
+    this.head = 0;
+    this.count = 0;
     this.currentBytes = 0;
-  }
-
-  private evictOne(incomingCritical: boolean): boolean {
-    const criticalCount = this.countCriticalRecords();
-    const criticalReserve = Math.min(CRITICAL_LEVEL_MIN_RESERVE, this.maxRecords);
-
-    // 우선 non-critical record부터 evict 시도
-    for (let i = 0; i < this.records.length; i++) {
-      if (!this.isCritical(this.records[i])) {
-        const removed = this.records.splice(i, 1);
-        this.currentBytes -= this.estimateBytes(removed[0]);
-        return true;
-      }
-    }
-
-    // 모든 record가 critical인 경우. 들어오는 record가 critical이라면 오래된 critical record를 대체할 수 있으나,
-    // non-critical record는 진단용으로 예약된 최소량을 침범해서는 안 됨.
-    if (incomingCritical || criticalCount > criticalReserve) {
-      const removed = this.records.shift();
-      if (removed) {
-        this.currentBytes -= this.estimateBytes(removed);
-      }
-      return true;
-    }
-
-    return false;
-  }
-
-  private countCriticalRecords(): number {
-    let count = 0;
-    for (const record of this.records) {
-      if (this.isCritical(record)) count += 1;
-    }
-    return count;
   }
 }
 
@@ -146,26 +127,12 @@ function estimateEventBytes(record: WebSocketTelemetryEventRecord): number {
   return size;
 }
 
-function isEventCritical(record: WebSocketTelemetryEventRecord): boolean {
-  if (record.level === "warn" || record.level === "error") return true;
-  if (record.name.includes("closed") || record.name.includes("rejected")) return true;
-  return false;
-}
-
 function estimateMetricBytes(_record: WebSocketTelemetryMetricRecord): number {
   return 200;
 }
 
-function isMetricCritical(_record: WebSocketTelemetryMetricRecord): boolean {
-  return false;
-}
-
 function estimateSpanBytes(_record: WebSocketTelemetrySpanRecord): number {
   return 200;
-}
-
-function isSpanCritical(record: WebSocketTelemetrySpanRecord): boolean {
-  return record.status === "error";
 }
 
 export class InMemoryEventStore implements WebSocketTelemetryEventStore {
@@ -177,10 +144,8 @@ export class InMemoryEventStore implements WebSocketTelemetryEventStore {
     this.buffer = new InMemoryRingBuffer<WebSocketTelemetryEventRecord>(
       options,
       estimateEventBytes,
-      isEventCritical,
     );
 
-    // has-a 관계: store가 sink를 구현하는 것이 아니라 sink를 보유함
     this.sink = {
       emit: (record: WebSocketTelemetryEventRecord): void => {
         this.buffer.push(record);
@@ -215,7 +180,6 @@ export class InMemoryMetricStore implements WebSocketTelemetryMetricStore {
     this.buffer = new InMemoryRingBuffer<WebSocketTelemetryMetricRecord>(
       options,
       estimateMetricBytes,
-      isMetricCritical,
     );
 
     this.sink = {
@@ -249,11 +213,7 @@ export class InMemorySpanStore implements WebSocketTelemetrySpanStore {
   private readonly buffer: InMemoryRingBuffer<WebSocketTelemetrySpanRecord>;
 
   constructor(options: InMemoryStoreOptions = {}) {
-    this.buffer = new InMemoryRingBuffer<WebSocketTelemetrySpanRecord>(
-      options,
-      estimateSpanBytes,
-      isSpanCritical,
-    );
+    this.buffer = new InMemoryRingBuffer<WebSocketTelemetrySpanRecord>(options, estimateSpanBytes);
 
     this.sink = {
       emit: (record: WebSocketTelemetrySpanRecord): void => {

--- a/modules/sonamu/src/stream/ws-telemetry-trace.ts
+++ b/modules/sonamu/src/stream/ws-telemetry-trace.ts
@@ -1,0 +1,52 @@
+import { randomBytes } from "node:crypto";
+
+export type ParsedTraceParent = {
+  version: string;
+  traceId: string;
+  parentId: string;
+  traceFlags: number;
+  sampled: boolean;
+};
+
+// traceparent 포맷: 00-<32 hex traceId>-<16 hex spanId>-<2 hex flags>
+// 예시: 00-4bf92f3577b16d8a2e3e24ff02e6c998-00f067aa0ba902b7-01
+const TRACEPARENT_REGEX = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+const ALL_ZERO_TRACE_ID = "00000000000000000000000000000000";
+const ALL_ZERO_SPAN_ID = "0000000000000000";
+
+export function parseTraceParent(header: string): ParsedTraceParent | null {
+  const trimmed = header.trim().toLowerCase();
+  const match = TRACEPARENT_REGEX.exec(trimmed);
+  if (!match) return null;
+
+  const [, version, traceId, parentId, flagsHex] = match;
+
+  // ff는 W3C Trace Context 스펙에서 invalid version marker로 예약되어 있음
+  if (version === "ff") return null;
+
+  // W3C 스펙에 따라 모두 0인 trace id / span id는 유효하지 않음
+  if (traceId === ALL_ZERO_TRACE_ID || parentId === ALL_ZERO_SPAN_ID) return null;
+
+  const traceFlags = parseInt(flagsHex, 16);
+
+  return {
+    version,
+    traceId,
+    parentId,
+    traceFlags,
+    sampled: (traceFlags & 0x01) === 1,
+  };
+}
+
+export function generateTraceId(): string {
+  return randomBytes(16).toString("hex");
+}
+
+export function generateSpanId(): string {
+  return randomBytes(8).toString("hex");
+}
+
+export function formatTraceParent(traceId: string, spanId: string, sampled: boolean): string {
+  const flags = sampled ? "01" : "00";
+  return `00-${traceId}-${spanId}-${flags}`;
+}

--- a/modules/sonamu/src/stream/ws-telemetry.ts
+++ b/modules/sonamu/src/stream/ws-telemetry.ts
@@ -1,0 +1,1760 @@
+import { InMemoryEventStore, InMemoryMetricStore, InMemorySpanStore } from "./ws-telemetry-memory";
+import { generateSpanId, generateTraceId, parseTraceParent } from "./ws-telemetry-trace";
+
+// -- Record types (unchanged) --
+
+export type WebSocketTelemetryRecordBase = {
+  timestamp: number;
+  monotonicTime?: number;
+  runtimeId: string;
+  nodeId: string;
+  namespace?: string;
+  connectionId?: string;
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  sampled?: boolean;
+};
+
+export type WebSocketTelemetryEventRecord = WebSocketTelemetryRecordBase & {
+  type: "event";
+  name: string;
+  level: "debug" | "info" | "warn" | "error";
+  attributes?: Record<string, string | number | boolean>;
+  detail?: Record<string, unknown>;
+  payloadPreview?: string;
+};
+
+export type WebSocketTelemetryMetricRecord = WebSocketTelemetryRecordBase & {
+  type: "metric";
+  name: string;
+  kind: "counter" | "histogram" | "gauge";
+  value: number;
+  unit?: "1" | "ms" | "By";
+  tags?: Record<string, string>;
+  snapshot?: WebSocketTelemetryMetricsSnapshot;
+};
+
+export type WebSocketTelemetrySpanRecord = WebSocketTelemetryRecordBase & {
+  type: "span";
+  operationName: string;
+  kind: "internal" | "producer" | "consumer" | "server" | "client";
+  durationMs: number;
+  status: "unset" | "ok" | "error";
+  attributes?: Record<string, string | number | boolean>;
+  errorType?: string;
+  events?: Array<{
+    name: string;
+    timestamp: number;
+    attributes?: Record<string, unknown>;
+  }>;
+  links?: Array<{
+    traceId: string;
+    spanId: string;
+    attributes?: Record<string, unknown>;
+  }>;
+};
+
+export type WebSocketTelemetryRecord =
+  | WebSocketTelemetryEventRecord
+  | WebSocketTelemetryMetricRecord
+  | WebSocketTelemetrySpanRecord;
+
+// -- Input types (unchanged) --
+
+export type WebSocketTelemetryEventInput = {
+  name: string;
+  level: "debug" | "info" | "warn" | "error";
+  namespace?: string;
+  connectionId?: string;
+  attributes?: Record<string, string | number | boolean>;
+  detail?: Record<string, unknown>;
+  payload?: unknown;
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  sampled?: boolean;
+};
+
+export type WebSocketMetricInput = {
+  name: string;
+  kind: "counter" | "histogram" | "gauge";
+  value: number;
+  unit?: "1" | "ms" | "By";
+  tags?: Record<string, string>;
+  namespace?: string;
+  connectionId?: string;
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  sampled?: boolean;
+  snapshot?: WebSocketTelemetryMetricsSnapshot;
+};
+
+export type WebSocketSpanInput = {
+  operationName: string;
+  kind: "internal" | "producer" | "consumer" | "server" | "client";
+  durationMs: number;
+  status: "unset" | "ok" | "error";
+  namespace?: string;
+  connectionId?: string;
+  attributes?: Record<string, string | number | boolean>;
+  errorType?: string;
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  sampled?: boolean;
+  events?: Array<{
+    name: string;
+    timestamp: number;
+    attributes?: Record<string, unknown>;
+  }>;
+  links?: Array<{
+    traceId: string;
+    spanId: string;
+    attributes?: Record<string, unknown>;
+  }>;
+};
+
+export type WebSocketTelemetryInput =
+  | ({ type: "event" } & WebSocketTelemetryEventInput)
+  | ({ type: "metric" } & WebSocketMetricInput)
+  | ({ type: "span" } & WebSocketSpanInput);
+
+// -- Metrics snapshot --
+
+export type WebSocketTelemetryMetricsSnapshot = {
+  timestamp: number;
+  activeConnections: number;
+  activeConnectionsByNamespace: Record<string, number>;
+  roomCount: number;
+  pendingInboundMessages: number;
+  pendingOutboundMessages: number;
+  socketBufferedBytes: number;
+  pendingFanOutJobs: number;
+  pendingFanOutTargets: number;
+  telemetryDroppedRecords: number;
+  telemetrySinkFailures: number;
+};
+
+// -- Connection snapshot (TelemetryInspectableConnection) --
+
+export type WebSocketTelemetryConnectionSnapshot = {
+  pendingInboundMessages: number;
+  pendingOutboundMessages: number;
+  socketBufferedBytes: number;
+};
+
+export interface TelemetryInspectableConnection {
+  getTelemetrySnapshot(): WebSocketTelemetryConnectionSnapshot;
+}
+
+// -- Signal-narrowed sinks --
+
+export interface WebSocketTelemetryEventSink {
+  emit(record: WebSocketTelemetryEventRecord): void | Promise<void>;
+  shutdown?(options?: { timeoutMs?: number }): void | Promise<void>;
+}
+
+export interface WebSocketTelemetryMetricSink {
+  emit(record: WebSocketTelemetryMetricRecord): void | Promise<void>;
+  shutdown?(options?: { timeoutMs?: number }): void | Promise<void>;
+}
+
+export interface WebSocketTelemetrySpanSink {
+  emit(record: WebSocketTelemetrySpanRecord): void | Promise<void>;
+  shutdown?(options?: { timeoutMs?: number }): void | Promise<void>;
+}
+
+// -- Signal-narrowed query filters --
+
+export type WebSocketTelemetryEventQueryFilter = {
+  name?: string;
+  level?: "debug" | "info" | "warn" | "error";
+  connectionId?: string;
+  namespace?: string;
+  traceId?: string;
+  since?: number;
+  until?: number;
+  limit?: number;
+};
+
+export type WebSocketTelemetryMetricQueryFilter = {
+  name?: string;
+  kind?: "counter" | "histogram" | "gauge";
+  connectionId?: string;
+  namespace?: string;
+  traceId?: string;
+  since?: number;
+  until?: number;
+  limit?: number;
+};
+
+export type WebSocketTelemetrySpanQueryFilter = {
+  operationName?: string;
+  kind?: "internal" | "producer" | "consumer" | "server" | "client";
+  status?: "unset" | "ok" | "error";
+  connectionId?: string;
+  namespace?: string;
+  traceId?: string;
+  since?: number;
+  until?: number;
+  limit?: number;
+};
+
+// -- Signal-narrowed stores --
+
+export interface WebSocketTelemetryEventStore {
+  readonly sink: WebSocketTelemetryEventSink;
+  query(filter: WebSocketTelemetryEventQueryFilter): WebSocketTelemetryEventRecord[];
+  clear(): void;
+}
+
+export interface WebSocketTelemetryMetricStore {
+  readonly sink: WebSocketTelemetryMetricSink;
+  query(filter: WebSocketTelemetryMetricQueryFilter): WebSocketTelemetryMetricRecord[];
+  clear(): void;
+}
+
+export interface WebSocketTelemetrySpanStore {
+  readonly sink: WebSocketTelemetrySpanSink;
+  query(filter: WebSocketTelemetrySpanQueryFilter): WebSocketTelemetrySpanRecord[];
+  clear(): void;
+}
+
+// -- Metric source interface (unchanged) --
+
+export interface WebSocketTelemetryMetricSource {
+  collect(now: number): Partial<WebSocketTelemetryMetricsSnapshot>;
+}
+
+// -- Redactor / beforeRecord types (signal-narrowed + shared) --
+
+export type WebSocketTelemetryEventRedactor = (
+  record: WebSocketTelemetryEventRecord,
+) => WebSocketTelemetryEventRecord | null;
+
+export type WebSocketTelemetryMetricRedactor = (
+  record: WebSocketTelemetryMetricRecord,
+) => WebSocketTelemetryMetricRecord | null;
+
+export type WebSocketTelemetrySpanRedactor = (
+  record: WebSocketTelemetrySpanRecord,
+) => WebSocketTelemetrySpanRecord | null;
+
+export type WebSocketTelemetryRedactor = (
+  record: WebSocketTelemetryRecord,
+) => WebSocketTelemetryRecord | null;
+
+export type WebSocketTelemetryEventBeforeRecord = (
+  record: WebSocketTelemetryEventRecord,
+) => WebSocketTelemetryEventRecord | null;
+
+export type WebSocketTelemetryMetricBeforeRecord = (
+  record: WebSocketTelemetryMetricRecord,
+) => WebSocketTelemetryMetricRecord | null;
+
+export type WebSocketTelemetrySpanBeforeRecord = (
+  record: WebSocketTelemetrySpanRecord,
+) => WebSocketTelemetrySpanRecord | null;
+
+export type WebSocketTelemetryBeforeRecord = (
+  record: WebSocketTelemetryRecord,
+) => WebSocketTelemetryRecord | null;
+
+// -- Trace options / connection context --
+
+export type WebSocketTelemetryTraceOptions = {
+  extractTraceParent: boolean;
+  generateConnectionTrace: boolean;
+  propagateMessageTrace: boolean;
+  recordConnectionLifetimeSpan: boolean;
+};
+
+export type WebSocketTelemetryConnectionContext = {
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  sampled?: boolean;
+};
+
+export interface TelemetryContextProvider {
+  getTelemetryContext(): WebSocketTelemetryConnectionContext;
+}
+
+// -- Options schema --
+
+export type WebSocketTelemetryEventSamplingOptions = {
+  defaultRate?: number;
+  rateByEvent?: Record<string, number>;
+  maxRecordsPerSecond?: number;
+  alwaysRecordLevels?: Array<"warn" | "error">;
+};
+
+export type WebSocketTelemetryMetricSamplingOptions = {
+  maxRecordsPerSecond?: number;
+};
+
+export type WebSocketTelemetrySpanSamplingOptions = {
+  defaultRate?: number;
+  maxRecordsPerSecond?: number;
+};
+
+export type WebSocketTelemetryDefaultsOptions = {
+  redactor?: WebSocketTelemetryRedactor;
+  beforeRecord?: WebSocketTelemetryBeforeRecord;
+  maxRecords?: number;
+  maxBytes?: number;
+  maxRecordsPerSecond?: number;
+};
+
+export type WebSocketTelemetryEventsOptions = {
+  sinks?: WebSocketTelemetryEventSink[];
+  store?: WebSocketTelemetryEventStore;
+  maxRecords?: number;
+  maxBytes?: number;
+  maxInFlightEmits?: number;
+  redactor?: WebSocketTelemetryEventRedactor | null;
+  beforeRecord?: WebSocketTelemetryEventBeforeRecord | null;
+  sampling?: WebSocketTelemetryEventSamplingOptions;
+  capturePayload?: false | "preview";
+  maxPayloadPreviewBytes?: number;
+};
+
+export type WebSocketTelemetryMetricsOptions = {
+  sinks?: WebSocketTelemetryMetricSink[];
+  store?: WebSocketTelemetryMetricStore;
+  maxRecords?: number;
+  maxBytes?: number;
+  maxInFlightEmits?: number;
+  redactor?: WebSocketTelemetryMetricRedactor | null;
+  beforeRecord?: WebSocketTelemetryMetricBeforeRecord | null;
+  sampling?: WebSocketTelemetryMetricSamplingOptions;
+  collectionEnabled?: boolean;
+  sampleIntervalMs?: number;
+};
+
+export type WebSocketTelemetrySpansOptions = {
+  sinks?: WebSocketTelemetrySpanSink[];
+  store?: WebSocketTelemetrySpanStore;
+  maxRecords?: number;
+  maxBytes?: number;
+  maxInFlightEmits?: number;
+  redactor?: WebSocketTelemetrySpanRedactor | null;
+  beforeRecord?: WebSocketTelemetrySpanBeforeRecord | null;
+  sampling?: WebSocketTelemetrySpanSamplingOptions;
+};
+
+export type WebSocketTelemetryOptions = {
+  enabled?: boolean;
+  controller?: WebSocketTelemetryController;
+  defaults?: WebSocketTelemetryDefaultsOptions;
+  events?: WebSocketTelemetryEventsOptions;
+  metrics?: WebSocketTelemetryMetricsOptions;
+  spans?: WebSocketTelemetrySpansOptions;
+  trace?: Partial<WebSocketTelemetryTraceOptions>;
+  shutdownTimeoutMs?: number;
+};
+
+// -- Controller interface --
+
+export interface WebSocketTelemetryController {
+  emit(input: WebSocketTelemetryEventInput): void;
+  recordMetric(input: WebSocketMetricInput): void;
+  recordSpan(input: WebSocketSpanInput): void;
+  getMetricsSnapshot(): WebSocketTelemetryMetricsSnapshot;
+  getEventStore(): WebSocketTelemetryEventStore | undefined;
+  getMetricStore(): WebSocketTelemetryMetricStore | undefined;
+  getSpanStore(): WebSocketTelemetrySpanStore | undefined;
+  registerMetricSource(source: WebSocketTelemetryMetricSource): () => void;
+  createConnectionContext(request?: {
+    headers?: Readonly<Record<string, string | string[] | undefined>>;
+  }): WebSocketTelemetryConnectionContext;
+  getTraceOptions(): WebSocketTelemetryTraceOptions;
+  shutdown(options?: { timeoutMs?: number }): Promise<void>;
+}
+
+// -- Constants and shared helpers (preserved-behavior) --
+
+export const EMPTY_METRICS_SNAPSHOT: WebSocketTelemetryMetricsSnapshot = {
+  timestamp: 0,
+  activeConnections: 0,
+  activeConnectionsByNamespace: {},
+  roomCount: 0,
+  pendingInboundMessages: 0,
+  pendingOutboundMessages: 0,
+  socketBufferedBytes: 0,
+  pendingFanOutJobs: 0,
+  pendingFanOutTargets: 0,
+  telemetryDroppedRecords: 0,
+  telemetrySinkFailures: 0,
+};
+
+export const DEFAULT_TRACE_OPTIONS: WebSocketTelemetryTraceOptions = {
+  extractTraceParent: true,
+  generateConnectionTrace: true,
+  propagateMessageTrace: true,
+  recordConnectionLifetimeSpan: false,
+};
+
+const DEFAULT_MAX_RECORDS_PER_SECOND = 10_000;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2_000;
+const DEFAULT_EVENT_SAMPLING_DEFAULT_RATE = 1.0;
+const DEFAULT_EVENT_ALWAYS_RECORD_LEVELS: ReadonlyArray<"warn" | "error"> = ["warn", "error"];
+const DEFAULT_EVENT_CAPTURE_PAYLOAD: false | "preview" = false;
+const DEFAULT_EVENT_MAX_PAYLOAD_PREVIEW_BYTES = 1024;
+const DEFAULT_METRIC_COLLECTION_ENABLED = true;
+const DEFAULT_METRIC_SAMPLE_INTERVAL_MS = 10_000;
+const DEFAULT_SPAN_SAMPLING_DEFAULT_RATE = 1.0;
+const DEFAULT_MAX_IN_FLIGHT_EMITS_PER_SINK = 100;
+
+const SENSITIVE_KEY_PATTERNS = [
+  "authorization",
+  "cookie",
+  "token",
+  "password",
+  "secret",
+  "apikey",
+  "session",
+  "email",
+] as const;
+const REDACTED_VALUE = "[redacted]";
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+  return SENSITIVE_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
+function redactValue(value: unknown, key?: string): unknown {
+  if (key !== undefined && isSensitiveKey(key)) {
+    return REDACTED_VALUE;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item));
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (value && typeof value === "object") {
+    const redacted: Record<string, unknown> = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      redacted[childKey] = redactValue(childValue, childKey);
+    }
+    return redacted;
+  }
+
+  return value;
+}
+
+/**
+ * defaultSensitiveKeyRedact — sensitive key 패턴 기반 built-in redactor.
+ * pipeline emit flow의 첫 단계에서 항상 적용된다.
+ */
+function defaultSensitiveKeyRedact(record: WebSocketTelemetryRecord): WebSocketTelemetryRecord {
+  if (record.type === "event") {
+    return {
+      ...record,
+      attributes: record.attributes
+        ? (redactValue(record.attributes) as WebSocketTelemetryEventRecord["attributes"])
+        : undefined,
+      detail: record.detail
+        ? (redactValue(record.detail) as WebSocketTelemetryEventRecord["detail"])
+        : undefined,
+      payloadPreview: record.payloadPreview,
+    };
+  }
+
+  if (record.type === "metric") {
+    return {
+      ...record,
+      tags: record.tags
+        ? (redactValue(record.tags) as WebSocketTelemetryMetricRecord["tags"])
+        : undefined,
+      snapshot: record.snapshot ? { ...record.snapshot } : undefined,
+    };
+  }
+
+  return {
+    ...record,
+    attributes: record.attributes
+      ? (redactValue(record.attributes) as WebSocketTelemetrySpanRecord["attributes"])
+      : undefined,
+    events: record.events?.map((event) => ({
+      ...event,
+      attributes: event.attributes
+        ? (redactValue(event.attributes) as Record<string, unknown>)
+        : undefined,
+    })),
+    links: record.links?.map((link) => ({
+      ...link,
+      attributes: link.attributes
+        ? (redactValue(link.attributes) as Record<string, unknown>)
+        : undefined,
+    })),
+  };
+}
+
+function truncatePayloadPreview(payload: unknown, maxBytes: number): string {
+  try {
+    const serialized = JSON.stringify(redactValue(payload));
+    if (Buffer.byteLength(serialized, "utf-8") <= maxBytes) {
+      return serialized;
+    }
+    return truncateUtf8String(serialized, maxBytes);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+function truncateUtf8String(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+
+  const suffix = maxBytes >= 3 ? "..." : "";
+  const contentBudget = maxBytes - Buffer.byteLength(suffix, "utf-8");
+  let result = "";
+  let usedBytes = 0;
+
+  for (const char of value) {
+    const charBytes = Buffer.byteLength(char, "utf-8");
+    if (usedBytes + charBytes > contentBudget) break;
+    result += char;
+    usedBytes += charBytes;
+  }
+
+  return result + suffix;
+}
+
+export function isPromiseLike(value: unknown): value is Promise<void> {
+  return typeof value === "object" && value !== null && "then" in value && "catch" in value;
+}
+
+// -- TokenBucket (unchanged) --
+
+class TokenBucket {
+  private tokens: number;
+  private lastRefill: number;
+
+  constructor(
+    private readonly maxTokens: number,
+    private readonly refillRate: number,
+  ) {
+    this.tokens = maxTokens;
+    this.lastRefill = Date.now();
+  }
+
+  tryConsume(): boolean {
+    this.refill();
+    if (this.tokens < 1) return false;
+    this.tokens -= 1;
+    return true;
+  }
+
+  private refill(): void {
+    const now = Date.now();
+    const elapsed = (now - this.lastRefill) / 1000;
+    this.tokens = Math.min(this.maxTokens, this.tokens + elapsed * this.refillRate);
+    this.lastRefill = now;
+  }
+}
+
+// -- NoopWebSocketTelemetryController (preserved-behavior) --
+
+const noopUnsubscribe = (): void => {};
+
+export class NoopWebSocketTelemetryController implements WebSocketTelemetryController {
+  emit(_input: WebSocketTelemetryEventInput): void {
+    // noop
+  }
+
+  recordMetric(_input: WebSocketMetricInput): void {
+    // noop
+  }
+
+  recordSpan(_input: WebSocketSpanInput): void {
+    // noop
+  }
+
+  getMetricsSnapshot(): WebSocketTelemetryMetricsSnapshot {
+    return { ...EMPTY_METRICS_SNAPSHOT, timestamp: Date.now() };
+  }
+
+  getEventStore(): WebSocketTelemetryEventStore | undefined {
+    return undefined;
+  }
+
+  getMetricStore(): WebSocketTelemetryMetricStore | undefined {
+    return undefined;
+  }
+
+  getSpanStore(): WebSocketTelemetrySpanStore | undefined {
+    return undefined;
+  }
+
+  registerMetricSource(_source: WebSocketTelemetryMetricSource): () => void {
+    return noopUnsubscribe;
+  }
+
+  createConnectionContext(_request?: {
+    headers?: Readonly<Record<string, string | string[] | undefined>>;
+  }): WebSocketTelemetryConnectionContext {
+    return {};
+  }
+
+  getTraceOptions(): WebSocketTelemetryTraceOptions {
+    return { ...DEFAULT_TRACE_OPTIONS };
+  }
+
+  shutdown(_options?: { timeoutMs?: number }): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+// -- Resolved per-pipeline option types (internal) --
+
+type RuntimeMetadata = {
+  runtimeId: string;
+  nodeId: string;
+};
+
+type ResolvedEventPipelineOptions = {
+  sinks: WebSocketTelemetryEventSink[];
+  store: WebSocketTelemetryEventStore | undefined;
+  maxRecordsPerSecond: number;
+  maxInFlightEmits: number;
+  sharedRedactor: WebSocketTelemetryRedactor | undefined;
+  signalRedactor: WebSocketTelemetryEventRedactor | undefined;
+  sharedBeforeRecord: WebSocketTelemetryBeforeRecord | undefined;
+  signalBeforeRecord: WebSocketTelemetryEventBeforeRecord | undefined;
+  sampling: {
+    defaultRate: number;
+    rateByEvent: Record<string, number>;
+    alwaysRecordLevels: Array<"warn" | "error">;
+  };
+  capturePayload: false | "preview";
+  maxPayloadPreviewBytes: number;
+};
+
+type ResolvedMetricPipelineOptions = {
+  sinks: WebSocketTelemetryMetricSink[];
+  store: WebSocketTelemetryMetricStore | undefined;
+  maxRecordsPerSecond: number;
+  maxInFlightEmits: number;
+  sharedRedactor: WebSocketTelemetryRedactor | undefined;
+  signalRedactor: WebSocketTelemetryMetricRedactor | undefined;
+  sharedBeforeRecord: WebSocketTelemetryBeforeRecord | undefined;
+  signalBeforeRecord: WebSocketTelemetryMetricBeforeRecord | undefined;
+  collectionEnabled: boolean;
+  sampleIntervalMs: number;
+};
+
+type ResolvedSpanPipelineOptions = {
+  sinks: WebSocketTelemetrySpanSink[];
+  store: WebSocketTelemetrySpanStore | undefined;
+  maxRecordsPerSecond: number;
+  maxInFlightEmits: number;
+  sharedRedactor: WebSocketTelemetryRedactor | undefined;
+  signalRedactor: WebSocketTelemetrySpanRedactor | undefined;
+  sharedBeforeRecord: WebSocketTelemetryBeforeRecord | undefined;
+  signalBeforeRecord: WebSocketTelemetrySpanBeforeRecord | undefined;
+  sampling: {
+    defaultRate: number;
+  };
+};
+
+// -- Internal event reporter type --
+// EventPipeline 자신과 controller가 내부 진단 이벤트를 발행할 때 사용한다.
+// type-mismatch / shutdown.timeout / sink.failed 등을 events pipeline 경로로 보낸다.
+type InternalEventReporter = (
+  name: string,
+  level: WebSocketTelemetryEventRecord["level"],
+  detail?: Record<string, unknown>,
+) => void;
+
+// -- TelemetryPipeline (abstract) --
+
+abstract class TelemetryPipeline<
+  TRecord extends WebSocketTelemetryRecord,
+  TInput,
+  TSink extends {
+    emit(record: TRecord): void | Promise<void>;
+    shutdown?(options?: { timeoutMs?: number }): void | Promise<void>;
+  },
+  TStore extends { readonly sink: TSink; clear(): void } | undefined,
+> {
+  abstract readonly signal: "event" | "metric" | "span";
+  protected readonly sinks: TSink[];
+  protected readonly _store: TStore;
+  protected readonly tokenBucket: TokenBucket;
+  protected readonly maxInFlightEmits: number;
+  protected readonly runtimeMetadata: RuntimeMetadata;
+  protected readonly sharedRedactor: WebSocketTelemetryRedactor | undefined;
+  protected readonly sharedBeforeRecord: WebSocketTelemetryBeforeRecord | undefined;
+  protected internalEventReporter: InternalEventReporter | undefined;
+  private readonly inFlightEmits = new WeakMap<TSink, number>();
+  droppedCount = 0;
+  sinkFailureCount = 0;
+  shutdownCalled = false;
+
+  protected constructor(
+    sinks: TSink[],
+    store: TStore,
+    maxRecordsPerSecond: number,
+    maxInFlightEmits: number,
+    sharedRedactor: WebSocketTelemetryRedactor | undefined,
+    sharedBeforeRecord: WebSocketTelemetryBeforeRecord | undefined,
+    runtimeMetadata: RuntimeMetadata,
+  ) {
+    this.sinks = sinks;
+    this._store = store;
+    this.tokenBucket = new TokenBucket(maxRecordsPerSecond, maxRecordsPerSecond);
+    this.maxInFlightEmits = maxInFlightEmits;
+    this.sharedRedactor = sharedRedactor;
+    this.sharedBeforeRecord = sharedBeforeRecord;
+    this.runtimeMetadata = runtimeMetadata;
+  }
+
+  get store(): TStore {
+    return this._store;
+  }
+
+  setInternalEventReporter(reporter: InternalEventReporter): void {
+    this.internalEventReporter = reporter;
+  }
+
+  abstract emit(input: TInput): void;
+
+  protected abstract buildRecord(input: TInput): TRecord;
+
+  protected abstract shouldBypassRateLimit(record: TRecord): boolean;
+
+  protected abstract isCriticalRecord(record: TRecord): boolean;
+
+  protected abstract getSignalRedactor(): ((record: TRecord) => TRecord | null) | undefined;
+
+  protected abstract getSignalBeforeRecord(): ((record: TRecord) => TRecord | null) | undefined;
+
+  // 공통 emit 흐름. 모든 신호별 pipeline의 emit이 이 메서드로 위임한다.
+  protected emitInternal(input: TInput): void {
+    if (this.shutdownCalled) return;
+
+    let record: TRecord;
+    try {
+      record = this.buildRecord(input);
+    } catch {
+      this.droppedCount += 1;
+      return;
+    }
+
+    const skipRateLimit = this.shouldBypassRateLimit(record);
+    if (!skipRateLimit && !this.tokenBucket.tryConsume()) {
+      this.droppedCount += 1;
+      return;
+    }
+
+    // step 1: defaultSensitiveKeyRedact 항상 적용
+    let prepared: TRecord;
+    try {
+      const afterDefault = defaultSensitiveKeyRedact(record);
+      if (afterDefault.type !== record.type) {
+        // 방어 로직 — 본 구현에서는 발생하지 않지만 type-narrow를 위해 검증
+        this.droppedCount += 1;
+        return;
+      }
+      prepared = afterDefault as TRecord;
+    } catch {
+      this.droppedCount += 1;
+      return;
+    }
+
+    // step 2: sharedRedactor (이미 buildController에서 signalRedactor===null이면 sharedRedactor=undefined로 덮어쓴 상태)
+    if (this.sharedRedactor !== undefined) {
+      const sharedRedactor = this.sharedRedactor;
+      const result = this.applyTransform(prepared, (r) => sharedRedactor(r), "shared", "redactor");
+      if (result === null) return;
+      prepared = result;
+    }
+
+    // step 3: signalRedactor
+    const signalRedactor = this.getSignalRedactor();
+    if (signalRedactor !== undefined) {
+      const result = this.applyTransform(prepared, (r) => signalRedactor(r), "signal", "redactor");
+      if (result === null) return;
+      prepared = result;
+    }
+
+    // step 4: sharedBeforeRecord
+    if (this.sharedBeforeRecord !== undefined) {
+      const sharedBeforeRecord = this.sharedBeforeRecord;
+      const result = this.applyTransform(
+        prepared,
+        (r) => sharedBeforeRecord(r),
+        "shared",
+        "beforeRecord",
+      );
+      if (result === null) return;
+      prepared = result;
+    }
+
+    // step 5: signalBeforeRecord
+    const signalBeforeRecord = this.getSignalBeforeRecord();
+    if (signalBeforeRecord !== undefined) {
+      const result = this.applyTransform(
+        prepared,
+        (r) => signalBeforeRecord(r),
+        "signal",
+        "beforeRecord",
+      );
+      if (result === null) return;
+      prepared = result;
+    }
+
+    this.dispatchToSinks(prepared);
+  }
+
+  // redactor 또는 beforeRecord 1회 적용. 반환값이 null이면 drop, type 불일치면 drop + internal event.
+  // shared 변환은 wider record를 받아 wider record를 반환하지만, signal 변환은 narrowed TRecord끼리 변환한다.
+  // 양쪽 모두 동일한 type-mismatch defensive 검사를 거친다.
+  private applyTransform(
+    record: TRecord,
+    runner: (record: TRecord) => WebSocketTelemetryRecord | null,
+    source: "shared" | "signal",
+    kind: "redactor" | "beforeRecord",
+  ): TRecord | null {
+    let result: WebSocketTelemetryRecord | null;
+    try {
+      result = runner(record);
+    } catch {
+      this.droppedCount += 1;
+      return null;
+    }
+
+    if (result === null) {
+      this.droppedCount += 1;
+      return null;
+    }
+
+    if (result.type !== record.type) {
+      this.droppedCount += 1;
+      const eventName =
+        kind === "redactor"
+          ? "ws.telemetry.redactor.type_mismatch"
+          : "ws.telemetry.beforeRecord.type_mismatch";
+      this.dispatchInternalEvent(eventName, "warn", {
+        expected: record.type,
+        actual: result.type,
+        source,
+      });
+      return null;
+    }
+
+    // result.type === record.type === TRecord["type"]이므로 narrowed TRecord로 안전하게 좁힐 수 있다.
+    return result as TRecord;
+  }
+
+  protected dispatchToSinks(record: TRecord, selfObserveFailures = true): void {
+    const critical = this.isCriticalRecord(record);
+    let droppedForRecord = false;
+
+    for (const sink of this.sinks) {
+      const inFlight = this.inFlightEmits.get(sink) ?? 0;
+      if (!critical && inFlight >= this.maxInFlightEmits) {
+        if (!droppedForRecord) {
+          this.droppedCount += 1;
+          droppedForRecord = true;
+        }
+        continue;
+      }
+
+      try {
+        const result = sink.emit(record);
+        if (isPromiseLike(result)) {
+          this.inFlightEmits.set(sink, inFlight + 1);
+          result.then(
+            () => {
+              this.decrementInFlightEmit(sink);
+            },
+            (error: unknown) => {
+              this.decrementInFlightEmit(sink);
+              this.observeSinkFailure("emit", error, selfObserveFailures);
+            },
+          );
+        }
+      } catch (error) {
+        this.observeSinkFailure("emit", error, selfObserveFailures);
+      }
+    }
+  }
+
+  private decrementInFlightEmit(sink: TSink): void {
+    const current = this.inFlightEmits.get(sink) ?? 0;
+    if (current <= 1) {
+      this.inFlightEmits.delete(sink);
+      return;
+    }
+    this.inFlightEmits.set(sink, current - 1);
+  }
+
+  private observeSinkFailure(
+    phase: "emit" | "shutdown",
+    error: unknown,
+    selfObserveFailure: boolean,
+  ): void {
+    this.sinkFailureCount += 1;
+    if (!selfObserveFailure) return;
+    this.dispatchInternalEvent("ws.telemetry.sink.failed", "warn", {
+      phase,
+      signal: this.signal,
+      errorType: error instanceof Error ? error.name : typeof error,
+    });
+  }
+
+  protected dispatchInternalEvent(
+    name: string,
+    level: WebSocketTelemetryEventRecord["level"],
+    detail?: Record<string, unknown>,
+  ): void {
+    if (this.internalEventReporter === undefined) return;
+    try {
+      this.internalEventReporter(name, level, detail);
+    } catch {
+      // 진단 이벤트 자체가 실패하면 swallow
+    }
+  }
+
+  async shutdown(timeoutMs: number): Promise<void> {
+    if (this.shutdownCalled) return;
+    this.shutdownCalled = true;
+
+    const sinkShutdowns = this.sinks.map((sink) => this.shutdownSink(sink, timeoutMs));
+    if (sinkShutdowns.length > 0) {
+      await Promise.allSettled(sinkShutdowns);
+    }
+  }
+
+  private async shutdownSink(sink: TSink, timeoutMs: number): Promise<void> {
+    if (!sink.shutdown) return;
+
+    try {
+      const result = sink.shutdown({ timeoutMs });
+      if (!isPromiseLike(result)) return;
+
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+      const shutdownPromise = result.then(
+        () => "completed" as const,
+        (error: unknown) => {
+          throw error;
+        },
+      );
+      const timeoutPromise = new Promise<"timeout">((resolve) => {
+        timeout = setTimeout(() => {
+          resolve("timeout");
+        }, timeoutMs);
+      });
+
+      const outcome = await Promise.race([shutdownPromise, timeoutPromise]);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+
+      if (outcome === "timeout") {
+        shutdownPromise.catch(() => {});
+        this.sinkFailureCount += 1;
+        this.dispatchInternalEvent("ws.telemetry.shutdown.timeout", "warn", {
+          timeoutMs,
+          signal: this.signal,
+        });
+      }
+    } catch (error) {
+      this.observeSinkFailure("shutdown", error, true);
+    }
+  }
+}
+
+// -- EventPipeline --
+
+class EventPipeline extends TelemetryPipeline<
+  WebSocketTelemetryEventRecord,
+  WebSocketTelemetryEventInput,
+  WebSocketTelemetryEventSink,
+  WebSocketTelemetryEventStore | undefined
+> {
+  readonly signal = "event" as const;
+  protected readonly signalRedactor: WebSocketTelemetryEventRedactor | undefined;
+  protected readonly signalBeforeRecord: WebSocketTelemetryEventBeforeRecord | undefined;
+  protected readonly sampling: {
+    defaultRate: number;
+    rateByEvent: Record<string, number>;
+    alwaysRecordLevels: Array<"warn" | "error">;
+  };
+  protected readonly capturePayload: false | "preview";
+  protected readonly maxPayloadPreviewBytes: number;
+  // alwaysRecord level 경로에서 prepareRecord(skipRateLimit=true) 의미를 보존하기 위한 플래그.
+  private currentEmitAlwaysRecord = false;
+
+  constructor(options: ResolvedEventPipelineOptions, runtimeMetadata: RuntimeMetadata) {
+    super(
+      options.sinks,
+      options.store,
+      options.maxRecordsPerSecond,
+      options.maxInFlightEmits,
+      options.sharedRedactor,
+      options.sharedBeforeRecord,
+      runtimeMetadata,
+    );
+    this.signalRedactor = options.signalRedactor;
+    this.signalBeforeRecord = options.signalBeforeRecord;
+    this.sampling = options.sampling;
+    this.capturePayload = options.capturePayload;
+    this.maxPayloadPreviewBytes = options.maxPayloadPreviewBytes;
+  }
+
+  emit(input: WebSocketTelemetryEventInput): void {
+    try {
+      if (this.shutdownCalled) return;
+
+      // sampling: alwaysRecordLevels 우선
+      const levels: ReadonlyArray<string> = this.sampling.alwaysRecordLevels;
+      const alwaysRecord = levels.includes(input.level);
+
+      if (!alwaysRecord) {
+        const rate = this.sampling.rateByEvent[input.name] ?? this.sampling.defaultRate;
+        if (rate <= 0) {
+          this.droppedCount += 1;
+          return;
+        }
+        if (rate < 1 && Math.random() >= rate) {
+          this.droppedCount += 1;
+          return;
+        }
+      }
+
+      this.currentEmitAlwaysRecord = alwaysRecord;
+      try {
+        this.emitInternal(input);
+      } finally {
+        this.currentEmitAlwaysRecord = false;
+      }
+    } catch {
+      // pipeline emit 또한 throw-free 정책
+    }
+  }
+
+  // 내부 진단 이벤트 — sampling/rate-limit 우회. shutdown 중에도 발행해 timeout/실패 진단이 유실되지 않도록 한다.
+  // 사용자 redactor의 type-mismatch 위험을 피하기 위해 default redactor만 적용한다.
+  dispatchInternalDiagnosticEvent(
+    name: string,
+    level: WebSocketTelemetryEventRecord["level"],
+    detail?: Record<string, unknown>,
+  ): void {
+    const record: WebSocketTelemetryEventRecord = {
+      type: "event",
+      timestamp: Date.now(),
+      monotonicTime: performance.now(),
+      runtimeId: this.runtimeMetadata.runtimeId,
+      nodeId: this.runtimeMetadata.nodeId,
+      name,
+      level,
+      detail,
+    };
+
+    // 진단 이벤트는 항상 default redactor만 적용해 sink에 직접 전달한다.
+    // (사용자 redactor가 진단 이벤트의 type을 잘못 바꿔 무한 루프를 일으키는 일을 막는다.)
+    try {
+      const sanitized = defaultSensitiveKeyRedact(record);
+      if (sanitized.type !== "event") return;
+      this.dispatchToSinks(sanitized, false);
+    } catch {
+      // swallow
+    }
+  }
+
+  protected buildRecord(input: WebSocketTelemetryEventInput): WebSocketTelemetryEventRecord {
+    let record: WebSocketTelemetryEventRecord = {
+      type: "event",
+      timestamp: Date.now(),
+      monotonicTime: performance.now(),
+      runtimeId: this.runtimeMetadata.runtimeId,
+      nodeId: this.runtimeMetadata.nodeId,
+      name: input.name,
+      level: input.level,
+      namespace: input.namespace,
+      connectionId: input.connectionId,
+      attributes: input.attributes,
+      detail: input.detail,
+      traceId: input.traceId,
+      spanId: input.spanId,
+      parentSpanId: input.parentSpanId,
+      sampled: input.sampled,
+    };
+
+    if (this.capturePayload === "preview" && input.payload !== undefined) {
+      record = {
+        ...record,
+        payloadPreview: truncatePayloadPreview(input.payload, this.maxPayloadPreviewBytes),
+      };
+    }
+
+    return record;
+  }
+
+  protected shouldBypassRateLimit(_record: WebSocketTelemetryEventRecord): boolean {
+    // alwaysRecordLevels에 해당하는 record는 sampling을 거치지 않고 들어왔으며,
+    // 기존 controller 동작을 보존하기 위해 token bucket도 skip한다.
+    return this.currentEmitAlwaysRecord;
+  }
+
+  protected isCriticalRecord(record: WebSocketTelemetryEventRecord): boolean {
+    return record.level === "warn" || record.level === "error";
+  }
+
+  protected getSignalRedactor():
+    | ((record: WebSocketTelemetryEventRecord) => WebSocketTelemetryEventRecord | null)
+    | undefined {
+    return this.signalRedactor;
+  }
+
+  protected getSignalBeforeRecord():
+    | ((record: WebSocketTelemetryEventRecord) => WebSocketTelemetryEventRecord | null)
+    | undefined {
+    return this.signalBeforeRecord;
+  }
+}
+
+// -- MetricPipeline --
+
+class MetricPipeline extends TelemetryPipeline<
+  WebSocketTelemetryMetricRecord,
+  WebSocketMetricInput,
+  WebSocketTelemetryMetricSink,
+  WebSocketTelemetryMetricStore | undefined
+> {
+  readonly signal = "metric" as const;
+  protected readonly signalRedactor: WebSocketTelemetryMetricRedactor | undefined;
+  protected readonly signalBeforeRecord: WebSocketTelemetryMetricBeforeRecord | undefined;
+  protected readonly metricSources: Set<WebSocketTelemetryMetricSource> = new Set();
+  protected readonly collectionEnabled: boolean;
+  protected readonly sampleIntervalMs: number;
+  protected collectionInterval: ReturnType<typeof setInterval> | null = null;
+  protected snapshotProvider: (() => WebSocketTelemetryMetricsSnapshot) | undefined;
+
+  constructor(options: ResolvedMetricPipelineOptions, runtimeMetadata: RuntimeMetadata) {
+    super(
+      options.sinks,
+      options.store,
+      options.maxRecordsPerSecond,
+      options.maxInFlightEmits,
+      options.sharedRedactor,
+      options.sharedBeforeRecord,
+      runtimeMetadata,
+    );
+    this.signalRedactor = options.signalRedactor;
+    this.signalBeforeRecord = options.signalBeforeRecord;
+    this.collectionEnabled = options.collectionEnabled;
+    this.sampleIntervalMs = options.sampleIntervalMs;
+
+    if (this.collectionEnabled && this.sampleIntervalMs > 0) {
+      this.collectionInterval = setInterval(() => {
+        this.collectAndEmit();
+      }, this.sampleIntervalMs);
+
+      if (
+        this.collectionInterval &&
+        typeof this.collectionInterval === "object" &&
+        "unref" in this.collectionInterval
+      ) {
+        this.collectionInterval.unref();
+      }
+    }
+  }
+
+  emit(input: WebSocketMetricInput): void {
+    try {
+      this.emitInternal(input);
+    } catch {
+      // pipeline emit throw-free 정책
+    }
+  }
+
+  protected buildRecord(input: WebSocketMetricInput): WebSocketTelemetryMetricRecord {
+    return {
+      type: "metric",
+      timestamp: Date.now(),
+      monotonicTime: performance.now(),
+      runtimeId: this.runtimeMetadata.runtimeId,
+      nodeId: this.runtimeMetadata.nodeId,
+      name: input.name,
+      kind: input.kind,
+      value: input.value,
+      unit: input.unit,
+      tags: input.tags,
+      namespace: input.namespace,
+      connectionId: input.connectionId,
+      traceId: input.traceId,
+      spanId: input.spanId,
+      parentSpanId: input.parentSpanId,
+      sampled: input.sampled,
+      snapshot: input.snapshot,
+    };
+  }
+
+  protected shouldBypassRateLimit(record: WebSocketTelemetryMetricRecord): boolean {
+    const outcome = record.tags?.outcome;
+    if (outcome === "failed" || outcome === "rejected" || outcome === "dropped") {
+      return true;
+    }
+
+    return (
+      record.name.endsWith(".failures") ||
+      record.name.endsWith(".failure") ||
+      record.name.endsWith(".dropped") ||
+      record.name.includes(".failures.") ||
+      record.name.includes(".dropped.")
+    );
+  }
+
+  protected isCriticalRecord(record: WebSocketTelemetryMetricRecord): boolean {
+    return this.shouldBypassRateLimit(record);
+  }
+
+  protected getSignalRedactor():
+    | ((record: WebSocketTelemetryMetricRecord) => WebSocketTelemetryMetricRecord | null)
+    | undefined {
+    return this.signalRedactor;
+  }
+
+  protected getSignalBeforeRecord():
+    | ((record: WebSocketTelemetryMetricRecord) => WebSocketTelemetryMetricRecord | null)
+    | undefined {
+    return this.signalBeforeRecord;
+  }
+
+  registerMetricSource(source: WebSocketTelemetryMetricSource): () => void {
+    this.metricSources.add(source);
+    return () => {
+      this.metricSources.delete(source);
+    };
+  }
+
+  setSnapshotProvider(provider: () => WebSocketTelemetryMetricsSnapshot): void {
+    this.snapshotProvider = provider;
+  }
+
+  getSnapshot(): WebSocketTelemetryMetricsSnapshot {
+    const now = Date.now();
+    const base: WebSocketTelemetryMetricsSnapshot = {
+      ...EMPTY_METRICS_SNAPSHOT,
+      timestamp: now,
+      activeConnectionsByNamespace: {},
+      telemetryDroppedRecords: this.droppedCount,
+      telemetrySinkFailures: this.sinkFailureCount,
+    };
+
+    for (const source of this.metricSources) {
+      try {
+        const partial = source.collect(now);
+        base.activeConnections += partial.activeConnections ?? 0;
+        base.roomCount += partial.roomCount ?? 0;
+        base.pendingInboundMessages += partial.pendingInboundMessages ?? 0;
+        base.pendingOutboundMessages += partial.pendingOutboundMessages ?? 0;
+        base.socketBufferedBytes += partial.socketBufferedBytes ?? 0;
+        base.pendingFanOutJobs += partial.pendingFanOutJobs ?? 0;
+        base.pendingFanOutTargets += partial.pendingFanOutTargets ?? 0;
+        if (partial.activeConnectionsByNamespace) {
+          for (const [ns, count] of Object.entries(partial.activeConnectionsByNamespace)) {
+            base.activeConnectionsByNamespace[ns] =
+              (base.activeConnectionsByNamespace[ns] ?? 0) + count;
+          }
+        }
+      } catch {
+        // metric source 실패는 외부로 전파되어선 안 됨
+      }
+    }
+
+    return base;
+  }
+
+  collectAndEmit(): void {
+    try {
+      if (this.shutdownCalled) return;
+      const snapshot = this.snapshotProvider?.() ?? this.getSnapshot();
+      const input: WebSocketMetricInput = {
+        name: "ws.connections.active",
+        kind: "gauge",
+        value: snapshot.activeConnections,
+        unit: "1",
+        snapshot,
+      };
+      this.emit(input);
+    } catch {
+      // metrics 수집 실패는 외부로 전파되어선 안 됨
+    }
+  }
+
+  override async shutdown(timeoutMs: number): Promise<void> {
+    if (this.collectionInterval !== null) {
+      clearInterval(this.collectionInterval);
+      this.collectionInterval = null;
+    }
+    await super.shutdown(timeoutMs);
+  }
+}
+
+// -- SpanPipeline --
+
+class SpanPipeline extends TelemetryPipeline<
+  WebSocketTelemetrySpanRecord,
+  WebSocketSpanInput,
+  WebSocketTelemetrySpanSink,
+  WebSocketTelemetrySpanStore | undefined
+> {
+  readonly signal = "span" as const;
+  protected readonly signalRedactor: WebSocketTelemetrySpanRedactor | undefined;
+  protected readonly signalBeforeRecord: WebSocketTelemetrySpanBeforeRecord | undefined;
+  protected readonly sampling: {
+    defaultRate: number;
+  };
+
+  constructor(options: ResolvedSpanPipelineOptions, runtimeMetadata: RuntimeMetadata) {
+    super(
+      options.sinks,
+      options.store,
+      options.maxRecordsPerSecond,
+      options.maxInFlightEmits,
+      options.sharedRedactor,
+      options.sharedBeforeRecord,
+      runtimeMetadata,
+    );
+    this.signalRedactor = options.signalRedactor;
+    this.signalBeforeRecord = options.signalBeforeRecord;
+    this.sampling = { defaultRate: options.sampling.defaultRate };
+  }
+
+  emit(input: WebSocketSpanInput): void {
+    try {
+      if (this.shutdownCalled) return;
+
+      // status === "error"는 sampling 우회
+      if (input.status !== "error") {
+        const rate = this.sampling.defaultRate;
+        if (rate <= 0) {
+          this.droppedCount += 1;
+          return;
+        }
+        if (rate < 1 && Math.random() >= rate) {
+          this.droppedCount += 1;
+          return;
+        }
+      }
+
+      this.emitInternal(input);
+    } catch {
+      // pipeline emit throw-free 정책
+    }
+  }
+
+  protected buildRecord(input: WebSocketSpanInput): WebSocketTelemetrySpanRecord {
+    return {
+      type: "span",
+      timestamp: Date.now(),
+      monotonicTime: performance.now(),
+      runtimeId: this.runtimeMetadata.runtimeId,
+      nodeId: this.runtimeMetadata.nodeId,
+      operationName: input.operationName,
+      kind: input.kind,
+      durationMs: input.durationMs,
+      status: input.status,
+      namespace: input.namespace,
+      connectionId: input.connectionId,
+      attributes: input.attributes,
+      errorType: input.errorType,
+      traceId: input.traceId,
+      spanId: input.spanId,
+      parentSpanId: input.parentSpanId,
+      sampled: input.sampled,
+      events: input.events,
+      links: input.links,
+    };
+  }
+
+  protected shouldBypassRateLimit(record: WebSocketTelemetrySpanRecord): boolean {
+    return record.status === "error";
+  }
+
+  protected isCriticalRecord(record: WebSocketTelemetrySpanRecord): boolean {
+    return record.status === "error";
+  }
+
+  protected getSignalRedactor():
+    | ((record: WebSocketTelemetrySpanRecord) => WebSocketTelemetrySpanRecord | null)
+    | undefined {
+    return this.signalRedactor;
+  }
+
+  protected getSignalBeforeRecord():
+    | ((record: WebSocketTelemetrySpanRecord) => WebSocketTelemetrySpanRecord | null)
+    | undefined {
+    return this.signalBeforeRecord;
+  }
+}
+
+// -- WebSocketTelemetryControllerImpl --
+
+export class WebSocketTelemetryControllerImpl implements WebSocketTelemetryController {
+  protected readonly events: EventPipeline;
+  protected readonly metrics: MetricPipeline;
+  protected readonly spans: SpanPipeline;
+  protected readonly runtimeId: string;
+  protected readonly nodeId: string;
+  protected readonly traceOptions: WebSocketTelemetryTraceOptions;
+  protected readonly shutdownTimeoutMs: number;
+  protected shutdownCalled = false;
+
+  constructor(
+    events: EventPipeline,
+    metrics: MetricPipeline,
+    spans: SpanPipeline,
+    traceOptions: WebSocketTelemetryTraceOptions,
+    runtimeMetadata: RuntimeMetadata,
+    shutdownTimeoutMs: number,
+  ) {
+    this.events = events;
+    this.metrics = metrics;
+    this.spans = spans;
+    this.traceOptions = traceOptions;
+    this.runtimeId = runtimeMetadata.runtimeId;
+    this.nodeId = runtimeMetadata.nodeId;
+    this.shutdownTimeoutMs = shutdownTimeoutMs;
+
+    // 모든 pipeline 진단 이벤트는 events pipeline 경로로 라우팅한다.
+    const reporter: InternalEventReporter = (name, level, detail) => {
+      this.events.dispatchInternalDiagnosticEvent(name, level, detail);
+    };
+    this.events.setInternalEventReporter(reporter);
+    this.metrics.setInternalEventReporter(reporter);
+    this.spans.setInternalEventReporter(reporter);
+    this.metrics.setSnapshotProvider(() => this.getMetricsSnapshot());
+  }
+
+  emit(input: WebSocketTelemetryEventInput): void {
+    try {
+      if (this.shutdownCalled) return;
+      this.events.emit(input);
+    } catch {
+      // controller throw-free
+    }
+  }
+
+  recordMetric(input: WebSocketMetricInput): void {
+    try {
+      if (this.shutdownCalled) return;
+      this.metrics.emit(input);
+    } catch {
+      // controller throw-free
+    }
+  }
+
+  recordSpan(input: WebSocketSpanInput): void {
+    try {
+      if (this.shutdownCalled) return;
+      this.spans.emit(input);
+    } catch {
+      // controller throw-free
+    }
+  }
+
+  getMetricsSnapshot(): WebSocketTelemetryMetricsSnapshot {
+    try {
+      const base = this.metrics.getSnapshot();
+      base.telemetryDroppedRecords =
+        this.events.droppedCount + this.metrics.droppedCount + this.spans.droppedCount;
+      base.telemetrySinkFailures =
+        this.events.sinkFailureCount + this.metrics.sinkFailureCount + this.spans.sinkFailureCount;
+      return base;
+    } catch {
+      return { ...EMPTY_METRICS_SNAPSHOT, timestamp: Date.now() };
+    }
+  }
+
+  getEventStore(): WebSocketTelemetryEventStore | undefined {
+    try {
+      return this.events.store;
+    } catch {
+      return undefined;
+    }
+  }
+
+  getMetricStore(): WebSocketTelemetryMetricStore | undefined {
+    try {
+      return this.metrics.store;
+    } catch {
+      return undefined;
+    }
+  }
+
+  getSpanStore(): WebSocketTelemetrySpanStore | undefined {
+    try {
+      return this.spans.store;
+    } catch {
+      return undefined;
+    }
+  }
+
+  registerMetricSource(source: WebSocketTelemetryMetricSource): () => void {
+    try {
+      return this.metrics.registerMetricSource(source);
+    } catch {
+      return noopUnsubscribe;
+    }
+  }
+
+  createConnectionContext(request?: {
+    headers?: Readonly<Record<string, string | string[] | undefined>>;
+  }): WebSocketTelemetryConnectionContext {
+    try {
+      if (this.traceOptions.extractTraceParent && request?.headers) {
+        const traceparentHeader = request.headers["traceparent"];
+        const traceparentValue = Array.isArray(traceparentHeader)
+          ? traceparentHeader[0]
+          : traceparentHeader;
+        if (traceparentValue) {
+          const parsed = parseTraceParent(traceparentValue);
+          if (parsed) {
+            const context: WebSocketTelemetryConnectionContext = {
+              traceId: parsed.traceId,
+              parentSpanId: parsed.parentId,
+              sampled: parsed.sampled,
+            };
+            if (this.traceOptions.generateConnectionTrace) {
+              context.spanId = generateSpanId();
+            }
+            return { ...context };
+          }
+        }
+      }
+
+      if (!this.traceOptions.generateConnectionTrace) {
+        return {};
+      }
+
+      return { traceId: generateTraceId(), spanId: generateSpanId() };
+    } catch {
+      return {};
+    }
+  }
+
+  getTraceOptions(): WebSocketTelemetryTraceOptions {
+    return { ...this.traceOptions };
+  }
+
+  async shutdown(options?: { timeoutMs?: number }): Promise<void> {
+    if (this.shutdownCalled) return;
+    this.shutdownCalled = true;
+
+    const timeoutMs = options?.timeoutMs ?? this.shutdownTimeoutMs;
+    try {
+      await Promise.allSettled([
+        this.events.shutdown(timeoutMs),
+        this.metrics.shutdown(timeoutMs),
+        this.spans.shutdown(timeoutMs),
+      ]);
+    } catch {
+      // controller shutdown은 throw-free
+    }
+  }
+}
+
+// -- Factory --
+
+function buildController(
+  options: WebSocketTelemetryOptions,
+  runtimeMetadata: RuntimeMetadata,
+): WebSocketTelemetryController {
+  const defaults = options.defaults ?? {};
+  const eventsOpt = options.events ?? {};
+  const metricsOpt = options.metrics ?? {};
+  const spansOpt = options.spans ?? {};
+
+  const defaultsMaxRecordsPerSecond =
+    defaults.maxRecordsPerSecond ?? DEFAULT_MAX_RECORDS_PER_SECOND;
+
+  // 신호별 redactor / beforeRecord 해석.
+  // null이면 sharedRedactor를 undefined로 덮어써 step 2 자체를 skip한다.
+  const eventsSharedRedactor = eventsOpt.redactor === null ? undefined : defaults.redactor;
+  const eventsSignalRedactor =
+    typeof eventsOpt.redactor === "function" ? eventsOpt.redactor : undefined;
+  const eventsSharedBeforeRecord =
+    eventsOpt.beforeRecord === null ? undefined : defaults.beforeRecord;
+  const eventsSignalBeforeRecord =
+    typeof eventsOpt.beforeRecord === "function" ? eventsOpt.beforeRecord : undefined;
+
+  const metricsSharedRedactor = metricsOpt.redactor === null ? undefined : defaults.redactor;
+  const metricsSignalRedactor =
+    typeof metricsOpt.redactor === "function" ? metricsOpt.redactor : undefined;
+  const metricsSharedBeforeRecord =
+    metricsOpt.beforeRecord === null ? undefined : defaults.beforeRecord;
+  const metricsSignalBeforeRecord =
+    typeof metricsOpt.beforeRecord === "function" ? metricsOpt.beforeRecord : undefined;
+
+  const spansSharedRedactor = spansOpt.redactor === null ? undefined : defaults.redactor;
+  const spansSignalRedactor =
+    typeof spansOpt.redactor === "function" ? spansOpt.redactor : undefined;
+  const spansSharedBeforeRecord =
+    spansOpt.beforeRecord === null ? undefined : defaults.beforeRecord;
+  const spansSignalBeforeRecord =
+    typeof spansOpt.beforeRecord === "function" ? spansOpt.beforeRecord : undefined;
+
+  // events
+  const eventSinks: WebSocketTelemetryEventSink[] = eventsOpt.sinks ? [...eventsOpt.sinks] : [];
+  let eventStore: WebSocketTelemetryEventStore | undefined = eventsOpt.store;
+  if (eventSinks.length === 0 && eventStore === undefined) {
+    eventStore = new InMemoryEventStore({
+      maxRecords: eventsOpt.maxRecords ?? defaults.maxRecords,
+      maxBytes: eventsOpt.maxBytes ?? defaults.maxBytes,
+    });
+    eventSinks.push(eventStore.sink);
+  } else if (eventStore !== undefined && !eventSinks.includes(eventStore.sink)) {
+    eventSinks.push(eventStore.sink);
+  }
+
+  const eventsResolved: ResolvedEventPipelineOptions = {
+    sinks: eventSinks,
+    store: eventStore,
+    maxRecordsPerSecond: eventsOpt.sampling?.maxRecordsPerSecond ?? defaultsMaxRecordsPerSecond,
+    maxInFlightEmits: eventsOpt.maxInFlightEmits ?? DEFAULT_MAX_IN_FLIGHT_EMITS_PER_SINK,
+    sharedRedactor: eventsSharedRedactor,
+    signalRedactor: eventsSignalRedactor,
+    sharedBeforeRecord: eventsSharedBeforeRecord,
+    signalBeforeRecord: eventsSignalBeforeRecord,
+    sampling: {
+      defaultRate: eventsOpt.sampling?.defaultRate ?? DEFAULT_EVENT_SAMPLING_DEFAULT_RATE,
+      rateByEvent: eventsOpt.sampling?.rateByEvent ?? {},
+      alwaysRecordLevels: eventsOpt.sampling?.alwaysRecordLevels ?? [
+        ...DEFAULT_EVENT_ALWAYS_RECORD_LEVELS,
+      ],
+    },
+    capturePayload: eventsOpt.capturePayload ?? DEFAULT_EVENT_CAPTURE_PAYLOAD,
+    maxPayloadPreviewBytes:
+      eventsOpt.maxPayloadPreviewBytes ?? DEFAULT_EVENT_MAX_PAYLOAD_PREVIEW_BYTES,
+  };
+
+  // metrics
+  const metricSinks: WebSocketTelemetryMetricSink[] = metricsOpt.sinks ? [...metricsOpt.sinks] : [];
+  let metricStore: WebSocketTelemetryMetricStore | undefined = metricsOpt.store;
+  if (metricSinks.length === 0 && metricStore === undefined) {
+    metricStore = new InMemoryMetricStore({
+      maxRecords: metricsOpt.maxRecords ?? defaults.maxRecords,
+      maxBytes: metricsOpt.maxBytes ?? defaults.maxBytes,
+    });
+    metricSinks.push(metricStore.sink);
+  } else if (metricStore !== undefined && !metricSinks.includes(metricStore.sink)) {
+    metricSinks.push(metricStore.sink);
+  }
+
+  const metricsResolved: ResolvedMetricPipelineOptions = {
+    sinks: metricSinks,
+    store: metricStore,
+    maxRecordsPerSecond: metricsOpt.sampling?.maxRecordsPerSecond ?? defaultsMaxRecordsPerSecond,
+    maxInFlightEmits: metricsOpt.maxInFlightEmits ?? DEFAULT_MAX_IN_FLIGHT_EMITS_PER_SINK,
+    sharedRedactor: metricsSharedRedactor,
+    signalRedactor: metricsSignalRedactor,
+    sharedBeforeRecord: metricsSharedBeforeRecord,
+    signalBeforeRecord: metricsSignalBeforeRecord,
+    collectionEnabled: metricsOpt.collectionEnabled ?? DEFAULT_METRIC_COLLECTION_ENABLED,
+    sampleIntervalMs: metricsOpt.sampleIntervalMs ?? DEFAULT_METRIC_SAMPLE_INTERVAL_MS,
+  };
+
+  // spans
+  const spanSinks: WebSocketTelemetrySpanSink[] = spansOpt.sinks ? [...spansOpt.sinks] : [];
+  let spanStore: WebSocketTelemetrySpanStore | undefined = spansOpt.store;
+  if (spanSinks.length === 0 && spanStore === undefined) {
+    spanStore = new InMemorySpanStore({
+      maxRecords: spansOpt.maxRecords ?? defaults.maxRecords,
+      maxBytes: spansOpt.maxBytes ?? defaults.maxBytes,
+    });
+    spanSinks.push(spanStore.sink);
+  } else if (spanStore !== undefined && !spanSinks.includes(spanStore.sink)) {
+    spanSinks.push(spanStore.sink);
+  }
+
+  const spansResolved: ResolvedSpanPipelineOptions = {
+    sinks: spanSinks,
+    store: spanStore,
+    maxRecordsPerSecond: spansOpt.sampling?.maxRecordsPerSecond ?? defaultsMaxRecordsPerSecond,
+    maxInFlightEmits: spansOpt.maxInFlightEmits ?? DEFAULT_MAX_IN_FLIGHT_EMITS_PER_SINK,
+    sharedRedactor: spansSharedRedactor,
+    signalRedactor: spansSignalRedactor,
+    sharedBeforeRecord: spansSharedBeforeRecord,
+    signalBeforeRecord: spansSignalBeforeRecord,
+    sampling: {
+      defaultRate: spansOpt.sampling?.defaultRate ?? DEFAULT_SPAN_SAMPLING_DEFAULT_RATE,
+    },
+  };
+
+  const eventPipeline = new EventPipeline(eventsResolved, runtimeMetadata);
+  const metricPipeline = new MetricPipeline(metricsResolved, runtimeMetadata);
+  const spanPipeline = new SpanPipeline(spansResolved, runtimeMetadata);
+
+  const traceOptions: WebSocketTelemetryTraceOptions = {
+    extractTraceParent:
+      options.trace?.extractTraceParent ?? DEFAULT_TRACE_OPTIONS.extractTraceParent,
+    generateConnectionTrace:
+      options.trace?.generateConnectionTrace ?? DEFAULT_TRACE_OPTIONS.generateConnectionTrace,
+    propagateMessageTrace:
+      options.trace?.propagateMessageTrace ?? DEFAULT_TRACE_OPTIONS.propagateMessageTrace,
+    recordConnectionLifetimeSpan:
+      options.trace?.recordConnectionLifetimeSpan ??
+      DEFAULT_TRACE_OPTIONS.recordConnectionLifetimeSpan,
+  };
+
+  const shutdownTimeoutMs = options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+
+  return new WebSocketTelemetryControllerImpl(
+    eventPipeline,
+    metricPipeline,
+    spanPipeline,
+    traceOptions,
+    runtimeMetadata,
+    shutdownTimeoutMs,
+  );
+}
+
+function assertControllerOptionIsExclusive(options: WebSocketTelemetryOptions): void {
+  const ignoredKeys = Object.entries(options)
+    .filter(([key, value]) => key !== "enabled" && key !== "controller" && value !== undefined)
+    .map(([key]) => key);
+
+  if (ignoredKeys.length === 0) return;
+
+  throw new Error(
+    `WebSocket telemetry controller option cannot be combined with other telemetry options: ${ignoredKeys.join(
+      ", ",
+    )}`,
+  );
+}
+
+export function createWebSocketTelemetryController(
+  telemetryOption: boolean | WebSocketTelemetryOptions | undefined,
+  runtimeMetadata: RuntimeMetadata,
+): WebSocketTelemetryController {
+  if (telemetryOption === undefined || telemetryOption === false) {
+    return new NoopWebSocketTelemetryController();
+  }
+
+  if (telemetryOption === true) {
+    return buildController({}, runtimeMetadata);
+  }
+
+  if (telemetryOption.enabled === false) {
+    return new NoopWebSocketTelemetryController();
+  }
+
+  if (telemetryOption.controller) {
+    assertControllerOptionIsExclusive(telemetryOption);
+    return telemetryOption.controller;
+  }
+
+  return buildController(telemetryOption, runtimeMetadata);
+}

--- a/modules/sonamu/src/stream/ws-telemetry.ts
+++ b/modules/sonamu/src/stream/ws-telemetry.ts
@@ -10,6 +10,9 @@ export type WebSocketTelemetryRecordBase = {
   nodeId: string;
   namespace?: string;
   connectionId?: string;
+  // userId는 connection 소유자를 식별하기 위한 opaque identifier (보통 DB PK)
+  // pseudonymous identifier로만 사용하며, 이메일/전화번호 등 PII는 들어가지 않는다고 가정함
+  userId?: string;
   traceId?: string;
   spanId?: string;
   parentSpanId?: string;
@@ -67,6 +70,7 @@ export type WebSocketTelemetryEventInput = {
   level: "debug" | "info" | "warn" | "error";
   namespace?: string;
   connectionId?: string;
+  userId?: string;
   attributes?: Record<string, string | number | boolean>;
   detail?: Record<string, unknown>;
   payload?: unknown;
@@ -84,6 +88,7 @@ export type WebSocketMetricInput = {
   tags?: Record<string, string>;
   namespace?: string;
   connectionId?: string;
+  userId?: string;
   traceId?: string;
   spanId?: string;
   parentSpanId?: string;
@@ -98,6 +103,7 @@ export type WebSocketSpanInput = {
   status: "unset" | "ok" | "error";
   namespace?: string;
   connectionId?: string;
+  userId?: string;
   attributes?: Record<string, string | number | boolean>;
   errorType?: string;
   traceId?: string;
@@ -172,6 +178,7 @@ export type WebSocketTelemetryEventQueryFilter = {
   name?: string;
   level?: "debug" | "info" | "warn" | "error";
   connectionId?: string;
+  userId?: string;
   namespace?: string;
   traceId?: string;
   since?: number;
@@ -183,6 +190,7 @@ export type WebSocketTelemetryMetricQueryFilter = {
   name?: string;
   kind?: "counter" | "histogram" | "gauge";
   connectionId?: string;
+  userId?: string;
   namespace?: string;
   traceId?: string;
   since?: number;
@@ -195,6 +203,7 @@ export type WebSocketTelemetrySpanQueryFilter = {
   kind?: "internal" | "producer" | "consumer" | "server" | "client";
   status?: "unset" | "ok" | "error";
   connectionId?: string;
+  userId?: string;
   namespace?: string;
   traceId?: string;
   since?: number;
@@ -1082,6 +1091,7 @@ class EventPipeline extends TelemetryPipeline<
       level: input.level,
       namespace: input.namespace,
       connectionId: input.connectionId,
+      userId: input.userId,
       attributes: input.attributes,
       detail: input.detail,
       traceId: input.traceId,
@@ -1192,6 +1202,7 @@ class MetricPipeline extends TelemetryPipeline<
       tags: input.tags,
       namespace: input.namespace,
       connectionId: input.connectionId,
+      userId: input.userId,
       traceId: input.traceId,
       spanId: input.spanId,
       parentSpanId: input.parentSpanId,
@@ -1368,6 +1379,7 @@ class SpanPipeline extends TelemetryPipeline<
       status: input.status,
       namespace: input.namespace,
       connectionId: input.connectionId,
+      userId: input.userId,
       attributes: input.attributes,
       errorType: input.errorType,
       traceId: input.traceId,

--- a/modules/sonamu/src/stream/ws.ts
+++ b/modules/sonamu/src/stream/ws.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { hostname } from "node:os";
 
 import { type WebSocket } from "ws";
 import { z } from "zod";
@@ -122,12 +123,15 @@ export class WebSocketRuntime {
   readonly telemetryController: WebSocketTelemetryController;
 
   constructor(options: WebSocketRuntimeOptions = {}) {
+    // 분산 환경에서 노드 간 충돌을 막기 위해 hostname + pid로 디폴트 식별자를 만든다.
+    // 같은 호스트에 여러 프로세스가 떠 있어도 pid로 구분되며, 로그/메트릭에서도 식별이 쉬움
+    const resolvedNodeId = options.nodeId ?? `${hostname()}-${process.pid}`;
     this.telemetryController = createWebSocketTelemetryController(options.telemetry, {
       runtimeId: randomUUID(),
-      nodeId: options.nodeId ?? "local",
+      nodeId: resolvedNodeId,
     });
     const registryOptions: WebSocketRegistryOptions = {
-      nodeId: options.nodeId,
+      nodeId: resolvedNodeId,
       presenceStore: options.presenceStore,
       clusterBus: options.clusterBus,
       telemetryController: this.telemetryController,

--- a/modules/sonamu/src/stream/ws.ts
+++ b/modules/sonamu/src/stream/ws.ts
@@ -210,6 +210,13 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
   private readonly connectionSampled?: boolean;
   private readonly connectionStartedAt = performance.now();
 
+  // connection 수명 동안 유지되는 식별자. setUserId/clearUserId로 업데이트되며 emit hot path에서 매번 registry lookup하지 않도록 캐시함
+  private _userId?: string;
+
+  get userId(): string | undefined {
+    return this._userId;
+  }
+
   private closedInternal = false;
   private closeStarted = false;
   private awaitingPong = false;
@@ -288,10 +295,12 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
   }
 
   setUserId(userId: WebSocketUserId): void {
+    this._userId = String(userId);
     this.options.registry.setUserId(this.id, userId);
   }
 
   clearUserId(): void {
+    this._userId = undefined;
     this.options.registry.clearUserId(this.id);
   }
 
@@ -312,17 +321,27 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
     };
   }
 
-  private emitInboundRejected(reason: string, event?: string): void {
-    this.options.telemetryController.emit({
-      name: "ws.message.rejected",
-      level: "warn",
+  // 모든 telemetry emit site가 공유하는 connection-level field 묶음.
+  // 향후 connection-scoped 식별자(e.g. tenantId)가 추가될 때 한 곳만 손대면 됨
+  private telemetryFields() {
+    return {
       connectionId: this.id,
       namespace: this.namespace,
-      detail: event !== undefined ? { reason, event } : { reason },
+      userId: this._userId,
       traceId: this.connectionTraceId,
       spanId: this.connectionSpanId,
       parentSpanId: this.connectionParentSpanId,
       sampled: this.connectionSampled,
+    };
+  }
+
+  private emitInboundRejected(reason: string, event?: string): void {
+    const fields = this.telemetryFields();
+    this.options.telemetryController.emit({
+      name: "ws.message.rejected",
+      level: "warn",
+      ...fields,
+      detail: event !== undefined ? { reason, event } : { reason },
     });
     this.options.telemetryController.recordMetric({
       name: "sonamu.ws.messages",
@@ -330,11 +349,7 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       value: 1,
       unit: "1",
       tags: { direction: "inbound", outcome: "rejected" },
-      namespace: this.namespace,
-      traceId: this.connectionTraceId,
-      spanId: this.connectionSpanId,
-      parentSpanId: this.connectionParentSpanId,
-      sampled: this.connectionSampled,
+      ...fields,
     });
   }
 
@@ -372,14 +387,9 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       this.options.telemetryController.emit({
         name: "ws.message.received",
         level: "debug",
-        connectionId: this.id,
-        namespace: this.namespace,
+        ...this.telemetryFields(),
         detail: { event: parsedEnvelope.event },
         payload: parsedEnvelope.data,
-        traceId: this.connectionTraceId,
-        spanId: this.connectionSpanId,
-        parentSpanId: this.connectionParentSpanId,
-        sampled: this.connectionSampled,
       });
       this.options.registry.touch(this.id);
       await this.dispatchEnvelope(parsedEnvelope);
@@ -425,13 +435,8 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       this.options.telemetryController.emit({
         name: "ws.trace.invalid",
         level: "debug",
-        connectionId: this.id,
-        namespace: this.namespace,
+        ...this.telemetryFields(),
         detail: { source: "message", traceparent: envelope.meta.traceparent },
-        traceId: this.connectionTraceId,
-        spanId: this.connectionSpanId,
-        parentSpanId: this.connectionParentSpanId,
-        sampled: this.connectionSampled,
       });
     }
 
@@ -468,8 +473,7 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
         this.options.telemetryController.emit({
           name: "ws.message.buffer.dropped",
           level: "warn",
-          connectionId: this.id,
-          namespace: this.namespace,
+          ...this.telemetryFields(),
           detail: { event: envelope.event },
         });
         this.pendingMessages.shift();
@@ -478,14 +482,23 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       this.options.telemetryController.emit({
         name: "ws.message.buffered",
         level: "debug",
-        connectionId: this.id,
-        namespace: this.namespace,
+        ...this.telemetryFields(),
         detail: { event: envelope.event },
       });
       return;
     }
 
     const traceCtx = this.resolveMessageTraceContext(envelope);
+    // message-level trace는 connection-level trace를 override함. userId / connectionId / namespace는 그대로 유지
+    const messageTraceFields = {
+      connectionId: this.id,
+      namespace: this.namespace,
+      userId: this._userId,
+      traceId: traceCtx.traceId,
+      spanId: traceCtx.spanId,
+      parentSpanId: traceCtx.parentSpanId,
+      sampled: traceCtx.sampled,
+    };
     try {
       for (const handler of handlers) {
         await handler(parsed.data, traceCtx);
@@ -493,13 +506,8 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       this.options.telemetryController.emit({
         name: "ws.message.dispatched",
         level: "debug",
-        connectionId: this.id,
-        namespace: this.namespace,
+        ...messageTraceFields,
         detail: { event: envelope.event },
-        traceId: traceCtx.traceId,
-        spanId: traceCtx.spanId,
-        parentSpanId: traceCtx.parentSpanId,
-        sampled: traceCtx.sampled,
       });
       this.options.telemetryController.recordMetric({
         name: "sonamu.ws.messages",
@@ -507,23 +515,14 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
         value: 1,
         unit: "1",
         tags: { direction: "inbound", event: envelope.event, outcome: "accepted" },
-        namespace: this.namespace,
-        traceId: traceCtx.traceId,
-        spanId: traceCtx.spanId,
-        parentSpanId: traceCtx.parentSpanId,
-        sampled: traceCtx.sampled,
+        ...messageTraceFields,
       });
     } catch (error) {
       this.options.telemetryController.emit({
         name: "ws.message.failed",
         level: "error",
-        connectionId: this.id,
-        namespace: this.namespace,
+        ...messageTraceFields,
         detail: { event: envelope.event },
-        traceId: traceCtx.traceId,
-        spanId: traceCtx.spanId,
-        parentSpanId: traceCtx.parentSpanId,
-        sampled: traceCtx.sampled,
       });
       throw error;
     }
@@ -558,12 +557,8 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       this.options.telemetryController.emit({
         name: "ws.publish.rejected",
         level: "error",
-        connectionId: this.id,
-        namespace: this.namespace,
+        ...this.telemetryFields(),
         detail: { event, reason: "unknownEvent" },
-        traceId: this.connectionTraceId,
-        spanId: this.connectionSpanId,
-        parentSpanId: this.connectionParentSpanId,
       });
       throw new Error(`Unknown websocket event: ${event}`);
     }
@@ -573,12 +568,8 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       this.options.telemetryController.emit({
         name: "ws.publish.rejected",
         level: "error",
-        connectionId: this.id,
-        namespace: this.namespace,
+        ...this.telemetryFields(),
         detail: { event, reason: "invalidPayload" },
-        traceId: this.connectionTraceId,
-        spanId: this.connectionSpanId,
-        parentSpanId: this.connectionParentSpanId,
       });
       throw new Error(`Invalid websocket event payload: ${event}`);
     }
@@ -587,12 +578,8 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       this.options.telemetryController.emit({
         name: "ws.publish.dropped",
         level: "debug",
-        connectionId: this.id,
-        namespace: this.namespace,
+        ...this.telemetryFields(),
         detail: { event, reason: "connectionClosed" },
-        traceId: this.connectionTraceId,
-        spanId: this.connectionSpanId,
-        parentSpanId: this.connectionParentSpanId,
       });
       return;
     }
@@ -617,14 +604,11 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
     this.closedInternal = true;
     this.closeStarted = false;
     this.stopHeartbeat();
+    const fields = this.telemetryFields();
     this.options.telemetryController.emit({
       name: "ws.connection.closed",
       level: "info",
-      connectionId: this.id,
-      namespace: this.namespace,
-      traceId: this.connectionTraceId,
-      spanId: this.connectionSpanId,
-      parentSpanId: this.connectionParentSpanId,
+      ...fields,
     });
     if (this.options.telemetryController.getTraceOptions().recordConnectionLifetimeSpan) {
       this.options.telemetryController.recordSpan({
@@ -632,12 +616,7 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
         kind: "server",
         durationMs: performance.now() - this.connectionStartedAt,
         status: deriveLifetimeStatus(code),
-        connectionId: this.id,
-        namespace: this.namespace,
-        traceId: this.connectionTraceId,
-        spanId: this.connectionSpanId,
-        parentSpanId: this.connectionParentSpanId,
-        sampled: this.connectionSampled,
+        ...fields,
       });
     }
     this.socket.off("message", this.handleMessage);
@@ -678,8 +657,7 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
         this.options.telemetryController.emit({
           name: "ws.heartbeat.timeout",
           level: "warn",
-          connectionId: this.id,
-          namespace: this.namespace,
+          ...this.telemetryFields(),
         });
         this.close(WS_CLOSE_CODE_GOING_AWAY, "Heartbeat timeout");
         return;
@@ -739,11 +717,7 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       this.options.telemetryController.emit({
         name: "ws.backpressure.overflow",
         level: "error",
-        connectionId: this.id,
-        namespace: this.namespace,
-        traceId: this.connectionTraceId,
-        spanId: this.connectionSpanId,
-        parentSpanId: this.connectionParentSpanId,
+        ...this.telemetryFields(),
       });
       this.close(WS_CLOSE_CODE_TRY_AGAIN_LATER, "WebSocket backpressure overflow");
       return;
@@ -753,13 +727,9 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
     this.options.telemetryController.emit({
       name: "ws.publish.queued",
       level: "debug",
-      connectionId: this.id,
-      namespace: this.namespace,
+      ...this.telemetryFields(),
       detail: { event },
       payload: data,
-      traceId: this.connectionTraceId,
-      spanId: this.connectionSpanId,
-      parentSpanId: this.connectionParentSpanId,
     });
     this.scheduleOutboundFlush();
   }
@@ -794,11 +764,7 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       this.options.telemetryController.emit({
         name: "ws.backpressure.delayed",
         level: "warn",
-        connectionId: this.id,
-        namespace: this.namespace,
-        traceId: this.connectionTraceId,
-        spanId: this.connectionSpanId,
-        parentSpanId: this.connectionParentSpanId,
+        ...this.telemetryFields(),
       });
       this.scheduleOutboundFlush(OUTBOUND_RETRY_DELAY_MS);
       return;
@@ -817,30 +783,23 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       const { payload, event } = next;
 
       const startedAt = performance.now();
+      const fields = this.telemetryFields();
       try {
         this.socket.send(payload);
         const durationMs = performance.now() - startedAt;
         this.options.telemetryController.emit({
           name: "ws.publish.sent",
           level: "debug",
-          connectionId: this.id,
-          namespace: this.namespace,
+          ...fields,
           detail: { event },
-          traceId: this.connectionTraceId,
-          spanId: this.connectionSpanId,
-          parentSpanId: this.connectionParentSpanId,
         });
         this.options.telemetryController.recordSpan({
           operationName: "ws.publish.send",
           kind: "producer",
           durationMs,
           status: "unset",
-          connectionId: this.id,
-          namespace: this.namespace,
+          ...fields,
           attributes: { event },
-          traceId: this.connectionTraceId,
-          spanId: this.connectionSpanId,
-          parentSpanId: this.connectionParentSpanId,
         });
         this.options.telemetryController.recordMetric({
           name: "sonamu.ws.publishes",
@@ -848,32 +807,24 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
           value: 1,
           unit: "1",
           tags: { outcome: "sent", event },
-          namespace: this.namespace,
+          ...fields,
         });
       } catch (error) {
         const durationMs = performance.now() - startedAt;
         this.options.telemetryController.emit({
           name: "ws.publish.failed",
           level: "error",
-          connectionId: this.id,
-          namespace: this.namespace,
+          ...fields,
           detail: { event },
-          traceId: this.connectionTraceId,
-          spanId: this.connectionSpanId,
-          parentSpanId: this.connectionParentSpanId,
         });
         this.options.telemetryController.recordSpan({
           operationName: "ws.publish.send",
           kind: "producer",
           durationMs,
           status: "error",
-          connectionId: this.id,
-          namespace: this.namespace,
+          ...fields,
           attributes: { event },
           errorType: error instanceof Error ? error.name : typeof error,
-          traceId: this.connectionTraceId,
-          spanId: this.connectionSpanId,
-          parentSpanId: this.connectionParentSpanId,
         });
         this.close(WS_CLOSE_CODE_INTERNAL_ERROR, "Outbound publish failed");
         return;

--- a/modules/sonamu/src/stream/ws.ts
+++ b/modules/sonamu/src/stream/ws.ts
@@ -13,6 +13,17 @@ import {
   type WebSocketRoomId,
   type WebSocketUserId,
 } from "./ws-registry";
+import {
+  type TelemetryContextProvider,
+  type WebSocketTelemetryConnectionSnapshot,
+  type WebSocketTelemetryConnectionContext,
+  type WebSocketTelemetryController,
+  type WebSocketTelemetryOptions,
+  type TelemetryInspectableConnection,
+  createWebSocketTelemetryController,
+  isPromiseLike,
+} from "./ws-telemetry";
+import { parseTraceParent, generateSpanId } from "./ws-telemetry-trace";
 
 // transport-level 상수와 queue threshold를 한 파일에 모아 lifecycle/backpressure 정책을 중앙화함
 const WS_CONNECTING = 0;
@@ -32,12 +43,22 @@ const OUTBOUND_BATCH_SIZE = 50;
 const OUTBOUND_RETRY_DELAY_MS = 5;
 
 // envelope을 `{event, data}` 형태로 고정해 server handler와 generated client가 같은 framing contract를 쓰게 함
+// meta는 optional이므로 기존 `{event, data}` 메시지도 그대로 파싱됨 (backward-compatible)
 const WebSocketEnvelopeSchema = z.object({
   event: z.string(),
   data: z.unknown(),
+  meta: z
+    .object({
+      traceparent: z.string().optional(),
+      tracestate: z.string().optional(),
+    })
+    .optional(),
 });
 
-type MessageHandler<T> = (data: T) => void | Promise<void>;
+type MessageHandler<T> = (
+  data: T,
+  telemetryContext?: WebSocketTelemetryConnectionContext,
+) => void | Promise<void>;
 type CloseHandler = () => void | Promise<void>;
 
 export type WebSocketEventMap = Record<string, unknown>;
@@ -81,34 +102,50 @@ type WebSocketConnectionOptions<TOut extends z.ZodRawShape, TIn extends z.ZodRaw
   outEvents: z.ZodObject<TOut>;
   inEvents: z.ZodObject<TIn>;
   registry: WebSocketRegistry;
+  telemetryController: WebSocketTelemetryController;
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  sampled?: boolean;
 };
 
 export type WebSocketRuntimeOptions = {
   nodeId?: string;
   presenceStore?: WebSocketPresenceStore;
   clusterBus?: WebSocketClusterBus;
+  telemetry?: boolean | WebSocketTelemetryOptions;
 };
 
 // registry를 소유하고 connection 생성/shutdown을 담당함. Sonamu 애플리케이션 수명주기와 같이 움직이도록 설계함
 export class WebSocketRuntime {
   readonly registry: WebSocketRegistry;
+  readonly telemetryController: WebSocketTelemetryController;
 
   constructor(options: WebSocketRuntimeOptions = {}) {
+    this.telemetryController = createWebSocketTelemetryController(options.telemetry, {
+      runtimeId: randomUUID(),
+      nodeId: options.nodeId ?? "local",
+    });
     const registryOptions: WebSocketRegistryOptions = {
       nodeId: options.nodeId,
       presenceStore: options.presenceStore,
       clusterBus: options.clusterBus,
+      telemetryController: this.telemetryController,
     };
     this.registry = new WebSocketRegistry(registryOptions);
   }
 
   registerConnection<TOutSchema extends z.ZodRawShape, TInSchema extends z.ZodRawShape>(
     socket: WebSocket,
-    options: Omit<WebSocketConnectionOptions<TOutSchema, TInSchema>, "registry">,
+    options: Omit<
+      WebSocketConnectionOptions<TOutSchema, TInSchema>,
+      "registry" | "telemetryController"
+    >,
   ): WebSocketConnection<InferWebSocketEventMap<TOutSchema>, InferWebSocketEventMap<TInSchema>> {
     return new WebSocketConnectionImpl(socket, {
       ...options,
       registry: this.registry,
+      telemetryController: this.telemetryController,
     });
   }
 
@@ -138,6 +175,7 @@ export class WebSocketRuntime {
     reason = "Server shutting down",
   ): Promise<void> {
     await this.registry.shutdown(code, reason);
+    await this.telemetryController.shutdown();
   }
 }
 
@@ -145,13 +183,12 @@ export function createWebSocketRuntime(options: WebSocketRuntimeOptions = {}): W
   return new WebSocketRuntime(options);
 }
 
-class WebSocketConnectionImpl<
-  TOutSchema extends z.ZodRawShape,
-  TInSchema extends z.ZodRawShape,
-> implements WebSocketConnection<
-  InferWebSocketEventMap<TOutSchema>,
-  InferWebSocketEventMap<TInSchema>
-> {
+class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extends z.ZodRawShape>
+  implements
+    WebSocketConnection<InferWebSocketEventMap<TOutSchema>, InferWebSocketEventMap<TInSchema>>,
+    TelemetryInspectableConnection,
+    TelemetryContextProvider
+{
   readonly id = randomUUID();
   readonly transport = "ws";
   readonly namespace: string;
@@ -159,13 +196,19 @@ class WebSocketConnectionImpl<
   private readonly closeCallbacks: CloseHandler[] = [];
   private readonly messageHandlers = new Map<string, Array<MessageHandler<unknown>>>();
   private readonly pendingMessages: ParsedEnvelope[] = [];
-  private readonly pendingOutboundMessages: string[] = [];
+  private readonly pendingOutboundMessages: Array<{ payload: string; event: string }> = [];
   private readonly closePromise: Promise<void>;
   private readonly resolveClosePromise: () => void;
   private readonly heartbeatMs: number;
   private readonly maxPayload?: number;
   private readonly eventSchemasIn: Record<string, z.ZodTypeAny>;
   private readonly eventSchemasOut: Record<string, z.ZodTypeAny>;
+
+  private readonly connectionTraceId?: string;
+  private readonly connectionSpanId?: string;
+  private readonly connectionParentSpanId?: string;
+  private readonly connectionSampled?: boolean;
+  private readonly connectionStartedAt = performance.now();
 
   private closedInternal = false;
   private closeStarted = false;
@@ -181,6 +224,10 @@ class WebSocketConnectionImpl<
     this.namespace = options.namespace ?? "default";
     this.heartbeatMs = options.heartbeat ?? 30000;
     this.maxPayload = options.maxPayload;
+    this.connectionTraceId = options.traceId;
+    this.connectionSpanId = options.spanId;
+    this.connectionParentSpanId = options.parentSpanId;
+    this.connectionSampled = options.sampled;
     this.eventSchemasIn = options.inEvents.shape as unknown as Record<string, z.ZodTypeAny>;
     this.eventSchemasOut = options.outEvents.shape as unknown as Record<string, z.ZodTypeAny>;
 
@@ -248,6 +295,49 @@ class WebSocketConnectionImpl<
     this.options.registry.clearUserId(this.id);
   }
 
+  getTelemetrySnapshot(): WebSocketTelemetryConnectionSnapshot {
+    return {
+      pendingInboundMessages: this.pendingMessages.length,
+      pendingOutboundMessages: this.pendingOutboundMessages.length,
+      socketBufferedBytes: this.socket.readyState === WS_OPEN ? this.socket.bufferedAmount : 0,
+    };
+  }
+
+  getTelemetryContext(): WebSocketTelemetryConnectionContext {
+    return {
+      traceId: this.connectionTraceId,
+      spanId: this.connectionSpanId,
+      parentSpanId: this.connectionParentSpanId,
+      sampled: this.connectionSampled,
+    };
+  }
+
+  private emitInboundRejected(reason: string, event?: string): void {
+    this.options.telemetryController.emit({
+      name: "ws.message.rejected",
+      level: "warn",
+      connectionId: this.id,
+      namespace: this.namespace,
+      detail: event !== undefined ? { reason, event } : { reason },
+      traceId: this.connectionTraceId,
+      spanId: this.connectionSpanId,
+      parentSpanId: this.connectionParentSpanId,
+      sampled: this.connectionSampled,
+    });
+    this.options.telemetryController.recordMetric({
+      name: "sonamu.ws.messages",
+      kind: "counter",
+      value: 1,
+      unit: "1",
+      tags: { direction: "inbound", outcome: "rejected" },
+      namespace: this.namespace,
+      traceId: this.connectionTraceId,
+      spanId: this.connectionSpanId,
+      parentSpanId: this.connectionParentSpanId,
+      sampled: this.connectionSampled,
+    });
+  }
+
   // transport 종료 도중 예외가 나도 markClosed가 반드시 실행되도록 try/finally로 감쌈
   close(code?: number, reason?: string): void {
     if (this.closedInternal || this.closeStarted || this.socket.readyState === WS_CLOSED) {
@@ -258,7 +348,7 @@ class WebSocketConnectionImpl<
     try {
       this.closeTransport(code, reason);
     } finally {
-      this.markClosed();
+      this.markClosed(code, reason);
     }
   }
 
@@ -267,23 +357,37 @@ class WebSocketConnectionImpl<
     this.enqueueMessageTask(async () => {
       const text = normalizeMessage(raw);
       if (this.maxPayload !== undefined && Buffer.byteLength(text) > this.maxPayload) {
+        this.emitInboundRejected("maxPayload");
         this.close(WS_CLOSE_CODE_MESSAGE_TOO_BIG, "Message too large");
         return;
       }
 
       const parsedEnvelope = safeParseEnvelope(text);
       if (!parsedEnvelope) {
+        this.emitInboundRejected("invalidPayload");
         this.close(WS_CLOSE_CODE_INVALID_FRAME_PAYLOAD_DATA, "Invalid message payload");
         return;
       }
 
+      this.options.telemetryController.emit({
+        name: "ws.message.received",
+        level: "debug",
+        connectionId: this.id,
+        namespace: this.namespace,
+        detail: { event: parsedEnvelope.event },
+        traceId: this.connectionTraceId,
+        spanId: this.connectionSpanId,
+        parentSpanId: this.connectionParentSpanId,
+        sampled: this.connectionSampled,
+      });
       this.options.registry.touch(this.id);
       await this.dispatchEnvelope(parsedEnvelope);
     });
   };
 
-  private readonly handleClose = () => {
-    this.markClosed();
+  private readonly handleClose = (code?: number, reason?: Buffer | string) => {
+    const reasonText = typeof reason === "string" ? reason : reason?.toString();
+    this.markClosed(code, reasonText);
   };
 
   // 소켓이 transport error를 emit하면 즉시 1011 close로 수렴시켜 상태 누락을 막음
@@ -296,6 +400,48 @@ class WebSocketConnectionImpl<
     this.options.registry.touch(this.id);
   };
 
+  // envelope의 meta.traceparent로부터 trace context를 추출함
+  // invalid traceparent는 연결을 거부하지 않고 debug 레벨 경고만 emit함
+  private resolveMessageTraceContext(
+    envelope: ParsedEnvelope,
+  ): WebSocketTelemetryConnectionContext {
+    const messageSpanId = generateSpanId();
+
+    if (
+      this.options.telemetryController.getTraceOptions().propagateMessageTrace &&
+      envelope.meta?.traceparent
+    ) {
+      const parsed = parseTraceParent(envelope.meta.traceparent);
+      if (parsed) {
+        return {
+          traceId: parsed.traceId,
+          spanId: messageSpanId,
+          parentSpanId: parsed.parentId,
+          sampled: parsed.sampled,
+        };
+      }
+      // invalid traceparent: warn but do not reject
+      this.options.telemetryController.emit({
+        name: "ws.trace.invalid",
+        level: "debug",
+        connectionId: this.id,
+        namespace: this.namespace,
+        detail: { source: "message", traceparent: envelope.meta.traceparent },
+        traceId: this.connectionTraceId,
+        spanId: this.connectionSpanId,
+        parentSpanId: this.connectionParentSpanId,
+        sampled: this.connectionSampled,
+      });
+    }
+
+    return {
+      traceId: this.connectionTraceId,
+      spanId: messageSpanId,
+      parentSpanId: this.connectionSpanId ?? this.connectionParentSpanId,
+      sampled: this.connectionSampled,
+    };
+  }
+
   // event 존재 여부 → schema 검증 → handler 실행 순으로 분기함
   // handler가 아직 등록되지 않은 초기 메시지는 버퍼에 보관했다가 onMessage 등록 시 flush함
   // handler는 `await`으로 순차 실행해 한 connection 안의 메시지 순서를 보장함
@@ -304,26 +450,81 @@ class WebSocketConnectionImpl<
     const schema = this.eventSchemasIn[envelope.event];
 
     if (!schema) {
+      this.emitInboundRejected("unknownEvent", envelope.event);
       this.close(WS_CLOSE_CODE_POLICY_VIOLATION, "Unknown event");
       return;
     }
 
     const parsed = schema.safeParse(envelope.data);
     if (!parsed.success) {
+      this.emitInboundRejected("invalidData", envelope.event);
       this.close(WS_CLOSE_CODE_INVALID_FRAME_PAYLOAD_DATA, "Invalid event data");
       return;
     }
 
     if (!handlers || handlers.length === 0) {
       if (this.pendingMessages.length >= MAX_PENDING_MESSAGES) {
+        this.options.telemetryController.emit({
+          name: "ws.message.buffer.dropped",
+          level: "warn",
+          connectionId: this.id,
+          namespace: this.namespace,
+          detail: { event: envelope.event },
+        });
         this.pendingMessages.shift();
       }
       this.pendingMessages.push(envelope);
+      this.options.telemetryController.emit({
+        name: "ws.message.buffered",
+        level: "debug",
+        connectionId: this.id,
+        namespace: this.namespace,
+        detail: { event: envelope.event },
+      });
       return;
     }
 
-    for (const handler of handlers) {
-      await handler(parsed.data);
+    const traceCtx = this.resolveMessageTraceContext(envelope);
+    try {
+      for (const handler of handlers) {
+        await handler(parsed.data, traceCtx);
+      }
+      this.options.telemetryController.emit({
+        name: "ws.message.dispatched",
+        level: "debug",
+        connectionId: this.id,
+        namespace: this.namespace,
+        detail: { event: envelope.event },
+        traceId: traceCtx.traceId,
+        spanId: traceCtx.spanId,
+        parentSpanId: traceCtx.parentSpanId,
+        sampled: traceCtx.sampled,
+      });
+      this.options.telemetryController.recordMetric({
+        name: "sonamu.ws.messages",
+        kind: "counter",
+        value: 1,
+        unit: "1",
+        tags: { direction: "inbound", event: envelope.event, outcome: "accepted" },
+        namespace: this.namespace,
+        traceId: traceCtx.traceId,
+        spanId: traceCtx.spanId,
+        parentSpanId: traceCtx.parentSpanId,
+        sampled: traceCtx.sampled,
+      });
+    } catch (error) {
+      this.options.telemetryController.emit({
+        name: "ws.message.failed",
+        level: "error",
+        connectionId: this.id,
+        namespace: this.namespace,
+        detail: { event: envelope.event },
+        traceId: traceCtx.traceId,
+        spanId: traceCtx.spanId,
+        parentSpanId: traceCtx.parentSpanId,
+        sampled: traceCtx.sampled,
+      });
+      throw error;
     }
   }
 
@@ -353,15 +554,45 @@ class WebSocketConnectionImpl<
   private publishValidated(event: string, data: unknown): void {
     const schema = this.eventSchemasOut[event];
     if (!schema) {
+      this.options.telemetryController.emit({
+        name: "ws.publish.rejected",
+        level: "error",
+        connectionId: this.id,
+        namespace: this.namespace,
+        detail: { event, reason: "unknownEvent" },
+        traceId: this.connectionTraceId,
+        spanId: this.connectionSpanId,
+        parentSpanId: this.connectionParentSpanId,
+      });
       throw new Error(`Unknown websocket event: ${event}`);
     }
 
     const parsed = schema.safeParse(data);
     if (!parsed.success) {
+      this.options.telemetryController.emit({
+        name: "ws.publish.rejected",
+        level: "error",
+        connectionId: this.id,
+        namespace: this.namespace,
+        detail: { event, reason: "invalidPayload" },
+        traceId: this.connectionTraceId,
+        spanId: this.connectionSpanId,
+        parentSpanId: this.connectionParentSpanId,
+      });
       throw new Error(`Invalid websocket event payload: ${event}`);
     }
 
     if (this.closedInternal || this.socket.readyState !== WS_OPEN) {
+      this.options.telemetryController.emit({
+        name: "ws.publish.dropped",
+        level: "debug",
+        connectionId: this.id,
+        namespace: this.namespace,
+        detail: { event, reason: "connectionClosed" },
+        traceId: this.connectionTraceId,
+        spanId: this.connectionSpanId,
+        parentSpanId: this.connectionParentSpanId,
+      });
       return;
     }
 
@@ -370,12 +601,13 @@ class WebSocketConnectionImpl<
         event,
         data: parsed.data,
       }),
+      event,
     );
   }
 
   // listener 해제 / heartbeat 중단 / pending queue 비움 / registry unregister / onClose 실행 / waitForClose resolve 을 한 곳에 모아 원자적으로 처리함
   // async onClose가 reject해도 unhandled rejection으로 새지 않도록 catch로 격리함
-  private markClosed(): void {
+  private markClosed(code?: number, _reason?: string): void {
     if (this.closedInternal) {
       return;
     }
@@ -383,6 +615,29 @@ class WebSocketConnectionImpl<
     this.closedInternal = true;
     this.closeStarted = false;
     this.stopHeartbeat();
+    this.options.telemetryController.emit({
+      name: "ws.connection.closed",
+      level: "info",
+      connectionId: this.id,
+      namespace: this.namespace,
+      traceId: this.connectionTraceId,
+      spanId: this.connectionSpanId,
+      parentSpanId: this.connectionParentSpanId,
+    });
+    if (this.options.telemetryController.getTraceOptions().recordConnectionLifetimeSpan) {
+      this.options.telemetryController.recordSpan({
+        operationName: "ws.connection.lifetime",
+        kind: "server",
+        durationMs: performance.now() - this.connectionStartedAt,
+        status: deriveLifetimeStatus(code),
+        connectionId: this.id,
+        namespace: this.namespace,
+        traceId: this.connectionTraceId,
+        spanId: this.connectionSpanId,
+        parentSpanId: this.connectionParentSpanId,
+        sampled: this.connectionSampled,
+      });
+    }
     this.socket.off("message", this.handleMessage);
     this.socket.off("close", this.handleClose);
     this.socket.off("error", this.handleError);
@@ -418,6 +673,12 @@ class WebSocketConnectionImpl<
       }
 
       if (this.awaitingPong) {
+        this.options.telemetryController.emit({
+          name: "ws.heartbeat.timeout",
+          level: "warn",
+          connectionId: this.id,
+          namespace: this.namespace,
+        });
         this.close(WS_CLOSE_CODE_GOING_AWAY, "Heartbeat timeout");
         return;
       }
@@ -470,13 +731,32 @@ class WebSocketConnectionImpl<
   }
 
   // queue가 한계에 도달하면 1013으로 닫아 느린 소비자가 메모리를 끝없이 잡아먹지 못하게 함
-  private enqueueOutboundMessage(payload: string): void {
+  private enqueueOutboundMessage(payload: string, event: string): void {
     if (this.pendingOutboundMessages.length >= MAX_PENDING_OUTBOUND_MESSAGES) {
+      this.options.telemetryController.emit({
+        name: "ws.backpressure.overflow",
+        level: "error",
+        connectionId: this.id,
+        namespace: this.namespace,
+        traceId: this.connectionTraceId,
+        spanId: this.connectionSpanId,
+        parentSpanId: this.connectionParentSpanId,
+      });
       this.close(WS_CLOSE_CODE_TRY_AGAIN_LATER, "WebSocket backpressure overflow");
       return;
     }
 
-    this.pendingOutboundMessages.push(payload);
+    this.pendingOutboundMessages.push({ payload, event });
+    this.options.telemetryController.emit({
+      name: "ws.publish.queued",
+      level: "debug",
+      connectionId: this.id,
+      namespace: this.namespace,
+      detail: { event },
+      traceId: this.connectionTraceId,
+      spanId: this.connectionSpanId,
+      parentSpanId: this.connectionParentSpanId,
+    });
     this.scheduleOutboundFlush();
   }
 
@@ -507,6 +787,15 @@ class WebSocketConnectionImpl<
     }
 
     if (this.socket.bufferedAmount > MAX_SOCKET_BUFFERED_AMOUNT) {
+      this.options.telemetryController.emit({
+        name: "ws.backpressure.delayed",
+        level: "warn",
+        connectionId: this.id,
+        namespace: this.namespace,
+        traceId: this.connectionTraceId,
+        spanId: this.connectionSpanId,
+        parentSpanId: this.connectionParentSpanId,
+      });
       this.scheduleOutboundFlush(OUTBOUND_RETRY_DELAY_MS);
       return;
     }
@@ -517,14 +806,71 @@ class WebSocketConnectionImpl<
       this.pendingOutboundMessages.length > 0 &&
       this.socket.readyState === WS_OPEN
     ) {
-      const payload = this.pendingOutboundMessages.shift();
-      if (!payload) {
+      const next = this.pendingOutboundMessages.shift();
+      if (!next) {
         break;
       }
+      const { payload, event } = next;
 
+      const startedAt = performance.now();
       try {
         this.socket.send(payload);
-      } catch {
+        const durationMs = performance.now() - startedAt;
+        this.options.telemetryController.emit({
+          name: "ws.publish.sent",
+          level: "debug",
+          connectionId: this.id,
+          namespace: this.namespace,
+          detail: { event },
+          traceId: this.connectionTraceId,
+          spanId: this.connectionSpanId,
+          parentSpanId: this.connectionParentSpanId,
+        });
+        this.options.telemetryController.recordSpan({
+          operationName: "ws.publish.send",
+          kind: "producer",
+          durationMs,
+          status: "unset",
+          connectionId: this.id,
+          namespace: this.namespace,
+          attributes: { event },
+          traceId: this.connectionTraceId,
+          spanId: this.connectionSpanId,
+          parentSpanId: this.connectionParentSpanId,
+        });
+        this.options.telemetryController.recordMetric({
+          name: "sonamu.ws.publishes",
+          kind: "counter",
+          value: 1,
+          unit: "1",
+          tags: { outcome: "sent", event },
+          namespace: this.namespace,
+        });
+      } catch (error) {
+        const durationMs = performance.now() - startedAt;
+        this.options.telemetryController.emit({
+          name: "ws.publish.failed",
+          level: "error",
+          connectionId: this.id,
+          namespace: this.namespace,
+          detail: { event },
+          traceId: this.connectionTraceId,
+          spanId: this.connectionSpanId,
+          parentSpanId: this.connectionParentSpanId,
+        });
+        this.options.telemetryController.recordSpan({
+          operationName: "ws.publish.send",
+          kind: "producer",
+          durationMs,
+          status: "error",
+          connectionId: this.id,
+          namespace: this.namespace,
+          attributes: { event },
+          errorType: error instanceof Error ? error.name : typeof error,
+          traceId: this.connectionTraceId,
+          spanId: this.connectionSpanId,
+          parentSpanId: this.connectionParentSpanId,
+        });
         this.close(WS_CLOSE_CODE_INTERNAL_ERROR, "Outbound publish failed");
         return;
       }
@@ -586,6 +932,9 @@ function truncateCloseReason(reason?: string): string | undefined {
     : Buffer.from(reason).subarray(0, 123).toString("utf-8");
 }
 
-function isPromiseLike(value: unknown): value is Promise<void> {
-  return typeof value === "object" && value !== null && "then" in value && "catch" in value;
+// connection lifetime span의 status를 close code 기준으로 분기함 (1000/1001 정상 종료, 그 외 known code error, code 미상은 unset)
+function deriveLifetimeStatus(code: number | undefined): "ok" | "error" | "unset" {
+  if (code === undefined) return "unset";
+  if (code === 1000 || code === 1001) return "ok";
+  return "error";
 }

--- a/modules/sonamu/src/stream/ws.ts
+++ b/modules/sonamu/src/stream/ws.ts
@@ -375,6 +375,7 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
         connectionId: this.id,
         namespace: this.namespace,
         detail: { event: parsedEnvelope.event },
+        payload: parsedEnvelope.data,
         traceId: this.connectionTraceId,
         spanId: this.connectionSpanId,
         parentSpanId: this.connectionParentSpanId,
@@ -602,6 +603,7 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
         data: parsed.data,
       }),
       event,
+      parsed.data,
     );
   }
 
@@ -731,7 +733,8 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
   }
 
   // queue가 한계에 도달하면 1013으로 닫아 느린 소비자가 메모리를 끝없이 잡아먹지 못하게 함
-  private enqueueOutboundMessage(payload: string, event: string): void {
+  // data 인자는 telemetry payload preview 용도로만 사용하며 pendingOutboundMessages에는 저장하지 않음 (큐 메모리 보호)
+  private enqueueOutboundMessage(payload: string, event: string, data: unknown): void {
     if (this.pendingOutboundMessages.length >= MAX_PENDING_OUTBOUND_MESSAGES) {
       this.options.telemetryController.emit({
         name: "ws.backpressure.overflow",
@@ -753,6 +756,7 @@ class WebSocketConnectionImpl<TOutSchema extends z.ZodRawShape, TInSchema extend
       connectionId: this.id,
       namespace: this.namespace,
       detail: { event },
+      payload: data,
       traceId: this.connectionTraceId,
       spanId: this.connectionSpanId,
       parentSpanId: this.connectionParentSpanId,

--- a/modules/sonamu/src/template/__tests__/services.template.websocket.test.ts
+++ b/modules/sonamu/src/template/__tests__/services.template.websocket.test.ts
@@ -73,7 +73,9 @@ describe("Template__services websocket event refs", () => {
     const rendered = template.render({});
 
     expect(rendered.body).toContain("handlers: EventHandlers<ChatOutEvents>");
+    expect(rendered.body).toContain("options: WebSocketChannelOptions = {}");
     expect(rendered.body).toContain("useWebSocketChannel<ChatOutEvents, ChatInEvents>");
+    expect(rendered.body).toContain("params, handlers, options");
     expect(rendered.importKeys).toEqual(expect.arrayContaining(["ChatOutEvents", "ChatInEvents"]));
   });
 });


### PR DESCRIPTION
## 배경

웹소켓 운영 중 가용성 지표와 오류 추적에 필요한 정보가 부족함.

Sonamu의 웹소켓 런타임은 연결 lifecycle, fan-out, cluster bus를 모두 자체 구현하고 있지만, 내부 동작을 외부에서 관찰할 수단이 없음.

본 PR은 이벤트·메트릭·스팬 3종 신호를 수집하는 telemetry 모듈을 도입함.

## 변경 사항

- `WebSocketRuntime`에 `WebSocketTelemetryController`를 추가하고, `Registry`/`DeliveryEngine`/`Connection`이 동일 controller를 공유한다.
- 연결 lifecycle, inbound 메시지, outbound publish, fan-out, cluster, 사용자/룸 바인딩 경로 전반에 관측 지점을 심는다.
- W3C `traceparent`를 envelope `meta` 필드로 전파해 클라이언트 trace를 서버 handler·fan-out·cluster까지 잇는다.
- Telemetry 미사용 시 `NoopWebSocketTelemetryController`가 주입되어 동작 차이가 없다.

## 전체 구조

```
                    WebSocketRuntime
                          │
                          ▼
              createWebSocketTelemetryController
                          │
       ┌──────────────────┼──────────────────┐
       ▼                  ▼                  ▼
 EventPipeline      MetricPipeline      SpanPipeline
   ├ sinks[]          ├ sinks[]          ├ sinks[]
   ├ store?           ├ store?           ├ store?
   ├ TokenBucket      ├ TokenBucket      ├ TokenBucket
   ├ sampling         ├ metricSources    ├ sampling
   └ alwaysRecord     └ sampleIntervalMs └ status=error
       ▲                  ▲                  ▲
       └──────────────────┼──────────────────┘
                          │
              WebSocketTelemetryControllerImpl
                          ▲
                          │ emit / recordMetric / recordSpan
       ┌─────────────┬────┴────┬─────────────┐
   Connection    Registry   Delivery    ScopedWrapper
    (ws.ts)    (registry)   Engine     (api/sonamu.ts)
```

관측 지점은 controller라는 단일 facade만 호출한다. controller 내부에서 신호별 pipeline이 각자의 sampling / rate-limit / sink / store를 책임진다.

## 동작 흐름

### Handshake (연결 수립)

1. Fastify가 WS upgrade를 받으면 createWebSocketHandler(dev에선 handleDevWebSocketRequest)가 라우트 매칭 → guard → query 파싱 → registry 등록을 순차로 시도한다.

2. 라우트 미스/guard 실패 등 등록 전 단계 거부는 ws.connection.rejected(reason과 phase 포함)로 기록한 뒤 transport를 닫는다. 이 단계에서는 connection이 없으므로 connection id/userId는 미부착.

3. 정상 흐름은 WebSocketConnectionImpl을 만들어 active: false로 등록한 뒤 ALS context를 깐 다음 activate()로 노출한다.

### Inbound (메시지 수신)

1. Frame 수신 → `enqueueMessageTask`로 직렬화
2. 정규화 및 1차 검증: `maxPayload` 초과 시 `close 1009`, envelope schema 실패 시 `close 1007` (모두 `ws.message.rejected` warn)
3. `dispatchEnvelope`에서 inbound schema 재검증 후 handler 미등록이면 `pendingMessages`에 buffer (한계 초과 시 oldest drop)
4. handler 등록 시 `resolveMessageTraceContext`로 trace를 결정한 뒤 (`envelope.meta.traceparent` 우선) 순차 await 실행
5. 정상 완료는 `ws.message.dispatched`, 실패는 `ws.message.failed` + `close 1011`

### Outbound (publish)

1. `connection.publish` → outbound schema 검증 (실패 시 throw + `ws.publish.rejected`)
2. 큐 적재: `pendingOutboundMessages` 1000 초과 시 `close 1013` + `ws.backpressure.overflow`, 아니면 `setImmediate`로 flush 예약
3. Flush: `socket.bufferedAmount > 1 MiB`이면 5ms 후 retry + `ws.backpressure.delayed`, 통과 시 최대 50개씩 batch 전송
4. 결과는 `ws.publish.sent`(success) 또는 `ws.publish.failed`(error)와 `ws.publish.send` span으로 기록

### Pipeline 내부 (`emit` → `emitInternal`)

`emit`은 shutdown 체크와 sampling 적용 후 `emitInternal`을 호출한다. 내부는 8단계로 동작한다.

1. 레코드 생성
2. **rate-limit bypass 판단**: critical record는 token bucket을 우회한다.
   - Event: `alwaysRecord` 플래그 (기본 warn/error)
   - Metric: `tags.outcome ∈ {failed, rejected, dropped}` 또는 name이 `.failures` / `.dropped` 패턴
   - Span: `status === "error"`
3. 토큰 소비 (신호별 독립 버킷, 실패 시 drop)
4. 키 기반 redact (authorization, cookie, token, password, secret, apikey, session, email)
5. Redactor chain (전역 → 신호별)
6. `beforeRecord` chain
7. 레코드 타입 검증
8. sink 배열 emit. 두 가지 격리 정책 적용:
   - **Sink 실패 격리**: 한 sink의 throw/reject는 카운트만 하고 다른 sink로 진행
   - **Sink backpressure 차폐**: in-flight emit이 `maxInFlightEmits` (기본 100) 초과 시 critical record는 그대로 보내고 non-critical은 drop

> 모든 단계에서 throw는 swallow하고 `droppedCount++`로 누적한다. Telemetry가 애플리케이션을 죽이지 않는다.

## 수집 데이터

### Event

| 카테고리 | 이벤트 이름 |
| --- | --- |
| 커넥션 수명주기 | `ws.connection.registered`, `ws.connection.activated`, `ws.connection.unregistered`, `ws.connection.closed`, `ws.heartbeat.timeout` |
| 사용자 바인딩 | `ws.user.bound`, `ws.user.cleared` |
| 룸 | `ws.room.joined`, `ws.room.left` |
| Inbound | `ws.message.received`, `ws.message.rejected`, `ws.message.buffered`, `ws.message.buffer.dropped`, `ws.message.dispatched`, `ws.message.failed`, `ws.trace.invalid` |
| Outbound | `ws.publish.queued`, `ws.publish.sent`, `ws.publish.failed`, `ws.publish.rejected`, `ws.publish.dropped`, `ws.backpressure.delayed`, `ws.backpressure.overflow` |
| 클러스터 | `ws.cluster.envelope.published`, `ws.cluster.envelope.received`, `ws.cluster.envelope.ignored`, `ws.cluster.envelope.failed` |
| Fan-out | `ws.fanout.resolved`, `ws.fanout.enqueued`, `ws.fanout.flushed`, `ws.fanout.publish.failed` |
| 레지스트리 | `ws.registry.mutation.skipped` |
| 내부 진단 | `ws.telemetry.redactor.type_mismatch`, `ws.telemetry.beforeRecord.type_mismatch`, `ws.telemetry.sink.failed`, `ws.telemetry.shutdown.timeout` |

### Metric

| 메트릭 이름 | 용도 |
| --- | --- |
| `sonamu.ws.connections` | 커넥션 등록·해제 카운터 |
| `sonamu.ws.messages` | inbound 메시지 수신·디스패치 카운터 |
| `sonamu.ws.publishes` | outbound publish 카운터 |
| `sonamu.ws.fanout.targets` | fan-out 대상 수 |
| `ws.connections.active` | 주기적 게이지 — `sampleIntervalMs` (기본 10s) 단위로 snapshot 전체 동봉 |

### Span

| 오퍼레이션 이름 | 측정 구간 |
| --- | --- |
| `ws.connection.lifetime` | 연결 생성 ~ 종료 (`recordConnectionLifetimeSpan` 옵션) |
| `ws.publish.send` | 단일 publish 전송 (성공·실패 양쪽) |
| `ws.cluster.publish` | 클러스터 envelope 발행 |
| `ws.cluster.receive` | 클러스터 envelope 수신 처리 |
| `ws.fanout.dispatch` | fan-out dispatch 한 사이클 |

## 사용법

```ts
// 1. Sonamu config
websocket: { telemetry: true }

// 2. frame api
@api({ httpMethod: "GET", clients: ["tanstack-query"], guards: ["admin"] })
async getTelemetry() {
  const c = Sonamu.websocketRuntime.telemetryController;
  return {
    metrics: c.getMetricsSnapshot(),
    events: c.getEventStore()?.query({ limit: 100 }) ?? [],
  };
}

// 3. page
const { data } = useQuery({
  ...TelemetryService.getTelemetryQueryOptions(),
  refetchInterval: 3_000,
});
```

## Non-goals

- OpenTelemetry SDK/Collector 연동은 후속 PR. 본 PR은 sink·store 인터페이스까지만 제공한다.
- 영속 저장 없음 — 현재 store는 ring buffer 기반 in-memory 구현만 포함한다.
- 클라이언트용 `traceProvider` 레퍼런스 구현은 제공하지 않음. 각 앱이 자체 트레이서를 주입한다.
- 