### PR TITLE
[Nightly 2026-05-12] Context 문서의 runWithMockContext 잘못된 호출 시그니처 및 미존재 context.ip 필드 사용 예제 정정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/api-reference/context/methods.mdx
+++ b/modules/docs/en/api-reference/context/methods.mdx
@@ -106,22 +106,26 @@ describe("PostModel", () => {
 });
 ```
 
-For tests that need actual Context, use `runWithMockContext`:
+For tests that need actual Context, use `runWithMockContext`, or `testAs` when you need to specify user info:
 
 ```typescript
-import { runWithMockContext } from "sonamu/test";
+import { runWithMockContext, testAs } from "sonamu/test";
 
-it("should use context in test", async () => {
-  await runWithMockContext(
-    {
-      user: { id: 1, email: "test@example.com" },
-    },
-    async () => {
-      const ctx = Sonamu.getContext();
-      expect(ctx.user?.id).toBe(1);
-    },
-  );
+it("should use mock context in test", async () => {
+  await runWithMockContext(async () => {
+    const ctx = Sonamu.getContext();
+    expect(ctx.user).toBeNull();
+  });
 });
+
+testAs(
+  { id: 1, email: "test@example.com" },
+  "should use context with user",
+  async () => {
+    const ctx = Sonamu.getContext();
+    expect(ctx.user?.id).toBe(1);
+  },
+);
 ```
 
 ## File Upload Context

--- a/modules/docs/en/testing/mocking/run-with-mock-context.mdx
+++ b/modules/docs/en/testing/mocking/run-with-mock-context.mdx
@@ -53,10 +53,10 @@ test("Context access test", async () => {
   // test() function automatically calls runWithMockContext
   // so you can access Context directly
   const context = Sonamu.getContext();
-  
-  expect(context.ip).toBe("127.0.0.1");
+
   expect(context.user).toBeNull();
-  expect(context.session).toEqual({});
+  expect(context.session).toBeNull();
+  expect(context.locale).toBe("");
 });
 ```
 
@@ -70,9 +70,10 @@ import { Sonamu } from "sonamu";
 
 await runWithMockContext(async () => {
   const context = Sonamu.getContext();
-  
+
   // Mock Context is active within this block
-  console.log(context.ip); // "127.0.0.1"
+  console.log(context.user); // null (unauthenticated)
+  console.log(context.session); // null
 });
 ```
 
@@ -185,14 +186,14 @@ import { test } from "sonamu/test";
 import { Sonamu } from "sonamu";
 import { expect } from "vitest";
 
-test("specific IP access test", async () => {
+test("locale-specific response test", async () => {
   const context = Sonamu.getContext();
-  
+
   // Modify Context property
-  context.ip = "192.168.1.100";
-  
-  const result = await someService.checkIPRestriction();
-  expect(result.allowed).toBe(true);
+  context.locale = "ko";
+
+  const result = await someService.getLocalizedGreeting();
+  expect(result).toBe("안녕하세요");
 });
 ```
 

--- a/modules/docs/ko/api-reference/context/methods.mdx
+++ b/modules/docs/ko/api-reference/context/methods.mdx
@@ -106,22 +106,26 @@ describe("PostModel", () => {
 });
 ```
 
-실제 Context가 필요한 테스트에서는 `runWithMockContext`를 사용하세요:
+실제 Context가 필요한 테스트에서는 `runWithMockContext`를, 사용자 정보까지 지정하려면 `testAs`를 사용하세요:
 
 ```typescript
-import { runWithMockContext } from "sonamu/test";
+import { runWithMockContext, testAs } from "sonamu/test";
 
-it("should use context in test", async () => {
-  await runWithMockContext(
-    {
-      user: { id: 1, email: "test@example.com" },
-    },
-    async () => {
-      const ctx = Sonamu.getContext();
-      expect(ctx.user?.id).toBe(1);
-    },
-  );
+it("should use mock context in test", async () => {
+  await runWithMockContext(async () => {
+    const ctx = Sonamu.getContext();
+    expect(ctx.user).toBeNull();
+  });
 });
+
+testAs(
+  { id: 1, email: "test@example.com" },
+  "should use context with user",
+  async () => {
+    const ctx = Sonamu.getContext();
+    expect(ctx.user?.id).toBe(1);
+  },
+);
 ```
 
 ## 파일 업로드 컨텍스트

--- a/modules/docs/ko/testing/mocking/run-with-mock-context.mdx
+++ b/modules/docs/ko/testing/mocking/run-with-mock-context.mdx
@@ -53,10 +53,10 @@ test("Context 접근 테스트", async () => {
   // test() 함수가 자동으로 runWithMockContext를 호출하므로
   // 바로 Context에 접근할 수 있습니다
   const context = Sonamu.getContext();
-  
-  expect(context.ip).toBe("127.0.0.1");
+
   expect(context.user).toBeNull();
-  expect(context.session).toEqual({});
+  expect(context.session).toBeNull();
+  expect(context.locale).toBe("");
 });
 ```
 
@@ -70,9 +70,10 @@ import { Sonamu } from "sonamu";
 
 await runWithMockContext(async () => {
   const context = Sonamu.getContext();
-  
+
   // 이 블록 내에서는 Mock Context가 활성화됩니다
-  console.log(context.ip); // "127.0.0.1"
+  console.log(context.user); // null (미인증)
+  console.log(context.session); // null
 });
 ```
 
@@ -185,14 +186,14 @@ import { test } from "sonamu/test";
 import { Sonamu } from "sonamu";
 import { expect } from "vitest";
 
-test("특정 IP에서의 접근 테스트", async () => {
+test("locale별 응답 테스트", async () => {
   const context = Sonamu.getContext();
-  
+
   // Context 속성 수정
-  context.ip = "192.168.1.100";
-  
-  const result = await someService.checkIPRestriction();
-  expect(result.allowed).toBe(true);
+  context.locale = "ko";
+
+  const result = await someService.getLocalizedGreeting();
+  expect(result).toBe("안녕하세요");
 });
 ```
 


### PR DESCRIPTION
## 이 PR은 무엇인가요

이 PR은 사용자(@potados99)가 설정한 Nightly PR Directions(#43) 및 작업 범위 issue(#44)에 따라 **AI(cartanova-dev / Claude Code)가 자동 생성한 문서 정정 PR**입니다. 매일 새벽 코드와 문서 사이의 명백한 불일치를 한 단위로 정정하는 흐름의 일부이며, 사용자의 코드/문서 ownership을 침해하지 않도록 사실관계가 확실한 변경만을 포함합니다.

## 왜 이 작업을 선정했나요

이슈 #44에서 강조된 항목 중 하나가 "문서와 주석이 코드와 어긋나는 경우 -> 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 한다"입니다.

이번 회차에 코드베이스 전반을 검토한 결과, Context 관련 문서 2종에서 다음과 같이 사용자가 그대로 따라하면 **TypeScript 컴파일 에러 또는 잘못된 단언 결과**를 일으키는 예제 코드를 발견했습니다.

### 1) `modules/docs/{ko,en}/api-reference/context/methods.mdx` - `runWithMockContext` 호출 시그니처 불일치

기존 문서 예제:

\`\`\`typescript
await runWithMockContext(
  { user: { id: 1, email: "test@example.com" } },
  async () => { ... },
);
\`\`\`

그러나 실제 시그니처(`modules/sonamu/src/testing/bootstrap.ts:80`)는:

\`\`\`typescript
export async function runWithMockContext(fn: () => Promise<void>) {
  await runWithContext(getMockContext(), fn);
}
\`\`\`

즉 `runWithMockContext`는 인자 한 개(`fn`)만 받습니다. 사용자의 본래 의도(특정 user로 테스트)는 같은 모듈이 export하는 `testAs`로 정확히 충족됩니다.

### 2) `modules/docs/{ko,en}/testing/mocking/run-with-mock-context.mdx` - 미존재 `context.ip` 필드 및 잘못된 `session` 기대값

기존 문서 예제 일부:

\`\`\`typescript
expect(context.ip).toBe("127.0.0.1");      // ❌
expect(context.session).toEqual({});       // ❌
console.log(context.ip); // "127.0.0.1"    // ❌
context.ip = "192.168.1.100";              // ❌
\`\`\`

그러나 실제 `Context` 타입(`modules/sonamu/src/api/context.ts`)에는 `ip` 필드가 존재하지 않으며, `getMockContext()`(`testing/bootstrap.ts:59`)의 `session`은 `null`로 초기화됩니다. 그대로 두면 사용자가 IP 기반 시나리오를 시도하다 타입 에러로 막히고, session 기대값도 잘못된 결과를 비교하게 됩니다.

## 어떤 접근을 채택했나요

- `methods.mdx`: 잘못된 2-인자 호출 예제를 1-인자 호출 예제로 정정하고, 사용자 지정 user로 테스트하려는 본래 의도는 같은 파일에 이미 소개되어 있는 `testAs` 예제로 함께 안내했습니다.
- `run-with-mock-context.mdx`:
  - `context.ip` 사용 예제는 실제로 존재하는 `context.locale` 기반의 시나리오(다국어 응답 테스트)로 교체했습니다. "Context 속성을 수정하는 방법"을 보여주려는 원작자의 의도를 유지하면서, 실제 타입에 존재하는 필드를 사용하도록 했습니다.
  - `expect(context.session).toEqual({})`를 실제 mock 값에 맞춰 `expect(context.session).toBeNull()`로 정정하고, 함께 `context.locale` 기본값 검증을 추가했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가요

- 문서를 그대로 따라하면 TypeScript 컴파일 에러가 발생하여, Sonamu를 처음 배우는 사용자가 테스트 작성 단계에서 막힙니다.
- `session` 기대값이 잘못되어 있어, 문서를 신뢰한 사용자가 작성한 테스트가 의도와 다른 이유로 실패합니다.
- 문서 신뢰도가 누적적으로 떨어집니다.

## 어떤 기능에 영향을 미치나요

- 런타임 동작 및 빌드 산출물에 영향은 없습니다(문서 4개 파일만 수정).
- `modules/sonamu`, `modules/create-sonamu`, `miomock` 등 코드 패키지는 일절 건드리지 않았습니다.

## 어떻게 즉시 확인하나요

1. `git diff master..HEAD -- modules/docs/ko/api-reference/context/methods.mdx modules/docs/en/api-reference/context/methods.mdx` 와 `... run-with-mock-context.mdx`로 diff 4개 파일을 검토.
2. 실제 시그니처 교차 확인:
   - `modules/sonamu/src/testing/bootstrap.ts:75-82` (`runWithContext`, `runWithMockContext`)
   - `modules/sonamu/src/api/context.ts:21-41` (`BaseContext` / `Context` 타입에 `ip` 필드 없음 확인)
3. 루트 `pnpm check`(oxlint + oxfmt) 통과 확인 — 본 변경 기준 에러 0건.

## 사람의 추가 확인이 필요한 부분

- `run-with-mock-context.mdx`의 같은 파일 내 정보성 코드 블록(`type Context = { ... }` 요약, "내부 구조"의 `getMockContext()` 구현 요약)은 일부 필드를 의도적으로 간소화한 표현으로 보여, 이번 PR에서는 손대지 않았습니다. 만약 이 부분도 실제 정의와 정확히 일치하도록 갱신하길 원하시면 알려주세요.
- 영문 번역은 한국어 변경과 1:1 대응되도록 작성했지만, 톤 측면에서 더 다듬을 여지가 있다면 메인테이너가 보완해 주시는 편이 안전합니다.

## 참고

- 작업 지침: #43
- 작업 범위 정의: #44
- 작성자: AI (cartanova-dev / Claude Code), 사용자 권한 위임 하에 자동 생성