### PR TITLE
[Nightly 2026-05-13] @websocket 데코레이터 레퍼런스 문서 신규 작성 (ko/en) 및 docs navigation 등록

### DIFF
--- a/modules/docs/docs.json
+++ b/modules/docs/docs.json
@@ -473,6 +473,7 @@
                 "pages": [
                   "ko/api-reference/decorators/api",
                   "ko/api-reference/decorators/stream",
+                  "ko/api-reference/decorators/websocket",
                   "ko/api-reference/decorators/transactional",
                   "ko/api-reference/decorators/upload",
                   "ko/api-reference/decorators/cache",
@@ -1027,6 +1028,7 @@
                 "pages": [
                   "en/api-reference/decorators/api",
                   "en/api-reference/decorators/stream",
+                  "en/api-reference/decorators/websocket",
                   "en/api-reference/decorators/transactional",
                   "en/api-reference/decorators/upload",
                   "en/api-reference/decorators/cache",

--- a/modules/docs/en/api-reference/decorators/stream.mdx
+++ b/modules/docs/en/api-reference/decorators/stream.mdx
@@ -73,7 +73,7 @@ Specifies the streaming type.
 type: "sse"; // Server-Sent Events (currently the only option)
 ```
 
-<Info>WebSocket is provided via the dedicated `@websocket` decorator. `@stream` is for SSE only and the `type` option accepts `"sse"` only.</Info>
+<Info>WebSocket is provided via the dedicated [`@websocket`](/en/api-reference/decorators/websocket) decorator. `@stream` is for SSE only and the `type` option accepts `"sse"` only.</Info>
 
 ### events
 

--- a/modules/docs/en/api-reference/decorators/websocket.mdx
+++ b/modules/docs/en/api-reference/decorators/websocket.mdx
@@ -1,0 +1,378 @@
+---
+title: "@websocket"
+description: "Bidirectional WebSocket channel API decorator"
+---
+
+The `@websocket` decorator defines a WebSocket API that opens a bidirectional message channel between client and server. Unlike `@stream` (SSE-only), it can also handle events sent by the client (`inEvents`) and broadcast messages to other connections in the same namespace/room.
+
+## Basic Usage
+
+```typescript
+import { BaseFrameClass, Sonamu, websocket, type WebSocketContext } from "sonamu";
+import { z } from "zod";
+
+const ChatOutEvents = z.object({
+  newMessage: z.object({
+    id: z.number(),
+    content: z.string(),
+    userId: z.string(),
+  }),
+  typingUsers: z.array(z.object({ id: z.string(), name: z.string() })),
+});
+
+const ChatInEvents = z.object({
+  send: z.object({ content: z.string() }),
+  typing: z.object({ active: z.boolean() }),
+});
+
+class ChatFrameClass extends BaseFrameClass {
+  @websocket({
+    namespace: "chat",
+    heartbeat: 30_000,
+    guards: ["user"],
+    outEvents: ChatOutEvents,
+    inEvents: ChatInEvents,
+  })
+  async subscribeChat(
+    ctx: WebSocketContext<typeof ChatOutEvents.shape, typeof ChatInEvents.shape>,
+  ): Promise<void> {
+    const user = ctx.user;
+    if (!user) throw new Error("unauthenticated");
+
+    ctx.ws.join("global");
+    ctx.ws.setUserId(user.id);
+
+    ctx.ws.onMessage("send", (data) => {
+      Sonamu.websocketRuntime.publishToRoom(
+        "global",
+        "newMessage",
+        { id: Date.now(), content: data.content, userId: user.id },
+        "chat",
+      );
+    });
+
+    ctx.ws.onClose(() => {
+      ctx.ws.leave("global");
+    });
+
+    await ctx.ws.waitForClose();
+  }
+}
+```
+
+## Options
+
+### outEvents
+
+Defines server → client event types using a Zod schema.
+
+**Required option**
+
+```typescript
+import { z } from "zod";
+
+const OutEvents = z.object({
+  ready: z.object({ history: z.array(z.string()) }),
+  newMessage: z.object({ id: z.number(), content: z.string() }),
+});
+```
+
+### inEvents
+
+Defines client → server event types using a Zod schema.
+
+**Required option**
+
+```typescript
+const InEvents = z.object({
+  send: z.object({ content: z.string() }),
+  setPeriod: z.object({ period: z.enum(["7", "30", "all"]) }),
+});
+```
+
+<Info>Inbound messages are validated against `inEvents` via the envelope contract. Events not declared in the schema, or payloads that fail validation, are not delivered to handlers and are treated as policy violations.</Info>
+
+### path
+
+WebSocket endpoint path.
+
+**Default:** `/{modelName}/{methodName}` (camelCase)
+
+```typescript
+@websocket({
+  outEvents,
+  inEvents,
+  path: "/realtime/chat",
+})
+async subscribeChat(ctx: WebSocketContext) {}
+```
+
+### namespace
+
+A logical group that scopes routing/broadcast inside the same server. `Sonamu.websocketRuntime.publishToRoom(roomId, event, data, namespace)` only delivers to connections in the same namespace.
+
+**Default:** `"default"`
+
+```typescript
+@websocket({ outEvents, inEvents, namespace: "chat" })
+```
+
+### heartbeat
+
+Heartbeat (ping) interval in milliseconds.
+
+**Default:** `30000` (30 seconds)
+
+```typescript
+@websocket({ outEvents, inEvents, heartbeat: 15_000 })
+```
+
+### guards
+
+Restricts who can connect.
+
+```typescript
+type GuardKey = "query" | "admin" | "user";
+```
+
+```typescript
+@websocket({ outEvents, inEvents, guards: ["user"] })
+```
+
+Guard failures are rejected during the handshake and close with `1008 Policy Violation`.
+
+### description
+
+Adds a description for the WebSocket API.
+
+```typescript
+@websocket({
+  outEvents,
+  inEvents,
+  description: "Subscribes to the global chat channel.",
+})
+```
+
+### resourceName
+
+Specifies the resource name for the generated service file.
+
+```typescript
+@websocket({ outEvents, inEvents, resourceName: "Chat" })
+```
+
+## WebSocketContext
+
+A `@websocket`-decorated method receives `WebSocketContext<TOut, TIn>` as its last argument.
+
+```typescript
+type WebSocketContext<TOut, TIn> = BaseContext & {
+  transport: "ws";
+  ws: WebSocketConnection<TOut, TIn>;
+};
+```
+
+### ctx.ws.publish
+
+Sends an event to this connection only.
+
+```typescript
+ctx.ws.publish("ready", { history: ["hello", "world"] });
+```
+
+### ctx.ws.onMessage
+
+Handles events sent by the client.
+
+```typescript
+ctx.ws.onMessage("send", async (data) => {
+  // data is validated against inEvents.send
+});
+```
+
+### ctx.ws.onClose
+
+Runs cleanup when the connection closes.
+
+```typescript
+ctx.ws.onClose(() => {
+  ctx.ws.leave("global");
+});
+```
+
+### ctx.ws.waitForClose
+
+Keeps the handler alive until the connection closes. WebSocket methods typically `await` this promise to wrap up.
+
+```typescript
+await ctx.ws.waitForClose();
+```
+
+### ctx.ws.join / ctx.ws.leave
+
+Joins or leaves a room, which is the broadcast unit.
+
+```typescript
+ctx.ws.join("room-1");
+ctx.ws.leave("room-1");
+```
+
+### ctx.ws.setUserId / ctx.ws.clearUserId
+
+Attaches a user identifier to the connection so it can be targeted by `publishToUser`.
+
+```typescript
+ctx.ws.setUserId(user.id);
+```
+
+## Broadcast
+
+From outside the handler you can also push messages to other connections via `Sonamu.websocketRuntime`.
+
+```typescript
+import { Sonamu } from "sonamu";
+
+Sonamu.websocketRuntime.publishToRoom(
+  "global",
+  "newMessage",
+  { id: 1, content: "hello" },
+  "chat", // namespace
+);
+
+Sonamu.websocketRuntime.publishToUser(
+  userId,
+  "notify",
+  { kind: "mention" },
+  "chat",
+);
+```
+
+## Combining With Other Decorators
+
+`@websocket` cannot share a method with `@api`, `@stream`, or `@upload`. If you want to expose the same data via both a WebSocket subscription and a plain HTTP endpoint, split them into two methods — one with `@api`, the other with `@websocket`.
+
+```typescript
+class DashboardFrameClass extends BaseFrameClass {
+  @api({ httpMethod: "GET" })
+  async getRecentActivity(period: ActivityPeriod = "7"): Promise<ActivityGroup[]> {
+    // ...
+  }
+
+  @websocket({ outEvents, inEvents })
+  async getRecentActivityStream(
+    initialPeriod: ActivityPeriod = "7",
+    ctx: WebSocketContext<typeof outEvents.shape, typeof inEvents.shape>,
+  ): Promise<void> {
+    // ...
+  }
+}
+```
+
+## Constraints
+
+### 1. Cannot be combined with @api / @stream / @upload
+
+```
+@websocket decorator can only be used once on Chat.subscribe.
+You can use only one of @api, @stream, @websocket, or @upload decorator on the same method.
+```
+
+### 2. httpMethod is always GET
+
+`@websocket` automatically sets `httpMethod: "GET"` because the WebSocket upgrade starts from a GET request.
+
+### 3. Watch out for context providers that depend on createSSE / reply
+
+In the WebSocket path, SSE helpers and `FastifyReply` access are meaningless and raise an error immediately. If your context setup depends on them, define a dedicated `websocketContextProvider`.
+
+## Client Usage (Web)
+
+For each `@websocket` method, Sonamu auto-generates a `useWebSocketChannel` hook.
+
+```typescript
+import { ChatService } from "@/services/ChatService";
+
+function ChatRoom() {
+  const channel = ChatService.useSubscribeChat(
+    {},
+    {
+      newMessage: (msg) => {
+        // outEvents.newMessage data
+      },
+      typingUsers: (users) => {
+        // outEvents.typingUsers data
+      },
+    },
+  );
+
+  return (
+    <div>
+      <div>{channel.isConnected ? "connected" : "disconnected"}</div>
+      <button onClick={() => channel.send("send", { content: "hi" })}>send</button>
+    </div>
+  );
+}
+```
+
+State returned from `useWebSocketChannel`:
+
+```typescript
+type WebSocketChannelState<TSend> = {
+  isConnected: boolean;
+  error: string | null;
+  retryCount: number;
+  readyState: number;
+  send<K extends keyof TSend>(event: K, data: TSend[K]): void;
+  close(code?: number, reason?: string): void;
+};
+```
+
+Options:
+
+```typescript
+type WebSocketChannelOptions = {
+  enabled?: boolean;
+  retry?: number;
+  retryInterval?: number;
+  protocols?: string | string[];
+  traceProvider?: () => string | undefined;
+};
+```
+
+## Logging
+
+The `@websocket` decorator emits a debug log on each invocation.
+
+```
+[DEBUG] websocket: ChatFrame.subscribeChat
+```
+
+## Compared to @stream
+
+| Item | `@stream` (SSE) | `@websocket` |
+| --- | --- | --- |
+| Direction | Server → client (one-way) | Bidirectional |
+| Client events | Not supported | Validated against `inEvents` |
+| Broadcast | Per-SSE publish only | `room` / `userId` routing built-in |
+| HTTP method | GET (auto) | GET (auto, upgrade) |
+| Generated client | `eventSource` helpers | `useWebSocketChannel` hook |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="@stream" icon="signal-stream" href="/en/api-reference/decorators/stream">
+    When one-way SSE streaming is enough
+  </Card>
+
+  <Card title="@api" icon="plug" href="/en/api-reference/decorators/api">
+    Build a standard REST endpoint
+  </Card>
+
+  <Card title="@transactional" icon="arrows-rotate" href="/en/api-reference/decorators/transactional">
+    Wrap mutations in a transaction
+  </Card>
+
+  <Card title="@cache" icon="database" href="/en/api-reference/decorators/cache">
+    Improve performance with caching
+  </Card>
+</CardGroup>

--- a/modules/docs/ko/api-reference/decorators/stream.mdx
+++ b/modules/docs/ko/api-reference/decorators/stream.mdx
@@ -73,7 +73,7 @@ class NotificationModelClass extends BaseModelClass {
 type: "sse"; // Server-Sent Events (현재 유일한 옵션)
 ```
 
-<Info>WebSocket은 별도의 `@websocket` 데코레이터로 지원됩니다. `@stream`은 SSE 전용이며 `type` 옵션은 `"sse"`만 받습니다.</Info>
+<Info>WebSocket은 별도의 [`@websocket`](/ko/api-reference/decorators/websocket) 데코레이터로 지원됩니다. `@stream`은 SSE 전용이며 `type` 옵션은 `"sse"`만 받습니다.</Info>
 
 ### events
 

--- a/modules/docs/ko/api-reference/decorators/websocket.mdx
+++ b/modules/docs/ko/api-reference/decorators/websocket.mdx
@@ -1,0 +1,378 @@
+---
+title: "@websocket"
+description: "양방향 WebSocket 채널 API 생성 데코레이터"
+---
+
+`@websocket` 데코레이터는 클라이언트와 서버 사이에 양방향 메시지 채널을 만드는 WebSocket API를 정의합니다. SSE 전용인 `@stream`과 달리 클라이언트가 보내는 이벤트(`inEvents`)도 처리할 수 있고, 같은 namespace/room에 묶인 다른 연결로 메시지를 브로드캐스트할 수 있습니다.
+
+## 기본 사용법
+
+```typescript
+import { BaseFrameClass, Sonamu, websocket, type WebSocketContext } from "sonamu";
+import { z } from "zod";
+
+const ChatOutEvents = z.object({
+  newMessage: z.object({
+    id: z.number(),
+    content: z.string(),
+    userId: z.string(),
+  }),
+  typingUsers: z.array(z.object({ id: z.string(), name: z.string() })),
+});
+
+const ChatInEvents = z.object({
+  send: z.object({ content: z.string() }),
+  typing: z.object({ active: z.boolean() }),
+});
+
+class ChatFrameClass extends BaseFrameClass {
+  @websocket({
+    namespace: "chat",
+    heartbeat: 30_000,
+    guards: ["user"],
+    outEvents: ChatOutEvents,
+    inEvents: ChatInEvents,
+  })
+  async subscribeChat(
+    ctx: WebSocketContext<typeof ChatOutEvents.shape, typeof ChatInEvents.shape>,
+  ): Promise<void> {
+    const user = ctx.user;
+    if (!user) throw new Error("unauthenticated");
+
+    ctx.ws.join("global");
+    ctx.ws.setUserId(user.id);
+
+    ctx.ws.onMessage("send", (data) => {
+      Sonamu.websocketRuntime.publishToRoom(
+        "global",
+        "newMessage",
+        { id: Date.now(), content: data.content, userId: user.id },
+        "chat",
+      );
+    });
+
+    ctx.ws.onClose(() => {
+      ctx.ws.leave("global");
+    });
+
+    await ctx.ws.waitForClose();
+  }
+}
+```
+
+## 옵션
+
+### outEvents
+
+서버 → 클라이언트로 보낼 이벤트의 타입을 Zod 스키마로 정의합니다.
+
+**필수 옵션**
+
+```typescript
+import { z } from "zod";
+
+const OutEvents = z.object({
+  ready: z.object({ history: z.array(z.string()) }),
+  newMessage: z.object({ id: z.number(), content: z.string() }),
+});
+```
+
+### inEvents
+
+클라이언트 → 서버로 들어올 이벤트의 타입을 Zod 스키마로 정의합니다.
+
+**필수 옵션**
+
+```typescript
+const InEvents = z.object({
+  send: z.object({ content: z.string() }),
+  setPeriod: z.object({ period: z.enum(["7", "30", "all"]) }),
+});
+```
+
+<Info>들어온 이벤트는 envelope을 거쳐 자동 검증됩니다. 스키마에 없는 이벤트나 형식이 맞지 않는 페이로드는 처리되지 않고 정책 위반으로 처리됩니다.</Info>
+
+### path
+
+WebSocket 엔드포인트 경로를 지정합니다.
+
+**기본값:** `/{modelName}/{methodName}` (camelCase)
+
+```typescript
+@websocket({
+  outEvents,
+  inEvents,
+  path: "/realtime/chat",
+})
+async subscribeChat(ctx: WebSocketContext) {}
+```
+
+### namespace
+
+같은 서버 안에서 라우팅·브로드캐스트의 범위를 가르는 논리적 그룹입니다. `Sonamu.websocketRuntime.publishToRoom(roomId, event, data, namespace)`로 보낼 때 같은 namespace의 연결에만 전달됩니다.
+
+**기본값:** `"default"`
+
+```typescript
+@websocket({ outEvents, inEvents, namespace: "chat" })
+```
+
+### heartbeat
+
+연결 유지를 위한 ping 간격(밀리초)입니다.
+
+**기본값:** `30000` (30초)
+
+```typescript
+@websocket({ outEvents, inEvents, heartbeat: 15_000 })
+```
+
+### guards
+
+접근 권한을 지정합니다.
+
+```typescript
+type GuardKey = "query" | "admin" | "user";
+```
+
+```typescript
+@websocket({ outEvents, inEvents, guards: ["user"] })
+```
+
+가드 실패는 핸드셰이크 단계에서 차단되어 `1008 Policy Violation`으로 close됩니다.
+
+### description
+
+WebSocket API 설명을 추가합니다.
+
+```typescript
+@websocket({
+  outEvents,
+  inEvents,
+  description: "전역 채팅 채널을 구독합니다.",
+})
+```
+
+### resourceName
+
+생성되는 서비스 파일의 리소스 이름을 지정합니다.
+
+```typescript
+@websocket({ outEvents, inEvents, resourceName: "Chat" })
+```
+
+## WebSocketContext
+
+데코레이터가 적용된 메서드는 마지막 인자로 `WebSocketContext<TOut, TIn>`을 받습니다.
+
+```typescript
+type WebSocketContext<TOut, TIn> = BaseContext & {
+  transport: "ws";
+  ws: WebSocketConnection<TOut, TIn>;
+};
+```
+
+### ctx.ws.publish
+
+해당 연결로만 이벤트를 전송합니다.
+
+```typescript
+ctx.ws.publish("ready", { history: ["hello", "world"] });
+```
+
+### ctx.ws.onMessage
+
+클라이언트가 보낸 이벤트를 처리합니다.
+
+```typescript
+ctx.ws.onMessage("send", async (data) => {
+  // data는 inEvents.send 스키마로 검증되어 들어옴
+});
+```
+
+### ctx.ws.onClose
+
+연결이 닫힐 때 정리 작업을 수행합니다.
+
+```typescript
+ctx.ws.onClose(() => {
+  ctx.ws.leave("global");
+});
+```
+
+### ctx.ws.waitForClose
+
+연결이 끝날 때까지 핸들러를 살아있게 유지합니다. WebSocket 메서드는 보통 이 promise를 await하며 마무리됩니다.
+
+```typescript
+await ctx.ws.waitForClose();
+```
+
+### ctx.ws.join / ctx.ws.leave
+
+브로드캐스트 단위인 room에 연결을 가입/탈퇴시킵니다.
+
+```typescript
+ctx.ws.join("room-1");
+ctx.ws.leave("room-1");
+```
+
+### ctx.ws.setUserId / ctx.ws.clearUserId
+
+연결에 사용자 식별자를 붙여 `publishToUser`의 타겟이 되게 합니다.
+
+```typescript
+ctx.ws.setUserId(user.id);
+```
+
+## 브로드캐스트
+
+핸들러 밖에서도 `Sonamu.websocketRuntime`을 통해 같은 채널의 다른 연결에 메시지를 보낼 수 있습니다.
+
+```typescript
+import { Sonamu } from "sonamu";
+
+Sonamu.websocketRuntime.publishToRoom(
+  "global",
+  "newMessage",
+  { id: 1, content: "hello" },
+  "chat", // namespace
+);
+
+Sonamu.websocketRuntime.publishToUser(
+  userId,
+  "notify",
+  { kind: "mention" },
+  "chat",
+);
+```
+
+## 다른 데코레이터와 함께 사용
+
+`@websocket`은 `@api`, `@stream`, `@upload`와 같은 메서드에 동시에 사용할 수 없습니다. WebSocket으로 구독하면서 동일 데이터를 일반 HTTP로도 조회하고 싶다면, 메서드를 분리해 한쪽은 `@api`로, 다른 한쪽은 `@websocket`으로 노출하세요.
+
+```typescript
+class DashboardFrameClass extends BaseFrameClass {
+  @api({ httpMethod: "GET" })
+  async getRecentActivity(period: ActivityPeriod = "7"): Promise<ActivityGroup[]> {
+    // ...
+  }
+
+  @websocket({ outEvents, inEvents })
+  async getRecentActivityStream(
+    initialPeriod: ActivityPeriod = "7",
+    ctx: WebSocketContext<typeof outEvents.shape, typeof inEvents.shape>,
+  ): Promise<void> {
+    // ...
+  }
+}
+```
+
+## 제약사항
+
+### 1. @api / @stream / @upload와 중복 사용 불가
+
+```
+@websocket decorator can only be used once on Chat.subscribe.
+You can use only one of @api, @stream, @websocket, or @upload decorator on the same method.
+```
+
+### 2. httpMethod는 항상 GET
+
+`@websocket`은 자동으로 `httpMethod: "GET"`을 설정합니다. WebSocket upgrade는 GET 요청에서 시작되기 때문입니다.
+
+### 3. createSSE / reply에 의존하는 contextProvider 사용 시 주의
+
+WebSocket 경로에서는 SSE 헬퍼나 FastifyReply 접근이 의미가 없어 접근하면 즉시 에러가 발생합니다. 컨텍스트가 SSE/reply에 의존한다면 `websocketContextProvider`를 별도로 정의하세요.
+
+## 클라이언트 사용 (Web)
+
+`@websocket`이 붙은 메서드에 대해 Sonamu는 `useWebSocketChannel` 훅을 자동 생성합니다.
+
+```typescript
+import { ChatService } from "@/services/ChatService";
+
+function ChatRoom() {
+  const channel = ChatService.useSubscribeChat(
+    {},
+    {
+      newMessage: (msg) => {
+        // outEvents.newMessage 데이터
+      },
+      typingUsers: (users) => {
+        // outEvents.typingUsers 데이터
+      },
+    },
+  );
+
+  return (
+    <div>
+      <div>{channel.isConnected ? "connected" : "disconnected"}</div>
+      <button onClick={() => channel.send("send", { content: "hi" })}>send</button>
+    </div>
+  );
+}
+```
+
+`useWebSocketChannel`이 반환하는 상태:
+
+```typescript
+type WebSocketChannelState<TSend> = {
+  isConnected: boolean;
+  error: string | null;
+  retryCount: number;
+  readyState: number;
+  send<K extends keyof TSend>(event: K, data: TSend[K]): void;
+  close(code?: number, reason?: string): void;
+};
+```
+
+옵션:
+
+```typescript
+type WebSocketChannelOptions = {
+  enabled?: boolean;
+  retry?: number;
+  retryInterval?: number;
+  protocols?: string | string[];
+  traceProvider?: () => string | undefined;
+};
+```
+
+## 로깅
+
+`@websocket` 데코레이터는 호출 시 자동으로 디버그 로그를 남깁니다.
+
+```
+[DEBUG] websocket: ChatFrame.subscribeChat
+```
+
+## @stream과의 차이
+
+| 항목 | `@stream` (SSE) | `@websocket` |
+| --- | --- | --- |
+| 방향 | 서버 → 클라이언트 (단방향) | 양방향 |
+| 클라이언트 이벤트 처리 | 불가 | `inEvents` 스키마로 수신 |
+| 브로드캐스트 | SSE 연결마다 수동 발행 | `room` / `userId` 기반 라우팅 지원 |
+| HTTP 메서드 | GET (자동) | GET (자동, upgrade) |
+| 자동 생성 클라이언트 | `eventSource` 헬퍼 | `useWebSocketChannel` 훅 |
+
+## 다음 단계
+
+<CardGroup cols={2}>
+  <Card title="@stream" icon="signal-stream" href="/ko/api-reference/decorators/stream">
+    단방향 SSE 스트리밍이 필요할 때
+  </Card>
+
+  <Card title="@api" icon="plug" href="/ko/api-reference/decorators/api">
+    일반 REST API 만들기
+  </Card>
+
+  <Card title="@transactional" icon="arrows-rotate" href="/ko/api-reference/decorators/transactional">
+    트랜잭션으로 일관성 보장
+  </Card>
+
+  <Card title="@cache" icon="database" href="/ko/api-reference/decorators/cache">
+    결과 캐싱으로 성능 향상
+  </Card>
+</CardGroup>


### PR DESCRIPTION
> 🤖 이 PR은 AI(Claude / slack-vibecoder, cartanova-dev로 커밋)가 [Nightly PR Directions(#43)](https://github.com/cartanova-ai/sonamu/issues/43)와 [내일 새벽에 AI에게 맡길 일들(#44)](https://github.com/cartanova-ai/sonamu/issues/44)의 지침에 따라 자동 생성한 변경입니다. 코드 ownership은 그대로 유지됩니다 — 본 description의 근거가 약하다면 닫고 무시해 주십시오.

## 무엇을 / 왜 했나

`modules/docs/api-reference/decorators/`에 `@websocket` 데코레이터의 별도 레퍼런스 페이지가 없는 상태였습니다. 그런데 `@stream` 데코레이터 문서가 이미 다음과 같이 명시적으로 사용자를 \"별도 페이지\"로 유도하고 있습니다.

> WebSocket은 별도의 `@websocket` 데코레이터로 지원됩니다. `@stream`은 SSE 전용이며 `type` 옵션은 `\"sse\"`만 받습니다.
> _(ko/en api-reference/decorators/stream.mdx)_

즉, 사용자는 본문에서 `@websocket`을 안내받지만 막상 그 데코레이터의 옵션·`WebSocketContext` API·자동 생성되는 `useWebSocketChannel` 훅 사용법이 어디에도 정리되어 있지 않습니다. 코드에서는 이미 정식 export로 노출되어 있고(`modules/sonamu/src/api/decorators.ts`의 `websocket(...)` + `WebSocketDecoratorOptions`), `examples/miomock`의 `chat.frame.ts` / `dashboard.frame.ts`가 실사용 패턴을 보여주고 있어 안내가 빈 채로 남은 영역이 명확합니다.

이 PR은 그 갭을 메꿉니다.

## 어떤 작업이 포함되어 있나

1. **신규 페이지 추가** — `modules/docs/ko/api-reference/decorators/websocket.mdx`, `modules/docs/en/api-reference/decorators/websocket.mdx`
   - 옵션(필수 `outEvents` / `inEvents`, 그리고 `path` / `namespace` / `heartbeat` / `guards` / `description` / `resourceName`) 정리 — 모두 `decorators.ts`의 `WebSocketDecoratorOptions` 정의를 그대로 따랐습니다.
   - `WebSocketContext`의 ws 메서드(`publish`, `onMessage`, `onClose`, `waitForClose`, `join`/`leave`, `setUserId`/`clearUserId`) 사용법 — `modules/sonamu/src/api/context.ts`, `modules/sonamu/src/stream/ws.ts`의 인터페이스 그대로.
   - 핸들러 밖 브로드캐스트(`Sonamu.websocketRuntime.publishToRoom` / `publishToUser`) — `ws.ts`의 public API.
   - 다른 데코레이터와의 조합 제약(에러 메시지 포함) — `decorators.ts`의 `checkSingleDecorator` 텍스트를 그대로 사용.
   - 클라이언트 사이드 — `useWebSocketChannel` 시그니처와 `WebSocketChannelState` / `WebSocketChannelOptions` 타입(`examples/miomock/web/src/services/sonamu.shared.ts`의 정의 기준).
   - `@stream`과의 차이를 표로 정리.
2. **`modules/docs/docs.json`에 등록** — ko·en 양쪽 `데코레이터` / `Decorators` 그룹의 `stream` 다음 위치에 `websocket`을 추가.
3. **`stream.mdx`의 안내문구 보강** — ko/en 모두 `[\`@websocket\`](.../decorators/websocket)` 형태로 새 페이지에 직접 링크하도록 정정. (안내 문구 자체와 카드 그룹 구성에는 손대지 않았습니다.)

## 왜 이 접근을 채택했나

- 코드 변경은 0줄입니다. `@websocket` 데코레이터·런타임 동작은 이미 master에 안정적으로 자리잡았고 (SON-435 시리즈, SON-465 telemetry까지) 본 PR은 그 동작을 **있는 그대로 문서화**합니다. 동작을 새로 정의하거나 미정 인터페이스를 미리 박지 않습니다.
- 페이지 구조와 톤은 기존 `stream.mdx` / `cache.mdx`와 일관되게 맞추어, 사용자가 다른 데코레이터를 보던 흐름에서 그대로 읽을 수 있게 했습니다.

## 이 변경의 영향 / 검증

- **영향 받는 기능**: docs 사이트 navigation에 `데코레이터 > @websocket` 항목이 새로 노출됩니다. 기존 페이지의 URL/제목은 그대로입니다.
- **빠른 확인 방법**:
  - 파일 경로: `modules/docs/ko/api-reference/decorators/websocket.mdx`, `modules/docs/en/api-reference/decorators/websocket.mdx`
  - `modules/docs/docs.json`의 데코레이터 그룹 ko/en 모두에 `websocket` 항목이 `stream` 바로 다음에 들어가 있는지
  - `stream.mdx`의 `<Info>` 문구가 새 페이지로 링크되는지
  - 로컬 docs 미리보기: `pnpm --filter sonamu-docs dev`
- **검증 결과**:
  - 루트 `pnpm check` (oxlint + oxfmt): **errors: 0** — warnings 8개는 모두 기존 코드(`modules/create-sonamu/template/...`)에 대한 것으로 본 PR과 무관합니다.
  - `docs.json`의 JSON 구문 유효성: 통과
  - 코드 변경 없음 → sonamu / miomock 빌드·테스트에 영향이 없습니다.

## 사람의 확인이 필요할 수 있는 부분

- 새 페이지 본문 중 일부 사용 예시(특히 \"@stream과의 차이\" 표, \"Compared to @stream\" 표)는 사실 관계는 코드 기준이지만 강조하고 싶은 포인트가 다를 수 있습니다. 톤/우선순위만 조정이 필요할 수도 있습니다.
- WebSocketContext 사용 예시에서 제네릭 인자로 `typeof Schema.shape`를 노출했는데, miomock 코드는 `ChatOutEvents`, `RecentActivityOutEvents`처럼 별도 타입 별칭을 쓰는 경우도 있어 표기 스타일이 다를 수 있습니다. 둘 다 유효하지만 팀 컨벤션이 한쪽에 가깝다면 그쪽으로 좁혀주세요.
- `@websocket`과 `@transactional` 조합에 관한 동작 보장 여부는 본문에서 다루지 않았습니다(코드상 명시적인 차단·허용 모두 단정하기 어려워, 안내를 제외하는 쪽이 안전하다고 판단했습니다). 정책이 정해져 있다면 별도 추가가 필요합니다.

Co-authored-by: Claude <noreply@anthropic.com>