### PR TITLE
[Nightly 2026-05-13] 트랜잭션/카운트 안내 문서의 미존재 API 호출(UserModel.transaction/count, save({trx}), DB.transact) 정정 (ko/en 6파일)

### DIFF
--- a/modules/docs/en/api-reference/decorators/api.mdx
+++ b/modules/docs/en/api-reference/decorators/api.mdx
@@ -607,10 +607,14 @@ Logs are recorded through LogTape, with categories in `[model:user]` or `[frame:
         guards: ["admin"]
       })
       async dashboard() {
-        // Admin only
+        // Admin only — use findMany with queryMode: "count" for aggregation only
+        const [users, orders] = await Promise.all([
+          UserModel.findMany("A", { queryMode: "count" }),
+          OrderModel.findMany("A", { queryMode: "count" })
+        ]);
         return {
-          users: await UserModel.count(),
-          orders: await OrderModel.count()
+          users: users.total ?? 0,
+          orders: orders.total ?? 0
         };
       }
 

--- a/modules/docs/en/faq/database.mdx
+++ b/modules/docs/en/faq/database.mdx
@@ -481,28 +481,43 @@ const posts = await PostModel.getPuri("r")
 <AccordionGroup>
 <Accordion title="How do I use transactions?">
 
-**Method 1: Model's transaction method**
+**Method 1: Manual transaction (`getPuri("w").transaction()`)**
 
 ```typescript
-await UserModel.transaction(async (trx) => {
-  const user = await UserModel.save({ name: "John" }, { trx });
-  const profile = await ProfileModel.save({ user_id: user.id }, { trx });
-  return user;
-});
+class UserModel extends BaseModelClass {
+  async createWithProfile(data: { name: string; bio: string }) {
+    const wdb = this.getPuri("w");
+
+    return wdb.transaction(async (trx) => {
+      trx.ubRegister("users", { name: data.name });
+      const [userId] = await trx.ubUpsert("users");
+
+      trx.ubRegister("profiles", { user_id: userId, bio: data.bio });
+      await trx.ubUpsert("profiles");
+
+      return userId;
+    });
+  }
+}
 ```
 
-**Method 2: DB.transact**
+**Method 2: `@transactional()` decorator**
 
 ```typescript
-import { DB } from "sonamu";
+import { transactional } from "sonamu";
 
-await DB.transact("w", async (trx) => {
-  await trx("users").insert({ name: "John" });
-  await trx("profiles").insert({ user_id: 1 });
-});
+class UserModel extends BaseModelClass {
+  @transactional()
+  async createWithProfile(data: { name: string; bio: string }) {
+    // The entire method body runs inside a transaction automatically.
+    const [userId] = await UserModel.save([{ name: data.name }]);
+    await ProfileModel.save([{ user_id: userId, bio: data.bio }]);
+    return userId;
+  }
+}
 ```
 
-**Auto-rollback on error.**
+**Auto-rollback on error.** See [Manual Transactions](/en/database/transactions/manual-transactions) and [@transactional Decorator](/en/database/transactions/transactional-decorator) for details.
 
 </Accordion>
 </AccordionGroup>

--- a/modules/docs/en/faq/testing.mdx
+++ b/modules/docs/en/faq/testing.mdx
@@ -338,31 +338,36 @@ describe("User API Errors", () => {
 <Accordion title="How do I test transactions?">
 
 ```typescript
+import { Puri } from "sonamu";
+
 describe("Transactions", () => {
   test("transaction success", async () => {
-    await UserModel.transaction(async (trx) => {
-      const user = await UserModel.save({ name: "Tx User" }, { trx });
-      const profile = await ProfileModel.save({ user_id: user.id, bio: "Bio" }, { trx });
+    const wdb = UserModel.getPuri("w");
 
-      expect(user.id).toBeGreaterThan(0);
-      expect(profile.user_id).toBe(user.id);
+    await wdb.transaction(async () => {
+      // Model.save() calls inside the callback automatically join the same transaction.
+      const [userId] = await UserModel.save([{ name: "Tx User" }]);
+      const [profileId] = await ProfileModel.save([{ user_id: userId, bio: "Bio" }]);
+
+      expect(userId).toBeGreaterThan(0);
+      expect(profileId).toBeGreaterThan(0);
     });
   });
 
   test("transaction rollback", async () => {
-    const initialCount = await UserModel.count();
+    const rdb = UserModel.getPuri("r");
+    const before = await rdb.table("users").select({ total: Puri.count() }).first();
 
-    try {
-      await UserModel.transaction(async (trx) => {
-        await UserModel.save({ name: "Rollback User" }, { trx });
+    const wdb = UserModel.getPuri("w");
+    await expect(
+      wdb.transaction(async () => {
+        await UserModel.save([{ name: "Rollback User" }]);
         throw new Error("Forced error");
-      });
-    } catch (error) {
-      // Ignore error
-    }
+      }),
+    ).rejects.toThrow("Forced error");
 
-    const finalCount = await UserModel.count();
-    expect(finalCount).toBe(initialCount); // No change
+    const after = await rdb.table("users").select({ total: Puri.count() }).first();
+    expect(after?.total).toBe(before?.total); // No change
   });
 });
 ```

--- a/modules/docs/ko/api-reference/decorators/api.mdx
+++ b/modules/docs/ko/api-reference/decorators/api.mdx
@@ -607,10 +607,14 @@ async findById(id: number) {
         guards: ["admin"]
       })
       async dashboard() {
-        // 관리자만 접근 가능
+        // 관리자만 접근 가능 — findMany의 queryMode: "count"로 집계만 수행
+        const [users, orders] = await Promise.all([
+          UserModel.findMany("A", { queryMode: "count" }),
+          OrderModel.findMany("A", { queryMode: "count" })
+        ]);
         return {
-          users: await UserModel.count(),
-          orders: await OrderModel.count()
+          users: users.total ?? 0,
+          orders: orders.total ?? 0
         };
       }
 

--- a/modules/docs/ko/faq/database.mdx
+++ b/modules/docs/ko/faq/database.mdx
@@ -481,28 +481,43 @@ const posts = await PostModel.getPuri("r")
 <AccordionGroup>
 <Accordion title="트랜잭션을 사용하려면?">
 
-**방법 1: Model의 transaction 메서드**
+**방법 1: 수동 트랜잭션 (`getPuri("w").transaction()`)**
 
 ```typescript
-await UserModel.transaction(async (trx) => {
-  const user = await UserModel.save({ name: "John" }, { trx });
-  const profile = await ProfileModel.save({ user_id: user.id }, { trx });
-  return user;
-});
+class UserModel extends BaseModelClass {
+  async createWithProfile(data: { name: string; bio: string }) {
+    const wdb = this.getPuri("w");
+
+    return wdb.transaction(async (trx) => {
+      trx.ubRegister("users", { name: data.name });
+      const [userId] = await trx.ubUpsert("users");
+
+      trx.ubRegister("profiles", { user_id: userId, bio: data.bio });
+      await trx.ubUpsert("profiles");
+
+      return userId;
+    });
+  }
+}
 ```
 
-**방법 2: DB.transact**
+**방법 2: `@transactional()` 데코레이터**
 
 ```typescript
-import { DB } from "sonamu";
+import { transactional } from "sonamu";
 
-await DB.transact("w", async (trx) => {
-  await trx("users").insert({ name: "John" });
-  await trx("profiles").insert({ user_id: 1 });
-});
+class UserModel extends BaseModelClass {
+  @transactional()
+  async createWithProfile(data: { name: string; bio: string }) {
+    // 메서드 본문 전체가 자동으로 트랜잭션 안에서 실행됩니다.
+    const [userId] = await UserModel.save([{ name: data.name }]);
+    await ProfileModel.save([{ user_id: userId, bio: data.bio }]);
+    return userId;
+  }
+}
 ```
 
-**에러 발생 시 자동 롤백됩니다.**
+**에러 발생 시 자동 롤백됩니다.** 더 자세한 내용은 [수동 트랜잭션](/ko/database/transactions/manual-transactions) 및 [@transactional 데코레이터](/ko/database/transactions/transactional-decorator) 문서를 참고하세요.
 
 </Accordion>
 </AccordionGroup>

--- a/modules/docs/ko/faq/testing.mdx
+++ b/modules/docs/ko/faq/testing.mdx
@@ -338,31 +338,36 @@ describe("User API Errors", () => {
 <Accordion title="트랜잭션을 테스트하려면?">
 
 ```typescript
+import { Puri } from "sonamu";
+
 describe("Transactions", () => {
   test("트랜잭션 성공", async () => {
-    await UserModel.transaction(async (trx) => {
-      const user = await UserModel.save({ name: "Tx User" }, { trx });
-      const profile = await ProfileModel.save({ user_id: user.id, bio: "Bio" }, { trx });
+    const wdb = UserModel.getPuri("w");
 
-      expect(user.id).toBeGreaterThan(0);
-      expect(profile.user_id).toBe(user.id);
+    await wdb.transaction(async () => {
+      // 트랜잭션 컨텍스트 안에서 호출하는 Model.save() 도 동일 트랜잭션에 자동 합류합니다.
+      const [userId] = await UserModel.save([{ name: "Tx User" }]);
+      const [profileId] = await ProfileModel.save([{ user_id: userId, bio: "Bio" }]);
+
+      expect(userId).toBeGreaterThan(0);
+      expect(profileId).toBeGreaterThan(0);
     });
   });
 
   test("트랜잭션 롤백", async () => {
-    const initialCount = await UserModel.count();
+    const rdb = UserModel.getPuri("r");
+    const before = await rdb.table("users").select({ total: Puri.count() }).first();
 
-    try {
-      await UserModel.transaction(async (trx) => {
-        await UserModel.save({ name: "Rollback User" }, { trx });
+    const wdb = UserModel.getPuri("w");
+    await expect(
+      wdb.transaction(async () => {
+        await UserModel.save([{ name: "Rollback User" }]);
         throw new Error("강제 에러");
-      });
-    } catch (error) {
-      // 에러 무시
-    }
+      }),
+    ).rejects.toThrow("강제 에러");
 
-    const finalCount = await UserModel.count();
-    expect(finalCount).toBe(initialCount); // 변화 없음
+    const after = await rdb.table("users").select({ total: Puri.count() }).first();
+    expect(after?.total).toBe(before?.total); // 변화 없음
   });
 });
 ```


### PR DESCRIPTION
> 🤖 이 PR은 AI(Claude / slack-vibecoder, cartanova-dev로 커밋)가 [Nightly PR Directions(#43)](https://github.com/cartanova-ai/sonamu/issues/43)와 [내일 새벽에 AI에게 맡길 일들(#44)](https://github.com/cartanova-ai/sonamu/issues/44)의 지침에 따라 자동 생성한 변경입니다. 코드 ownership은 그대로 유지됩니다 — 본 description의 근거가 약하다면 닫고 무시해 주십시오.

## 무엇을 / 왜 했나

문서 3개 (`faq/testing.mdx`, `faq/database.mdx`, `api-reference/decorators/api.mdx`)에서 BaseModel/자동 생성 모델에 **존재하지 않는 API**를 호출하는 예제가 발견되어 정정했습니다. 사용자가 그대로 따라 하면 컴파일/런타임에서 즉시 실패합니다.

## 무엇이 어긋났는가 (코드 근거)

`modules/sonamu/src/database/base-model.ts` 의 `BaseModelClass`(L38–592)에 정의된 메서드는 `getDB`/`getPuri`/`destroy`/`getInsertedIds`/`getSubsetQueries`/`createEnhancers`/`executeSubsetQuery`/`omitInternalFields`/`hydrate` 뿐입니다. `transaction`/`count`는 없습니다.

`modules/sonamu/src/template/implementations/model.template.ts` 의 Syncer 자동 생성 메서드(L84–205)는 `findById` / `findOne` / `findMany` / `save(spa: SaveParams[])` / `del(ids: number[])` 다섯 가지뿐이고, `save`는 **배열**만 받으며 `{ trx }` 같은 두 번째 인자가 없습니다. `transaction`/`count`도 자동 생성되지 않습니다.

`modules/sonamu/src/database/db.ts` 의 `DBClass`(L58–263)에는 `transact` 메서드가 없습니다. 트랜잭션 진입점은 `PuriWrapper.transaction()`(`puri-wrapper.ts` L96–142) 또는 `@transactional()` 데코레이터(`api/decorators.ts`)입니다.

## 어떤 작업이 포함되어 있나

### 1. `modules/docs/{ko,en}/faq/testing.mdx` — \"트랜잭션을 테스트하려면?\" 예제 정정
- `UserModel.transaction(async (trx) => ...)` → `const wdb = UserModel.getPuri(\"w\"); await wdb.transaction(async () => ...)` (manual-transactions.mdx의 공식 예제 형식과 일치)
- `UserModel.save({...}, { trx })` → `UserModel.save([{...}])` 배열 인자로 정정. \"트랜잭션 컨텍스트 안에서 호출하는 Model.save() 도 동일 트랜잭션에 자동 합류한다\" 점을 주석으로 명시 (`BaseModelClass#getPuri()` 가 `DB.getTransactionContext().getTransaction()` 으로 합류 — `base-model.ts` L58–68 참조)
- `UserModel.count()` → `rdb.table(\"users\").select({ total: Puri.count() }).first()` 로 정정 (`Puri.count()` 는 `select` 절 정적 메서드 — `puri.ts` L99)
- 롤백 케이스의 try/catch 패턴을 `expect(...).rejects.toThrow(...)` 로 의도를 명확히

### 2. `modules/docs/{ko,en}/faq/database.mdx` — \"트랜잭션을 사용하려면?\" 예제 정정
기존 안내의 두 패턴이 모두 미존재 API였습니다:
- 방법 1 `UserModel.transaction(...)` → **`getPuri(\"w\").transaction(async (trx) => trx.ubRegister/ubUpsert)`** 수동 트랜잭션 패턴으로 교체 (manual-transactions.mdx 예제와 동일)
- 방법 2 `DB.transact(\"w\", ...)` → **`@transactional()` 데코레이터** 패턴으로 교체 (transactional-decorator.mdx 및 `examples/miomock/api/src/practices/p5-transactional-decorator.ts` 와 동일 형식)
- 상세 문서 두 페이지로의 링크도 함께 추가

### 3. `modules/docs/{ko,en}/api-reference/decorators/api.mdx` — admin 대시보드 예시 정정
\"권한 제어\" 탭의 `UserModel.count()` / `OrderModel.count()` 호출을 `findMany(\"A\", { queryMode: \"count\" })` 패턴으로 교체. 본 예시의 주제(@api guards)는 그대로 유지하면서 내부 호출만 정정. 실제 사용 패턴 근거: `examples/miomock/api/src/application/dashboard/dashboard.frame.ts` L29–31.

## 어떤 issue를 참조 / 왜 이 작업을 선정했나

- [#43 (Nightly PR Directions)](https://github.com/cartanova-ai/sonamu/issues/43) 지침에 따라, [#44 (내일 새벽에 AI에게 맡길 일들)](https://github.com/cartanova-ai/sonamu/issues/44) 의 \"문서/주석이 코드와 어긋나는 경우\" 항목을 표적으로 선정.
- #44의 명시적 무시 항목(`puri.ts` SQL injection / `PostgresPubSub.destroy()` null 체크 / `examples/practices` 폴더)은 모두 회피했습니다.
- 최근 머지된 Nightly PR들이 `getPuri()/.table()` 누락(#147/#148/#160/#161/#163), `this.puri()` / `.many()` 미존재(#148), `toBuffer()/getResponse()` 미존재(#152) 등 \"미존재 API 호출\" 카테고리를 다뤄왔는데, **transaction/count 패턴은 아직 다뤄지지 않은 빈틈** 이라 선정 근거가 명확했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가

- FAQ는 사용자가 검색해 처음 들어오는 진입점입니다. 미존재 메서드 호출이 가장 잘 보이는 위치에 그대로 노출되면 신규 사용자가 \"이게 sonamu가 제공하는 표준 패턴\" 으로 오해하고 그대로 복붙합니다.
- 특히 트랜잭션의 경우, 잘못된 패턴을 따라하면 즉시 컴파일/런타임 오류로 빠르게 실패하긴 하지만, sonamu 입문자가 \"문서가 이상한가, 내가 잘못한 건가\" 로 시간을 잃습니다.

## 어떤 기능에 영향을 미치는가

문서 6개 파일(ko/en 각 3개)의 코드 블록만 변경. 소스 코드 변경 없음. 런타임/빌드 산출물에 영향 없음.

## 영향을 바로 확인하는 방법

1. 본 PR의 6개 mdx diff 확인.
2. 변경된 예제가 가리키는 실제 API 정의 위치는 description에 모두 라인 단위로 명시되어 있습니다.
3. 검증: 루트에서 `pnpm check` (oxlint + oxfmt) 통과 (8 warnings, 0 errors — 변경과 무관한 기존 warning).
4. 추가로 트랜잭션 패턴이 잘 작동하는지 확인하려면 `examples/miomock` 에서 `pnpm sonamu test src/sonamu-test/puri-wrapper.test.ts` (`wdb.transaction()` 패턴의 정식 테스트가 그대로 사용됩니다).

## 사람의 확인이 필요한 부분 / 의사결정이 불완전했던 부분

- `findMany(\"A\", { queryMode: \"count\" })` 의 `\"A\"` 서브셋 키는 sonamu의 관례적 \"All\" 서브셋 명을 따른 것이며 실제 `examples/miomock/api/src/application/dashboard/dashboard.frame.ts` 의 사용 패턴과 동일하지만, Entity 별 서브셋 정의는 사용자 정의이므로 문서 독자가 자신 프로젝트의 실제 서브셋 키로 치환해 읽어야 한다는 점은 명시하지 않았습니다. 별도 한 줄 안내가 필요하다고 판단되시면 알려주세요.
- `database.mdx` 의 트랜잭션 안내에서 \"방법 1: 수동 트랜잭션\" 의 예제를 `trx.ubRegister/ubUpsert` 기반으로 작성했는데, `manual-transactions.mdx` 의 첫 예제와 동일한 패턴입니다. 더 가벼운 `trx.table(\"...\").insert(...)` 형태를 선호하시면 그쪽으로 바꿔도 됩니다.