### PR TITLE
[Nightly 2026-05-15] storage-manager 문서의 미존재 defaultDisk/use() 시그니처 및 bad-request-error의 Sonamu.storage.save() 호출 정정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/advanced-features/storage/storage-manager.mdx
+++ b/modules/docs/en/advanced-features/storage/storage-manager.mdx
@@ -407,29 +407,17 @@ class FileModelClass extends BaseModelClass {
 
 ## Storage Manager API
 
-### use(diskName?)
+### use(diskName)
 
-Returns a disk instance.
+Returns the disk instance for the given name. `diskName` is a required argument and must be one of the keys registered in `config.server.storage.drivers` (`DriverKey = "fs" | "s3"`).
 
 ```typescript
-// Default disk
-const disk = Sonamu.storage.use();
-
-// Specific disk
+// Pick a disk registered under drivers
 const s3 = Sonamu.storage.use("s3");
 const fs = Sonamu.storage.use("fs");
 ```
 
 **Return value**: `Disk` instance (Flydrive)
-
-### defaultDisk
-
-Returns the default disk name.
-
-```typescript
-const defaultName = Sonamu.storage.defaultDisk;
-// => 'fs' or 's3', etc.
-```
 
 ## Disk API (Flydrive)
 
@@ -438,7 +426,7 @@ The Disk returned by Storage Manager is a Flydrive Disk instance.
 ### Key Methods
 
 ```typescript
-const disk = Sonamu.storage.use();
+const disk = Sonamu.storage.use("fs");
 
 // Save file
 await disk.put("path/to/file.txt", "content");

--- a/modules/docs/en/api-reference/exceptions/bad-request-error.mdx
+++ b/modules/docs/en/api-reference/exceptions/bad-request-error.mdx
@@ -169,11 +169,8 @@ async uploadProfileImage(ctx: Context) {
   }
 
   // Save image
-  return Sonamu.storage.save({
-    file: file.buffer,
-    filename: file.filename,
-    bucket: "profile-images"
-  });
+  const key = `profile-images/${Date.now()}-${file.filename}`;
+  return file.saveToDisk("s3", key);
 }
 ```
 

--- a/modules/docs/ko/advanced-features/storage/storage-manager.mdx
+++ b/modules/docs/ko/advanced-features/storage/storage-manager.mdx
@@ -402,29 +402,17 @@ class FileModelClass extends BaseModelClass {
 
 ## Storage Manager API
 
-### use(diskName?)
+### use(diskName)
 
-디스크 인스턴스를 반환합니다.
+지정한 디스크 이름의 인스턴스를 반환합니다. `diskName`은 `config.server.storage.drivers`에 등록된 키(`DriverKey = "fs" | "s3"`) 중 하나로 필수 인자입니다.
 
 ```typescript
-// 기본 디스크
-const disk = Sonamu.storage.use();
-
-// 특정 디스크
+// drivers에 등록된 디스크 지정
 const s3 = Sonamu.storage.use("s3");
 const fs = Sonamu.storage.use("fs");
 ```
 
 **반환값**: `Disk` 인스턴스 (Flydrive)
-
-### defaultDisk
-
-기본 디스크 이름을 반환합니다.
-
-```typescript
-const defaultName = Sonamu.storage.defaultDisk;
-// => 'fs' 또는 's3' 등
-```
 
 ## Disk API (Flydrive)
 
@@ -433,7 +421,7 @@ Storage Manager가 반환하는 Disk는 Flydrive의 Disk 인스턴스입니다.
 ### 주요 메서드
 
 ```typescript
-const disk = Sonamu.storage.use();
+const disk = Sonamu.storage.use("fs");
 
 // 파일 저장
 await disk.put("path/to/file.txt", "content");

--- a/modules/docs/ko/api-reference/exceptions/bad-request-error.mdx
+++ b/modules/docs/ko/api-reference/exceptions/bad-request-error.mdx
@@ -169,11 +169,8 @@ async uploadProfileImage(ctx: Context) {
   }
 
   // 이미지 저장
-  return Sonamu.storage.save({
-    file: file.buffer,
-    filename: file.filename,
-    bucket: "profile-images"
-  });
+  const key = `profile-images/${Date.now()}-${file.filename}`;
+  return file.saveToDisk("s3", key);
 }
 ```
 


### PR DESCRIPTION
> 🤖 이 PR은 AI(Claude / slack-vibecoder, cartanova-dev로 커밋)가 [Nightly PR Directions(#43)](https://github.com/cartanova-ai/sonamu/issues/43)와 [내일 새벽에 AI에게 맡길 일들(#44)](https://github.com/cartanova-ai/sonamu/issues/44)의 지침에 따라 자동 생성한 변경입니다. 코드 ownership은 그대로 유지됩니다 — 본 description의 근거가 약하다면 닫고 무시해 주십시오.

## 무엇을 / 왜 했나

storage 관련 사용자 가이드(`advanced-features/storage/storage-manager.mdx`)의 **"Storage Manager API"** 섹션과, 자주 참조되는 예외 가이드(`api-reference/exceptions/bad-request-error.mdx`)의 파일 업로드 검증 예제에서 **소스 코드에 존재하지 않는 API**를 호출하는 부분 3건을 발견하여 정정했습니다. 모두 사용자가 그대로 따라 하면 TypeScript 컴파일 또는 런타임에서 즉시 실패하는 명백한 오류입니다.

## 무엇이 어긋났는가 (코드 근거)

**1) `StorageManager.use()` 시그니처**

`modules/sonamu/src/storage/storage-manager.ts` L19의 정의는 다음과 같습니다.

```ts
use(diskName: DriverKey): Disk {
```

`diskName`은 **필수 인자**(`?` 없음)이며, `DriverKey = "fs" | "s3"`(`modules/sonamu/src/storage/drivers.ts`)입니다. 그러나 ko/en `storage-manager.mdx`의 "Storage Manager API" 섹션은 `### use(diskName?)`처럼 옵셔널로 표기하고 본문 예제도 인자 없는 `Sonamu.storage.use()` 호출을 보여주고 있었습니다. 그대로 따라 하면 `Expected 1 arguments, but got 0.` 컴파일 에러가 발생합니다.

**2) `StorageManager.defaultDisk` 미존재 속성**

`StorageManager`(`storage-manager.ts` L10–31)는 `use(diskName)` 단 한 개의 public 메서드만 노출합니다. `defaultDisk` 속성·게터는 정의되어 있지 않습니다. 또한 `StorageConfig` 자체에 `default` 필드가 없다는 점은 이미 PR #150에서 `setup.mdx` 기준으로 정정되었으나, `storage-manager.mdx`의 "Storage Manager API > defaultDisk" 섹션은 그때 함께 제거되지 않은 잔재였습니다.

**3) `Sonamu.storage.save({...})` 미존재 메서드**

`api-reference/exceptions/bad-request-error.mdx`의 "파일 업로드 검증" 예제가 `Sonamu.storage.save({ file, filename, bucket })` 형태를 호출하고 있었습니다. 그러나 `StorageManager`에 `save` 메서드는 존재하지 않으며, sonamu 소스/예제 어디에서도 호출되지 않습니다(`grep -rn "Sonamu\.storage\.save" modules/sonamu/src/ examples/` → 결과 0건). 실제 파일 저장 API는 `BufferedFile.saveToDisk(diskName: DriverKey, key: string): Promise<string>`(`modules/sonamu/src/storage/buffered-file.ts` L42)입니다.

## 어떤 작업이 포함되어 있나

### 커밋 1: `storage-manager.mdx` (ko/en)
- `### use(diskName?)` → `### use(diskName)`
- 본문 설명에 등록된 키(`DriverKey = "fs" | "s3"`)만 허용되며 필수 인자라는 점 명시
- 인자 없는 `Sonamu.storage.use()` 예제 줄 제거
- 미존재 `### defaultDisk` 섹션 전체 삭제
- "Disk API" 섹션 첫 줄의 인자 없는 호출도 `Sonamu.storage.use("fs")`로 정정

### 커밋 2: `bad-request-error.mdx` (ko/en)
- `Sonamu.storage.save({...})` → `file.saveToDisk("s3", key)` 패턴으로 교체
- `key`는 `\`profile-images/${Date.now()}-${file.filename}\`` 형태로 명시
- BadRequestException 검증 흐름 자체는 그대로 보존(예제 주제 유지)

## 어떤 issue를 참조 / 왜 이 작업을 선정했나

- [#43 (Nightly PR Directions)](https://github.com/cartanova-ai/sonamu/issues/43) 지침에 따라, [#44 (내일 새벽에 AI에게 맡길 일들)](https://github.com/cartanova-ai/sonamu/issues/44)의 **"문서/주석이 코드와 어긋나는 경우"** 항목을 표적으로 선정.
- #44의 명시적 무시 항목(`puri.ts` SQL injection / `PostgresPubSub.destroy()` null 체크 / `examples/practices` 폴더)은 모두 회피했습니다.
- PR #150이 storage 관련 문서에서 `default` 필드, 잘못된 `DriverKey`, `StorageManager` 정적 API 사용을 `setup.mdx` 위주로 정정했지만, **`storage-manager.mdx`의 API 레퍼런스 섹션과 `bad-request-error.mdx`의 미존재 `.save()` 호출은 그 PR에서 다뤄지지 않은 잔존 오류**임을 확인했습니다. 가장 명백하게 컴파일/런타임 즉시 실패하는 부분만 좁혀 선정했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가

- "Storage Manager API" 섹션은 사용자가 storage 사용법을 익힐 때 가장 마지막에 참조하는 레퍼런스입니다. 이 섹션이 잘못된 시그니처와 미존재 속성을 안내하면, 본문 예제를 보고 따라 한 사용자가 IDE에서 즉시 빨간 줄을 보게 되어 "어디부터 잘못된 건지" 추적에 시간을 잃습니다.
- `bad-request-error.mdx`는 검증 흐름의 정식 예제로 자주 검색됩니다. `Sonamu.storage.save({ file, filename, bucket })` 같이 그럴듯해 보이는 미존재 메서드가 정식 패턴인 것처럼 노출되면, 신규 사용자가 잘못된 멘탈 모델을 굳히게 됩니다.

## 이 변경이 어떤 기능에 영향을 미치는가

문서 4개 파일(ko/en 각 2개)의 텍스트·코드 블록만 변경. 소스 코드 변경 없음. 런타임/빌드 산출물에 영향 없습니다.

## 영향을 바로 확인하는 방법

1. 본 PR의 4개 mdx diff 확인.
2. 코드 근거 검증:
   - `modules/sonamu/src/storage/storage-manager.ts` L19에서 `use(diskName: DriverKey): Disk` (필수 인자, defaultDisk 없음) 확인
   - `modules/sonamu/src/storage/drivers.ts`에서 `DriverKey = "fs" | "s3"` 확인
   - `modules/sonamu/src/storage/buffered-file.ts` L42의 `saveToDisk(diskName: DriverKey, key: string)` 확인
   - `grep -rn "Sonamu\.storage\.save" modules/sonamu/src/ examples/` → 결과 0건 확인
3. 빌드/검증: 루트에서 `pnpm check` (oxlint + oxfmt) 통과 — **0 errors, 8 warnings**(모두 변경과 무관한 기존 경고, `modules/create-sonamu/template`·`modules/react-sui` 등).

## 사람의 확인이 필요한 부분 / 의사결정이 불완전했던 부분

- 본 PR은 `storage-manager.mdx`의 **API 레퍼런스 섹션**과 `bad-request-error.mdx`의 한 예제만 좁혀 다뤘습니다. `storage-manager.mdx` 본문에는 그 외에도 다음과 같은 잠재 정정 후보가 남아 있습니다(별도 PR로 처리 권장):
  - 본문 코드 예제 다수에서 인자 없는 `Sonamu.storage.use()` 호출 (lines ~37, 70, 112, 411 등)
  - `default: "fs"` / `default: process.env.STORAGE_DISK || "fs"` 같은 미존재 `StorageConfig.default` 필드 사용 (PR #150이 setup.mdx에서 정리한 패턴이 본 파일에는 남아있음)
  - `"backup"`, `"public"`처럼 `DriverKey = "fs" | "s3"`에 포함되지 않는 임의 키를 사용한 다중 디스크 예제 (lines ~167, 210, 287–326)
  - 다이어그램의 `r2` (Cloudflare R2) 노드 — 실제 드라이버에 포함되지 않음

  이번 PR이 작아도 즉시 실패하는 부분부터 안전하게 끊은 형태이고, 본문 예제 정리는 의도 보존 판단(예: 사용자 정의 디스크 키를 허용하는 방향으로 framework가 확장될 가능성)이 필요하다고 보아 분리했습니다. 본문도 함께 정리하라는 방침이라면 후속 PR로 처리하겠습니다.
- `bad-request-error.mdx`의 정정에서 `"s3"` 디스크 키를 선택한 것은 원본의 의도(이미지 영구 저장 → "profile-images" 버킷)를 가장 잘 반영하는 등록 가능한 키라고 판단했기 때문입니다. 프로젝트 컨벤션이 `"fs"`라면 그쪽으로 수정해 주세요.

Co-authored-by: Claude <noreply@anthropic.com>