### PR TITLE
[Nightly 2026-05-18] @transactional 가이드의 잘못된 기본 격리 수준 표기 제거 및 test-helpers fixture 예제의 미존재 .create() 호출을 표준 Model.save() 패턴으로 정정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/database/transactions/transactional-decorator.mdx
+++ b/modules/docs/en/database/transactions/transactional-decorator.mdx
@@ -120,7 +120,7 @@ class UserModel extends BaseModelClass {
     // Only read committed data (Non-repeatable Read possible)
   }
 
-  // REPEATABLE READ (default)
+  // REPEATABLE READ
   @transactional({ isolation: "repeatable read" })
   async repeatableRead() {
     const wdb = this.getPuri("w");

--- a/modules/docs/en/testing/writing-tests/test-helpers.mdx
+++ b/modules/docs/en/testing/writing-tests/test-helpers.mdx
@@ -37,45 +37,45 @@ import { PostModel } from "@/models/post.model";
 export const loadFixtures = createFixtureLoader({
   // User fixtures
   user01: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "john",
       email: "john@example.com",
       password: "password123",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   user02: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "jane",
       email: "jane@example.com",
       password: "password456",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   admin: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "admin",
       email: "admin@example.com",
       password: "admin123",
       role: "admin",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   // Post fixtures
   post01: async () => {
-    const postModel = new PostModel();
-    const { post } = await postModel.create({
+    const params = {
       title: "First Post",
       content: "Content of first post",
       author_id: 1,
-    });
-    return post;
+    };
+    const [id] = await PostModel.save([params]);
+    return { id, ...params };
   },
 });
 ```
@@ -96,8 +96,7 @@ test("Get user's posts", async () => {
   const { user01, post01 } = await loadFixtures(["user01", "post01"]);
 
   // Test
-  const postModel = new PostModel();
-  const { posts } = await postModel.getPostsByUser(user01.id);
+  const { posts } = await PostModel.getPostsByUser(user01.id);
 
   expect(posts).toHaveLength(1);
   expect(posts[0].id).toBe(post01.id);
@@ -156,26 +155,26 @@ const { user01, user02 } = await loadFixtures(["user01", "user02"]);
 // api/src/testing/fixture.ts
 export const loadFixtures = createFixtureLoader({
   author: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "author",
       email: "author@example.com",
       password: "password",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   authorPost: async () => {
     // Load author fixture first
     const { author } = await loadFixtures(["author"]);
 
-    const postModel = new PostModel();
-    const { post } = await postModel.create({
+    const params = {
       title: "Author's Post",
       content: "Content",
       author_id: author.id, // Set relationship
-    });
-    return post;
+    };
+    const [id] = await PostModel.save([params]);
+    return { id, ...params };
   },
 });
 ```
@@ -196,30 +195,24 @@ test("Author and post relationship", async () => {
 export const loadFixtures = createFixtureLoader({
   // Fixture that takes parameters
   userWithEmail: async (email: string) => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: email.split("@")[0],
       email,
       password: "password",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   // Create multiple data
   users10: async () => {
-    const userModel = new UserModel();
-    const users = [];
-
-    for (let i = 1; i <= 10; i++) {
-      const { user } = await userModel.create({
-        username: `user${i}`,
-        email: `user${i}@example.com`,
-        password: "password",
-      });
-      users.push(user);
-    }
-
-    return users;
+    const paramsList = Array.from({ length: 10 }, (_, i) => ({
+      username: `user${i + 1}`,
+      email: `user${i + 1}@example.com`,
+      password: "password",
+    }));
+    const ids = await UserModel.save(paramsList);
+    return paramsList.map((params, i) => ({ id: ids[i], ...params }));
   },
 });
 ```
@@ -298,62 +291,60 @@ import { PostModel } from "@/models/post.model";
 export const loadFixtures = createFixtureLoader({
   // 1. Simple data
   guestUser: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "guest",
       email: "guest@example.com",
       password: "password",
       role: "guest",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
-  // 2. Multiple data
+  // 2. Multiple data (pass array at once)
   testUsers: async () => {
-    const userModel = new UserModel();
-    const users = await Promise.all([
-      userModel.create({
+    const paramsList = [
+      {
         username: "user1",
         email: "user1@example.com",
         password: "password",
-      }),
-      userModel.create({
+      },
+      {
         username: "user2",
         email: "user2@example.com",
         password: "password",
-      }),
-    ]);
-    return users.map(({ user }) => user);
+      },
+    ];
+    const ids = await UserModel.save(paramsList);
+    return paramsList.map((params, i) => ({ id: ids[i], ...params }));
   },
 
   // 3. Data with relationships
   userWithPosts: async () => {
-    const userModel = new UserModel();
-    const postModel = new PostModel();
-
-    const { user } = await userModel.create({
+    const userParams = {
       username: "blogger",
       email: "blogger@example.com",
       password: "password",
-    });
+    };
+    const [userId] = await UserModel.save([userParams]);
+    const user = { id: userId, ...userParams };
 
-    const posts = await Promise.all([
-      postModel.create({
+    const postParamsList = [
+      {
         title: "Post 1",
         content: "Content 1",
         author_id: user.id,
-      }),
-      postModel.create({
+      },
+      {
         title: "Post 2",
         content: "Content 2",
         author_id: user.id,
-      }),
-    ]);
+      },
+    ];
+    const postIds = await PostModel.save(postParamsList);
+    const posts = postParamsList.map((params, i) => ({ id: postIds[i], ...params }));
 
-    return {
-      user,
-      posts: posts.map(({ post }) => post),
-    };
+    return { user, posts };
   },
 });
 ```
@@ -374,17 +365,17 @@ test("Create and retrieve comments", async () => {
   const { userWithPosts } = await loadFixtures(["userWithPosts"]);
   const { user, posts } = userWithPosts;
 
-  const commentModel = new CommentModel();
-
   // Create comment
-  const { comment } = await commentModel.create({
-    content: "Great post!",
-    post_id: posts[0].id,
-    author_id: user.id,
-  });
+  const [commentId] = await CommentModel.save([
+    {
+      content: "Great post!",
+      post_id: posts[0].id,
+      author_id: user.id,
+    },
+  ]);
 
   // Get comments
-  const { comments } = await commentModel.getCommentsByPost(posts[0].id);
+  const { comments } = await CommentModel.getCommentsByPost(posts[0].id);
 
   expect(comments).toHaveLength(1);
   expect(comments[0].content).toBe("Great post!");
@@ -433,21 +424,20 @@ export const loadFixtures = createFixtureLoader({
 // ✅ Correct: Only needed fields
 export const loadFixtures = createFixtureLoader({
   basicUser: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "user",
       email: "user@example.com",
       password: "password",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 });
 
 // ❌ Wrong: Unnecessary fields
 export const loadFixtures = createFixtureLoader({
   complexUser: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "user",
       email: "user@example.com",
       password: "password",
@@ -457,8 +447,9 @@ export const loadFixtures = createFixtureLoader({
         /* ... */
       },
       // ... too many fields
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 });
 ```
@@ -469,24 +460,24 @@ export const loadFixtures = createFixtureLoader({
 // ✅ Correct: Reuse in other fixtures
 export const loadFixtures = createFixtureLoader({
   user: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "user",
       email: "user@example.com",
       password: "password",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   userPost: async () => {
     const { user } = await loadFixtures(["user"]);
-    const postModel = new PostModel();
-    const { post } = await postModel.create({
+    const params = {
       title: "Post",
       content: "Content",
       author_id: user.id,
-    });
-    return post;
+    };
+    const [id] = await PostModel.save([params]);
+    return { id, ...params };
   },
 });
 ```

--- a/modules/docs/ko/database/transactions/transactional-decorator.mdx
+++ b/modules/docs/ko/database/transactions/transactional-decorator.mdx
@@ -120,7 +120,7 @@ class UserModel extends BaseModelClass {
     // 커밋된 데이터만 읽기 (Non-repeatable Read 가능)
   }
 
-  // REPEATABLE READ (기본값)
+  // REPEATABLE READ
   @transactional({ isolation: "repeatable read" })
   async repeatableRead() {
     const wdb = this.getPuri("w");

--- a/modules/docs/ko/testing/writing-tests/test-helpers.mdx
+++ b/modules/docs/ko/testing/writing-tests/test-helpers.mdx
@@ -37,45 +37,45 @@ import { PostModel } from "@/models/post.model";
 export const loadFixtures = createFixtureLoader({
   // 사용자 fixtures
   user01: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "john",
       email: "john@example.com",
       password: "password123",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   user02: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "jane",
       email: "jane@example.com",
       password: "password456",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   admin: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "admin",
       email: "admin@example.com",
       password: "admin123",
       role: "admin",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   // 게시글 fixtures
   post01: async () => {
-    const postModel = new PostModel();
-    const { post } = await postModel.create({
+    const params = {
       title: "First Post",
       content: "Content of first post",
       author_id: 1,
-    });
-    return post;
+    };
+    const [id] = await PostModel.save([params]);
+    return { id, ...params };
   },
 });
 ```
@@ -96,8 +96,7 @@ test("사용자의 게시글 조회", async () => {
   const { user01, post01 } = await loadFixtures(["user01", "post01"]);
 
   // 테스트
-  const postModel = new PostModel();
-  const { posts } = await postModel.getPostsByUser(user01.id);
+  const { posts } = await PostModel.getPostsByUser(user01.id);
 
   expect(posts).toHaveLength(1);
   expect(posts[0].id).toBe(post01.id);
@@ -156,26 +155,26 @@ const { user01, user02 } = await loadFixtures(["user01", "user02"]);
 // api/src/testing/fixture.ts
 export const loadFixtures = createFixtureLoader({
   author: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "author",
       email: "author@example.com",
       password: "password",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   authorPost: async () => {
     // author fixture 먼저 로드
     const { author } = await loadFixtures(["author"]);
 
-    const postModel = new PostModel();
-    const { post } = await postModel.create({
+    const params = {
       title: "Author's Post",
       content: "Content",
       author_id: author.id, // 관계 설정
-    });
-    return post;
+    };
+    const [id] = await PostModel.save([params]);
+    return { id, ...params };
   },
 });
 ```
@@ -196,30 +195,24 @@ test("작성자와 게시글 관계", async () => {
 export const loadFixtures = createFixtureLoader({
   // 파라미터를 받는 fixture
   userWithEmail: async (email: string) => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: email.split("@")[0],
       email,
       password: "password",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   // 여러 데이터 생성
   users10: async () => {
-    const userModel = new UserModel();
-    const users = [];
-
-    for (let i = 1; i <= 10; i++) {
-      const { user } = await userModel.create({
-        username: `user${i}`,
-        email: `user${i}@example.com`,
-        password: "password",
-      });
-      users.push(user);
-    }
-
-    return users;
+    const paramsList = Array.from({ length: 10 }, (_, i) => ({
+      username: `user${i + 1}`,
+      email: `user${i + 1}@example.com`,
+      password: "password",
+    }));
+    const ids = await UserModel.save(paramsList);
+    return paramsList.map((params, i) => ({ id: ids[i], ...params }));
   },
 });
 ```
@@ -298,62 +291,60 @@ import { PostModel } from "@/models/post.model";
 export const loadFixtures = createFixtureLoader({
   // 1. 단순 데이터
   guestUser: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "guest",
       email: "guest@example.com",
       password: "password",
       role: "guest",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
-  // 2. 여러 데이터
+  // 2. 여러 데이터 (배열을 한 번에 전달)
   testUsers: async () => {
-    const userModel = new UserModel();
-    const users = await Promise.all([
-      userModel.create({
+    const paramsList = [
+      {
         username: "user1",
         email: "user1@example.com",
         password: "password",
-      }),
-      userModel.create({
+      },
+      {
         username: "user2",
         email: "user2@example.com",
         password: "password",
-      }),
-    ]);
-    return users.map(({ user }) => user);
+      },
+    ];
+    const ids = await UserModel.save(paramsList);
+    return paramsList.map((params, i) => ({ id: ids[i], ...params }));
   },
 
   // 3. 관계가 있는 데이터
   userWithPosts: async () => {
-    const userModel = new UserModel();
-    const postModel = new PostModel();
-
-    const { user } = await userModel.create({
+    const userParams = {
       username: "blogger",
       email: "blogger@example.com",
       password: "password",
-    });
+    };
+    const [userId] = await UserModel.save([userParams]);
+    const user = { id: userId, ...userParams };
 
-    const posts = await Promise.all([
-      postModel.create({
+    const postParamsList = [
+      {
         title: "Post 1",
         content: "Content 1",
         author_id: user.id,
-      }),
-      postModel.create({
+      },
+      {
         title: "Post 2",
         content: "Content 2",
         author_id: user.id,
-      }),
-    ]);
+      },
+    ];
+    const postIds = await PostModel.save(postParamsList);
+    const posts = postParamsList.map((params, i) => ({ id: postIds[i], ...params }));
 
-    return {
-      user,
-      posts: posts.map(({ post }) => post),
-    };
+    return { user, posts };
   },
 });
 ```
@@ -374,17 +365,17 @@ test("댓글 작성 및 조회", async () => {
   const { userWithPosts } = await loadFixtures(["userWithPosts"]);
   const { user, posts } = userWithPosts;
 
-  const commentModel = new CommentModel();
-
   // 댓글 작성
-  const { comment } = await commentModel.create({
-    content: "Great post!",
-    post_id: posts[0].id,
-    author_id: user.id,
-  });
+  const [commentId] = await CommentModel.save([
+    {
+      content: "Great post!",
+      post_id: posts[0].id,
+      author_id: user.id,
+    },
+  ]);
 
   // 댓글 조회
-  const { comments } = await commentModel.getCommentsByPost(posts[0].id);
+  const { comments } = await CommentModel.getCommentsByPost(posts[0].id);
 
   expect(comments).toHaveLength(1);
   expect(comments[0].content).toBe("Great post!");
@@ -433,21 +424,20 @@ export const loadFixtures = createFixtureLoader({
 // ✅ 올바른 방법: 필요한 필드만
 export const loadFixtures = createFixtureLoader({
   basicUser: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "user",
       email: "user@example.com",
       password: "password",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 });
 
 // ❌ 잘못된 방법: 불필요한 필드까지
 export const loadFixtures = createFixtureLoader({
   complexUser: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "user",
       email: "user@example.com",
       password: "password",
@@ -457,8 +447,9 @@ export const loadFixtures = createFixtureLoader({
         /* ... */
       },
       // ... 너무 많은 필드
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 });
 ```
@@ -469,24 +460,24 @@ export const loadFixtures = createFixtureLoader({
 // ✅ 올바른 방법: 다른 fixture에서 재사용
 export const loadFixtures = createFixtureLoader({
   user: async () => {
-    const userModel = new UserModel();
-    const { user } = await userModel.create({
+    const params = {
       username: "user",
       email: "user@example.com",
       password: "password",
-    });
-    return user;
+    };
+    const [id] = await UserModel.save([params]);
+    return { id, ...params };
   },
 
   userPost: async () => {
     const { user } = await loadFixtures(["user"]);
-    const postModel = new PostModel();
-    const { post } = await postModel.create({
+    const params = {
       title: "Post",
       content: "Content",
       author_id: user.id,
-    });
-    return post;
+    };
+    const [id] = await PostModel.save([params]);
+    return { id, ...params };
   },
 });
 ```
@@ -533,13 +524,13 @@ describe("PostModel with error handling", () => {
 export const loadFixtures = createFixtureLoader({
   user01: async () => {
     try {
-      const userModel = new UserModel();
-      const { user } = await userModel.create({
+      const params = {
         username: "john",
         email: "john@example.com",
         password: "password123",
-      });
-      return user;
+      };
+      const [id] = await UserModel.save([params]);
+      return { id, ...params };
     } catch (error) {
       // 에러 로깅 및 재전파
       console.error("Failed to create user01 fixture:", error);
@@ -557,13 +548,13 @@ export const loadFixtures = createFixtureLoader({
     }
 
     try {
-      const postModel = new PostModel();
-      const { post } = await postModel.create({
+      const params = {
         title: "Post",
         content: "Content",
         author_id: user.id,
-      });
-      return post;
+      };
+      const [id] = await PostModel.save([params]);
+      return { id, ...params };
     } catch (error) {
       throw new Error(`Failed to create post: ${error.message}`);
     }
@@ -629,20 +620,19 @@ test("환경별 fixture", async () => {
 ```typescript
 export const loadFixtures = createFixtureLoader({
   resilientUser: async () => {
-    const userModel = new UserModel();
-
     // 재시도 로직
     const maxRetries = 3;
     let lastError;
 
     for (let i = 0; i < maxRetries; i++) {
       try {
-        const { user } = await userModel.create({
+        const params = {
           username: `user_${Date.now()}`, // 충돌 방지
           email: `user_${Date.now()}@example.com`,
           password: "password123",
-        });
-        return user;
+        };
+        const [id] = await UserModel.save([params]);
+        return { id, ...params };
       } catch (error) {
         lastError = error;
         console.warn(`Retry ${i + 1}/${maxRetries} failed:`, error);


### PR DESCRIPTION
> 🤖 이 PR은 AI(Claude / slack-vibecoder, cartanova-dev로 커밋)가 [Nightly PR Directions(#43)](https://github.com/cartanova-ai/sonamu/issues/43)와 [내일 새벽에 AI에게 맡길 일들(#44)](https://github.com/cartanova-ai/sonamu/issues/44)의 지침에 따라 자동 생성한 변경입니다. 코드 ownership은 그대로 유지됩니다 — 본 description의 근거가 약하다면 닫고 무시해 주십시오.

## 무엇을 / 왜 했나

#44의 "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트" 지침에 따라, 사용자가 그대로 따라하면 TypeScript 컴파일 오류 또는 런타임 `TypeError`가 발생하거나 사실과 다른 설명을 믿게 되는 문서 2건을 정정했습니다. 모두 ko/en 양쪽에 동일하게 존재했습니다.

## 변경 1: `transactional-decorator.mdx` — "REPEATABLE READ (기본값)" 표기 제거

**대상 파일**
- `modules/docs/ko/database/transactions/transactional-decorator.mdx` L123
- `modules/docs/en/database/transactions/transactional-decorator.mdx` L123

**무엇이 어긋났는가**

"Isolation Level 설정" 예제에서 `@transactional({ isolation: "repeatable read" })` 옆에만 `// REPEATABLE READ (기본값)`/`// REPEATABLE READ (default)` 코멘트가 붙어 있었습니다. 그런데 같은 저장소의 API 레퍼런스 `modules/docs/ko/api-reference/decorators/transactional.mdx` L52는 다음과 같이 명시합니다.

```
**기본값:** 데이터베이스 기본 격리 수준 (PostgreSQL: `read committed`)
```

같은 옵션의 기본값이 한쪽에서는 `repeatable read`, 다른 쪽에서는 `read committed`라고 설명되어 서로 모순됩니다.

**실제 동작 (코드 근거)**

`modules/sonamu/src/database/puri-wrapper.ts` L24–25에서 옵션 타입은 다음과 같습니다.

```ts
export type TransactionalOptions = {
  isolation?: Exclude<Knex.IsolationLevels, "snapshot">;
  // ...
};
```

`isolation`은 **옵셔널**이며, `modules/sonamu/src/api/decorators.ts` L381–382, L420은 이를 그대로 Knex에 전달합니다.

```ts
export function transactional(options: TransactionalOptions = {}) {
  const { isolation, readOnly, dbPreset = "w" } = options;
  // ...
  return puri.knex.transaction(async (trx) => { /* ... */ },
    { isolationLevel: isolation, readOnly },
  );
};
```

즉 `isolation` 미지정 시 `isolationLevel: undefined`가 Knex로 전달되며, Knex는 `SET TRANSACTION ISOLATION LEVEL`을 호출하지 않고 **DB 인스턴스의 기본값**을 그대로 사용합니다. 따라서:
- PostgreSQL: `READ COMMITTED`가 기본
- MySQL: `REPEATABLE READ`가 기본

`@transactional()`(인자 없음)의 격리 수준이 무조건 `REPEATABLE READ`인 것이 아니므로, "REPEATABLE READ (기본값)" 표기는 사실이 아닙니다. API 레퍼런스의 "데이터베이스 기본 격리 수준" 표기가 정확합니다.

**채택한 접근**

가이드 문서(`transactional-decorator.mdx`)의 잘못된 `(기본값)`/`(default)` 코멘트만 제거했습니다. API 레퍼런스 표기는 이미 정확하므로 그대로 두었습니다. "기본값"에 대한 더 상세한 설명을 본문에 추가하는 것은 본 PR 범위 밖이며, API 레퍼런스로의 자연스러운 분기를 그대로 유지하기 위해 코멘트 제거만으로 최소화했습니다.

**이렇게 하지 않으면**

- 가이드 예제에 "(기본값)" 코멘트가 남아있으면, 사용자가 PostgreSQL 환경에서도 `@transactional()`이 `REPEATABLE READ`로 동작한다고 잘못 가정한 채 동시성 분석/성능 튜닝을 진행하게 됩니다(예: phantom read를 신경 쓰지 않거나, 반대로 불필요한 `serializable` 도입).
- 같은 저장소 내 두 문서가 같은 옵션에 대해 서로 다른 기본값을 주장하는 모순 상태가 지속됩니다.

## 변경 2: `test-helpers.mdx` — 미존재 `Model.create()` 호출을 표준 `Model.save([params])` 패턴으로 정정

**대상 파일**
- `modules/docs/ko/testing/writing-tests/test-helpers.mdx`
- `modules/docs/en/testing/writing-tests/test-helpers.mdx`

**무엇이 어긋났는가**

해당 문서의 **모든 fixture 예제**(createFixtureLoader, 복잡한 Fixture 패턴, 동적 Fixture, 실전 예제, 베스트 프랙티스, 한국어 버전의 에러 처리 섹션까지)가 다음과 같은 형태였습니다.

```ts
user01: async () => {
  const userModel = new UserModel();
  const { user } = await userModel.create({
    username: "john",
    email: "john@example.com",
    password: "password123",
  });
  return user;
},
```

여기에는 사용자가 그대로 따라하면 즉시 실패하는 두 가지 오류가 누적되어 있습니다.

**1) `UserModel`은 클래스가 아니라 인스턴스입니다 — `new UserModel()`은 잘못된 호출**

`modules/sonamu/src/template/implementations/model.template.ts` L208에서 자동 생성되는 형태는 다음과 같습니다.

```ts
export const ${entityId}Model = new ${entityId}ModelClass();
```

즉 `UserModel`은 이미 `new UserModelClass()`로 인스턴스화되어 export되는 **값**이므로, `new UserModel()`은 "값을 생성자처럼 호출"하는 셈이라 TypeScript에서 `This expression is not constructable.` 오류가 납니다.

**2) `.create({...})` 메서드는 존재하지 않습니다 — 표준은 `Model.save([...])`**

자동 생성되는 BaseModel 기반의 표준 메서드는 동 template L177–193이 정의하는 다음 형태입니다.

```ts
async save(spa: ${entityId}SaveParams[]): Promise<${idTsType}[]> { ... }
```

- 정적이 아닌 인스턴스 메서드이지만, `UserModel`이 이미 인스턴스이므로 호출은 `UserModel.save([...])` 형태가 됩니다.
- 인자는 **배열**, 반환은 **id 배열**.
- `.create()`는 BaseModelClass에도, 자동 생성 템플릿에도 정의되어 있지 않습니다(`rg "create\(" modules/sonamu/src/template/` 0건).
- 동 저장소의 공식 skill 문서 `modules/sonamu/src/skills/sonamu/testing.md`는 모든 예제(L44, L346, L371, L439, L1372, L1545, L1672, L1682, L1701, L1819, L1889, L1965 등)에서 `const [id] = await UserModel.save([{ ... }])` 패턴을 사용합니다.

따라서 사용자가 본 문서를 그대로 복사하면 다음 중 하나가 발생합니다.
- TS: `This expression is not constructable. Type 'UserModelClass' has no construct signatures.`
- TS: `Property 'create' does not exist on type 'UserModelClass'.`
- 런타임: `TypeError: userModel.create is not a function`

**채택한 접근**

문서의 의도(fixture에서 `user.username`, `expect(admin.role).toBe("admin")`처럼 객체 속성을 그대로 사용하는 것)를 깨뜨리지 않기 위해, 표준 패턴을 사용하되 input과 id를 합쳐서 반환하는 형태로 통일했습니다.

```ts
user01: async () => {
  const params = {
    username: "john",
    email: "john@example.com",
    password: "password123",
  };
  const [id] = await UserModel.save([params]);
  return { id, ...params };
},
```

- `new XxxModel()` 호출은 모두 제거.
- 단건 생성은 `const [id] = await Model.save([params])`, 다건 생성은 `const ids = await Model.save(paramsList)` 후 `paramsList.map((p, i) => ({ id: ids[i], ...p }))` 형태로 통일.
- 테스트 본문 안의 `new PostModel()`/`new CommentModel()` 호출 2건도 같은 이유로 `PostModel.X()`/`CommentModel.X()` 직접 호출로 정정.
- 문서 라이프사이클 측면에서 fixture 반환 객체의 형태(`{ id, ...params }`)는 기존 사용처(`user01.username`, `expect(admin.role).toBe("admin")`, `expect(authorPost.author_id).toBe(author.id)`, `posts[0].id` 등)와 호환됩니다.

**ko/en 동기화 한정**

한국어 문서에만 존재하는 "에러 처리" 섹션(L494–665)이 영어 문서에는 누락되어 있었습니다(영어 문서는 L494에서 곧바로 "Cautions"로 넘어감). 한국어 측의 해당 섹션 내 fixture 예제도 본 PR에서 함께 정정했지만, **영어 문서로의 섹션 추가는 본 PR 범위 밖**입니다(별도 동기화 PR이 적절). 다른 testing 관련 문서에도 유사한 `new XxxModel()` + `.create()` 패턴이 분포할 가능성이 있으나(grep으로 `.create(` 호출이 다수의 파일에서 발견됨), 그 중 다수는 사용자 정의 메서드일 수도 있어 false positive 방지 차원에서 본 PR은 `test-helpers.mdx`로 한정합니다.

**이렇게 하지 않으면**

- 사용자가 testing 문서를 통해 sonamu의 fixture 시스템을 처음 학습할 때, 가장 먼저 마주치는 예제부터 잘못된 패턴이 박혀버립니다.
- 사용자가 본인의 모델에 `.create()` 메서드가 자동 생성된다고 오해하거나, 본인이 직접 만든 후에야 동작한다고 착각할 수 있습니다.
- 표준 `save([params])` 패턴(공식 skill 문서가 일관되게 사용하는)과 가이드 문서가 어긋난 상태가 지속됩니다.

## 이 변경이 미치는 영향

- 코드 변경 0건. 런타임 동작에 영향 없음.
- mdx 4파일만 변경. Mintlify 기반이라 빌드 단계 없음.
- `pnpm check` 통과(0 errors, 기존 워닝만). `mint dev`로 렌더 확인 권장.

## 빠른 확인 방법

1. `modules/docs/ko/database/transactions/transactional-decorator.mdx`의 "Isolation Level 설정" 코드 블록에서 `REPEATABLE READ` 옆의 `(기본값)` 코멘트가 사라졌는지 확인.
2. `modules/docs/ko/testing/writing-tests/test-helpers.mdx`에서 `grep -n "userModel\|postModel\|commentModel\|\.create(\|new \w*Model"` 시 0건이어야 함(영문도 동일).
3. 본 PR의 fixture 예제를 실제 sonamu 프로젝트의 `api/src/testing/fixture.ts`에 복사해서 `tsc --noEmit` 시 오류가 없는지 확인(이상적으로 miomock의 fixture 파일에서 비교 가능).

## 추후 사람의 확인이 필요할 수 있는 부분

- **격리 수준 본문 보강 여부**: 현재 `transactional-decorator.mdx` 가이드 본문 어디에도 "isolation 미지정 시 DB 기본값을 따른다"는 명시적 설명이 없습니다. API 레퍼런스 L52에는 있지만, 가이드 본문에도 한 문장 보강할지 여부는 사람의 판단이 필요합니다(본 PR은 잘못된 표기 제거에만 한정).
- **다른 testing 문서로의 동일 패턴 정정 확장**: `testing/fixtures/*.mdx`, `testing/mocking/*.mdx` 등에도 `.create(` 호출이 grep으로 발견됩니다. 그 중 사용자 정의 메서드 호출도 섞여 있어 false positive 위험 회피를 위해 본 PR에선 다루지 않았습니다.
- **영문 문서에 누락된 "에러 처리" 섹션 동기화**: 본 PR 범위 밖. 별도 동기화 PR이 적절합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)