### PR TITLE
[Nightly 2026-05-19] @api/@stream 데코레이터 문서의 옛 "@api or @stream" 중복 사용 제약 에러 메시지를 실제 코드 메시지(@api, @stream, @websocket, @upload)로 정정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/api-reference/decorators/api.mdx
+++ b/modules/docs/en/api-reference/decorators/api.mdx
@@ -398,7 +398,9 @@ async uploadAvatar() {
 
 ## Constraints
 
-### 1. Cannot be used with @stream
+### 1. Cannot be combined with other routing decorators (@stream, @websocket, @upload)
+
+`@api`, `@stream`, `@websocket`, and `@upload` cannot be combined on the same method.
 
 ```typescript
 // ❌ Error
@@ -411,7 +413,7 @@ async subscribe() {}
 
 ```
 @api decorator can only be used once on UserModel.subscribe.
-You can use only one of @api or @stream decorator on the same method.
+You can use only one of @api, @stream, @websocket, or @upload decorator on the same method.
 ```
 
 ### 2. Using Multiple Times on Same Method

--- a/modules/docs/en/api-reference/decorators/stream.mdx
+++ b/modules/docs/en/api-reference/decorators/stream.mdx
@@ -339,7 +339,9 @@ async process() {
 
 ## Constraints
 
-### 1. Cannot be used with @api
+### 1. Cannot be combined with other routing decorators (@api, @websocket, @upload)
+
+`@api`, `@stream`, `@websocket`, and `@upload` cannot be combined on the same method.
 
 ```typescript
 // ❌ Error
@@ -352,7 +354,7 @@ async subscribe() {}
 
 ```
 @stream decorator can only be used once on NotificationModel.subscribe.
-You can use only one of @api or @stream decorator on the same method.
+You can use only one of @api, @stream, @websocket, or @upload decorator on the same method.
 ```
 
 ### 2. events is required

--- a/modules/docs/ko/api-reference/decorators/api.mdx
+++ b/modules/docs/ko/api-reference/decorators/api.mdx
@@ -398,7 +398,9 @@ async uploadAvatar() {
 
 ## 제약사항
 
-### 1. @stream과 중복 사용 불가
+### 1. 다른 라우팅 데코레이터(@stream, @websocket, @upload)와 중복 사용 불가
+
+같은 메서드에 `@api`, `@stream`, `@websocket`, `@upload` 중 둘 이상을 함께 사용할 수 없습니다.
 
 ```typescript
 // ❌ 에러 발생
@@ -411,7 +413,7 @@ async subscribe() {}
 
 ```
 @api decorator can only be used once on UserModel.subscribe.
-You can use only one of @api or @stream decorator on the same method.
+You can use only one of @api, @stream, @websocket, or @upload decorator on the same method.
 ```
 
 ### 2. 같은 메서드에 여러 번 사용 시

--- a/modules/docs/ko/api-reference/decorators/stream.mdx
+++ b/modules/docs/ko/api-reference/decorators/stream.mdx
@@ -337,7 +337,9 @@ async process() {
 
 ## 제약사항
 
-### 1. @api와 중복 사용 불가
+### 1. 다른 라우팅 데코레이터(@api, @websocket, @upload)와 중복 사용 불가
+
+같은 메서드에 `@api`, `@stream`, `@websocket`, `@upload` 중 둘 이상을 함께 사용할 수 없습니다.
 
 ```typescript
 // ❌ 에러 발생
@@ -350,7 +352,7 @@ async subscribe() {}
 
 ```
 @stream decorator can only be used once on NotificationModel.subscribe.
-You can use only one of @api or @stream decorator on the same method.
+You can use only one of @api, @stream, @websocket, or @upload decorator on the same method.
 ```
 
 ### 2. events는 필수


### PR DESCRIPTION
> 🤖 이 PR은 AI(Claude / slack-vibecoder, cartanova-dev로 커밋)가 [Nightly PR Directions(#43)](https://github.com/cartanova-ai/sonamu/issues/43)와 [내일 새벽에 AI에게 맡길 일들(#44)](https://github.com/cartanova-ai/sonamu/issues/44)의 지침에 따라 자동 생성한 변경입니다. 코드 ownership은 그대로 유지됩니다 — 본 description의 근거가 약하다면 닫고 무시해 주십시오.

## 무엇을 / 왜 했나

#44의 "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 한다" 지침에 따라, `@api`와 `@stream` 데코레이터의 "제약사항" 섹션에서 코드의 실제 에러 메시지와 다른 옛 문구를 정정했습니다. ko/en 양쪽에 동일한 형태로 존재했습니다.

## 어떤 불일치인가 (코드 근거)

`modules/sonamu/src/api/decorators.ts:130-139`의 `checkSingleDecorator`가 던지는 실제 에러 메시지는 다음과 같습니다.

```typescript
function checkSingleDecorator(target: DecoratorTarget, propertyKey: string, decoratorType: symbol) {
  const method = target[propertyKey as keyof typeof target] as { __decoratorType?: symbol };
  if (method?.__decoratorType && method?.__decoratorType !== decoratorType) {
    throw new Error(
      `@${decoratorType.description ?? String(decoratorType)} decorator can only be used once on ${target.constructor.name}.${propertyKey}. You can use only one of @api, @stream, @websocket, or @upload decorator on the same method.`,
    );
  }
  // ...
}
```

그런데 `@api`/`@stream` 문서는 옛 문구를 그대로 남겨두고 있었습니다.

| 파일 | 라인 | 잘못된 표기 |
| --- | --- | --- |
| `modules/docs/ko/api-reference/decorators/api.mdx` | 414 | `You can use only one of @api or @stream decorator on the same method.` |
| `modules/docs/ko/api-reference/decorators/stream.mdx` | 353 | (동일) |
| `modules/docs/en/api-reference/decorators/api.mdx` | 414 | (동일) |
| `modules/docs/en/api-reference/decorators/stream.mdx` | 355 | (동일) |

같은 제약을 정확히 적은 `websocket.mdx`(L277)에는 이미 `@api, @stream, @websocket, or @upload`로 적혀 있어서, 같은 저장소 안에서 같은 제약이 두 가지 문구로 갈라져 있던 상태였습니다. 또한 SON-435(`@websocket` 도입)와 `@upload`가 같은 단일 라우팅 데코레이터 그룹임에도, `@api`/`@stream` 문서에서는 이 두 데코레이터가 같은 제약의 적용 대상이라는 사실이 누락되어 있었습니다.

## 무엇을 바꾸었나

각 파일의 "제약사항 → 1번" 항목에 대해 두 가지를 함께 정정했습니다.

1. 섹션 제목을 네 데코레이터를 모두 명시하는 형태로 갱신
   - 한국어: `### 1. @stream과 중복 사용 불가` → `### 1. 다른 라우팅 데코레이터(@stream, @websocket, @upload)와 중복 사용 불가` (api.mdx)
   - 한국어: `### 1. @api와 중복 사용 불가` → `### 1. 다른 라우팅 데코레이터(@api, @websocket, @upload)와 중복 사용 불가` (stream.mdx)
   - 영어: `### 1. Cannot be used with @stream/@api` → `### 1. Cannot be combined with other routing decorators (...)`
2. 에러 메시지 블록을 코드와 글자 그대로 일치시킴
   - `@api or @stream` → `@api, @stream, @websocket, or @upload`

예시 코드 블록(`@api()` + `@stream(...)` 동시 사용)은 가장 대표적인 충돌 케이스라 그대로 두고, 본문에 "@api, @stream, @websocket, @upload 중 둘 이상을 함께 사용할 수 없습니다."라는 한 문장만 추가해 다른 조합도 같은 제약을 받음을 명시했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가

- 사용자가 데코레이터 충돌 에러를 만났을 때, 문서에 적힌 메시지(`@api or @stream`)와 실제 콘솔/스택 트레이스의 메시지(`@api, @stream, @websocket, or @upload`)가 달라서 "이게 내가 보고 있는 문서의 에러가 맞나?"라는 검색/대조에 혼선이 생깁니다.
- `@websocket`/`@upload`가 같은 제약을 공유한다는 사실이 누락되어, 예컨대 `@websocket` + `@upload`를 같이 시도하다 에러를 만난 사용자가 "왜 막혔는지" 문서에서 찾기 어렵습니다.
- 같은 저장소 안에서 같은 에러 메시지가 두 가지 문구로 갈라져 있어 문서 신뢰도가 떨어집니다.

## 영향 범위

- 변경된 것은 `.mdx` 문서 4개뿐이며, **런타임 동작/소스 코드/생성 코드/공개 API에는 어떠한 영향도 없습니다**.
- 단순 텍스트 정정이므로 마이그레이션이나 별도 빌드 산출물 갱신은 불필요합니다.

## 확인 방법

1. 빠른 확인: 본 PR의 diff에서 옛 문구(`@api or @stream`)가 더 이상 어떤 .mdx 파일에도 남아 있지 않은지 확인.
   ```sh
   rg -n "@api or @stream" modules/docs   # 결과 없어야 함
   ```
2. 코드와의 일치 확인:
   ```sh
   rg -n "You can use only one of" modules/docs   # 6건 모두 동일 문구여야 함
   rg -n "You can use only one of" modules/sonamu/src/api/decorators.ts
   ```
3. (선택) 로컬에서 sonamu-docs 미리보기로 렌더링 점검:
   ```sh
   pnpm --filter sonamu-docs dev
   ```

## 검증

- `pnpm check`(oxlint + oxfmt) 통과. 기존 8개 경고 외 에러 0, 새 경고도 없음. `All matched files use the correct format.`
- 변경이 문서뿐이므로 별도 빌드/타입체크/테스트는 영향받지 않음.
- pre-commit lefthook은 모든 hook을 "no matching staged files"로 skip하며 통과.

## 어떤 issue/근거를 참조했나

- 작업 지침: [Nightly PR Directions(#43)](https://github.com/cartanova-ai/sonamu/issues/43)
- 작업 범위: [#44 — "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트", ko/en 동기화](https://github.com/cartanova-ai/sonamu/issues/44)
- 이미 정확히 적힌 비교 대상: `modules/docs/ko/api-reference/decorators/websocket.mdx:277`, `modules/docs/en/api-reference/decorators/websocket.mdx:277` (PR #175에서 신규 작성됨)

## 추후 사람의 확인이 필요한 부분

- 영어 섹션 제목 표현(`Cannot be combined with other routing decorators (@stream, @websocket, @upload)`)이 문서 톤과 맞는지. 다른 데코레이터 문서들의 영어 톤을 따라가도록 의도했으나, 원하시는 표현이 있다면 교체해 주십시오.
- 한국어 섹션 제목에서 "라우팅 데코레이터"라는 그룹 명칭을 새로 도입했습니다. 저장소 내에서 이 네 데코레이터를 묶어 부르는 공식 명칭이 따로 있다면 그 표현으로 바꾸는 게 더 일관될 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)