### PR TITLE
[Nightly 2026-05-20] Naite recording-logs 문서의 extractCallStack 콜스택 종료 조건(runWithContext/runWithMockContext) 정정 (ko/en 2파일)

### DIFF
--- a/modules/docs/en/testing/naite/recording-logs.mdx
+++ b/modules/docs/en/testing/naite/recording-logs.mdx
@@ -243,8 +243,11 @@ function extractCallStack(): StackFrame[] {
     .map(parseStackFrame)
     .filter((frame) => frame !== null);
 
-  // Stop when runWithContext is found
-  const contextIndex = frames.findIndex((f) => f.functionName?.includes("runWithContext"));
+  // Stop when runWithContext/runWithMockContext is found
+  const contextIndex = frames.findIndex(
+    (f) =>
+      f.functionName?.includes("runWithContext") || f.functionName?.includes("runWithMockContext"),
+  );
 
   return contextIndex >= 0 ? frames.slice(0, contextIndex + 1) : frames;
 }

--- a/modules/docs/ko/testing/naite/recording-logs.mdx
+++ b/modules/docs/ko/testing/naite/recording-logs.mdx
@@ -228,8 +228,11 @@ function extractCallStack(): StackFrame[] {
     .map(parseStackFrame)
     .filter((frame) => frame !== null);
 
-  // runWithContext 발견 시 종료
-  const contextIndex = frames.findIndex((f) => f.functionName?.includes("runWithContext"));
+  // runWithContext/runWithMockContext 발견 시 거기서 자르기
+  const contextIndex = frames.findIndex(
+    (f) =>
+      f.functionName?.includes("runWithContext") || f.functionName?.includes("runWithMockContext"),
+  );
 
   return contextIndex >= 0 ? frames.slice(0, contextIndex + 1) : frames;
 }


### PR DESCRIPTION
> 🤖 이 PR은 AI(Claude)에 의해 #43 의 Nightly PR Directions에 따라 자동 생성된 문서 정정 패치입니다. 채택/반려/수정 모두 사용자의 판단에 따릅니다.

## 무엇을, 왜

modules/docs/ko/testing/naite/recording-logs.mdx 와 동일한 영어 문서의 "내부 동작 이해하기 > 콜스택 수집" 섹션에서, 예시로 보여주는 `extractCallStack()` 함수의 콜스택 종료 조건이 실제 소스코드와 어긋나 있어 이를 정정합니다.

- 문서: `runWithContext` 만 발견 조건으로 표시
- 실제 코드 (`modules/sonamu/src/naite/naite.ts:62-65`): `runWithContext` 또는 `runWithMockContext` 둘 다 검사

## 어떤 issue/맥락을 참조했는가

- 작업 지침: #43 (Nightly PR Directions)
- 작업 범위 지침: #44 (내일 새벽에 AI에게 맡길 일들) — "문서와 주석이 코드와 어긋나는 경우 -> 설명 업데이트" 항목에 해당
- 권한 확인: `gh api repos/cartanova-ai/sonamu/collaborators/{potados99,cartanova-dev}/permission` 으로 두 작성자 모두 write/admin 권한 보유 확인

## 왜 이 작업을 선정했는가 (확신의 근거)

해당 페이지 내·외에서 이미 명백한 모순이 발생하고 있어, 안전하면서도 가치가 명확한 수정입니다.

1. **같은 페이지의 '콜스택 예시' Accordion (recording-logs.mdx 256-273줄)**: 수집된 콜스택 마지막 프레임으로 `runWithMockContext`가 포함되어 있음 — 즉 이 함수도 종료 지점으로 인식되어야 한다고 보여줌.
2. **인접 문서 debugging-tests.mdx (155-159줄, 690-708줄)**: 이미 두 조건 모두를 코드 예제에 정확히 표시하고 있음. 따라서 본 PR의 수정은 형제 문서들 사이의 일관성도 회복시킴.
3. **실제 소스 코드 (`naite.ts:62-65`)**:
   ```typescript
   const contextIndex = frames.findIndex(
     (f) =>
       f.functionName?.includes("runWithContext") || f.functionName?.includes("runWithMockContext"),
   );
   ```
   주석에도 \"runWithContext 계열 함수 발견 시 거기서 자르기\"로 명시되어 있음.

이 모순을 방치하면 독자가 \"테스트 환경에서 흔히 쓰이는 `runWithMockContext`는 종료 지점으로 인식되지 않는 모양이다\" 라고 잘못 학습할 수 있고, 동일 페이지의 예시 콜스택 결과와도 어긋나 학습 흐름이 매끄럽지 않습니다.

## 어떤 접근을 채택했고 왜

- 코드 예제 한 곳(2~5줄)만 실제 구현에 맞춰 동기화. 설명 문구는 \"runWithContext\" 라는 표현이 \"runWithContext 계열\" 의 약칭으로 자연스러우므로 손대지 않았습니다. (debugging-tests.mdx 175줄과의 일관성 유지)
- 한국어/영어 문서를 동일 변경으로 함께 동기화 (지침 요구사항).

## 영향 범위

- 문서 1개 페이지의 코드 블록 1곳, 한/영 두 파일.
- 코드 동작·빌드 산출물에는 영향 없음.

## 변경 확인 방법

1. `git diff master..HEAD -- modules/docs/{ko,en}/testing/naite/recording-logs.mdx`
2. recording-logs.mdx 의 \"3. 콜스택 수집\" 섹션 → 이전 페이지 안 \"콜스택 예시\" Accordion 이 동일한 종료 조건을 설명하는지 시각적으로 확인.
3. `modules/sonamu/src/naite/naite.ts:45-68` 의 `extractCallStack` 원본과 대조.
4. `pnpm check` (oxlint + oxfmt) 모두 통과 (0 errors, 사전 8 warnings는 무관한 기존 코드 영역).

## 사람 확인이 필요할 수 있는 부분

- 본 PR은 코드 예제만 정정합니다. debugging-tests.mdx 175줄 \"runWithContext를 만나면 거기서 자릅니다\" 같은 설명 문구는 \"runWithContext 계열\"의 줄임말로 자연스럽다고 판단하여 손대지 않았으나, 더 엄밀한 표현으로 통일하고 싶다면 후속 PR 또는 본 PR 보완으로 적용 가능합니다.
- 본 작업은 문서 변경만이므로 빌드/타입체크/테스트 단계는 생략했고 `pnpm check`만 수행했습니다.

Co-authored-by: Claude <noreply@anthropic.com>