### PR TITLE
[Nightly 2026-05-22] FAQ/Using-Services 문서의 미존재 Context 최상위 필드(ip/userId/userAgent) 사용 예제 정정 (ko/en 6파일)

### DIFF
--- a/modules/docs/en/faq/api.mdx
+++ b/modules/docs/en/faq/api.mdx
@@ -295,21 +295,30 @@ async getMyProfile(): Promise<User> {
 ```typescript
 const context = Sonamu.getContext();
 
-// User info
-context.user; // Logged-in user object
-context.userId; // User ID
+// Auth info (better-auth)
+context.user; // Logged-in user (null if unauthenticated)
+context.session; // Session (null if unauthenticated)
+context.user?.id; // User ID
 
 // Request info
-context.ip; // Client IP
-context.userAgent; // User-Agent header
+context.transport; // "http" | "ws"
+context.headers; // Request headers (IncomingHttpHeaders)
+context.headers["user-agent"]; // User-Agent
+context.locale; // Locale of the current request
 
-// Fastify objects
-context.request; // Fastify Request
-context.reply; // Fastify Reply
+// Fastify objects (when transport === "http")
+context.request; // FastifyRequest (use context.request.ip for client IP)
+context.reply; // FastifyReply
 
-// Session
-context.session; // Session object
+// Naite log store
+context.naiteStore;
 ```
+
+<Info>
+  `userId`/`ip`/`userAgent` are not top-level properties on Context. Use
+  `context.user?.id`, `context.request.ip`, and `context.headers["user-agent"]`
+  respectively.
+</Info>
 
 </Accordion>
 

--- a/modules/docs/en/faq/entity-and-model.mdx
+++ b/modules/docs/en/faq/entity-and-model.mdx
@@ -339,7 +339,7 @@ class UserModelClass extends BaseModelClass {
   @api({ httpMethod: "GET" })
   async getMyIP(): Promise<{ ip: string }> {
     const context = Sonamu.getContext();
-    return { ip: context.ip };
+    return { ip: context.request.ip };
   }
 
   @api({ httpMethod: "POST" })

--- a/modules/docs/en/frontend-integration/generated-services/using-services.mdx
+++ b/modules/docs/en/frontend-integration/generated-services/using-services.mdx
@@ -403,7 +403,7 @@ class UserModelClass extends BaseModelClass {
 
     console.log(context.user); // Authenticated user
     console.log(context.session); // Session information
-    console.log(context.ip); // Client IP
+    console.log(context.request.ip); // Client IP
 
     // Authorization checks possible
     if (!context.user) {

--- a/modules/docs/ko/faq/api.mdx
+++ b/modules/docs/ko/faq/api.mdx
@@ -295,21 +295,29 @@ async getMyProfile(): Promise<User> {
 ```typescript
 const context = Sonamu.getContext();
 
-// 사용자 정보
-context.user; // 로그인한 사용자 객체
-context.userId; // 사용자 ID
+// 인증 정보 (better-auth)
+context.user; // 로그인한 사용자 (null이면 미인증)
+context.session; // 세션 (null이면 미인증)
+context.user?.id; // 사용자 ID
 
 // 요청 정보
-context.ip; // 클라이언트 IP
-context.userAgent; // User-Agent 헤더
+context.transport; // "http" | "ws"
+context.headers; // 요청 헤더 (IncomingHttpHeaders)
+context.headers["user-agent"]; // User-Agent
+context.locale; // 현재 요청의 locale
 
-// Fastify 객체
-context.request; // Fastify Request
-context.reply; // Fastify Reply
+// Fastify 객체 (transport === "http"일 때)
+context.request; // FastifyRequest (context.request.ip로 클라이언트 IP)
+context.reply; // FastifyReply
 
-// 세션
-context.session; // 세션 객체
+// Naite 로그 스토어
+context.naiteStore;
 ```
+
+<Info>
+  `userId`/`ip`/`userAgent`는 Context의 최상위 속성이 아닙니다. 각각 `context.user?.id`,
+  `context.request.ip`, `context.headers["user-agent"]`로 접근하세요.
+</Info>
 
 </Accordion>
 

--- a/modules/docs/ko/faq/entity-and-model.mdx
+++ b/modules/docs/ko/faq/entity-and-model.mdx
@@ -339,7 +339,7 @@ class UserModelClass extends BaseModelClass {
   @api({ httpMethod: "GET" })
   async getMyIP(): Promise<{ ip: string }> {
     const context = Sonamu.getContext();
-    return { ip: context.ip };
+    return { ip: context.request.ip };
   }
 
   @api({ httpMethod: "POST" })

--- a/modules/docs/ko/frontend-integration/generated-services/using-services.mdx
+++ b/modules/docs/ko/frontend-integration/generated-services/using-services.mdx
@@ -515,7 +515,7 @@ class UserModelClass extends BaseModelClass {
 
     console.log(context.user); // 인증된 사용자
     console.log(context.session); // 세션 정보
-    console.log(context.ip); // 클라이언트 IP
+    console.log(context.request.ip); // 클라이언트 IP
 
     // 권한 체크 등 가능
     if (!context.user) {


### PR DESCRIPTION
## 이 PR은 무엇이며, 누가, 왜 만들었나요

이 PR은 issue #43(Nightly PR Directions)·#44(내일 새벽에 AI에게 맡길 일들)의 지침에 따라 AI(Claude)가 자동 생성한 nightly 문서 정정 PR입니다. 사용자가 문서 그대로 따라 작성하면 TypeScript 컴파일 에러가 발생하는 구간(`context.ip`, `context.userId`, `context.userAgent` 등)을 실제 Context 타입에 맞게 정정합니다.

## 어떤 issue를 참조했고, 왜 이 작업을 선정했나요

- issue #44에서 "한국어 문서가 outdated인 경우 정정 후 영어 문서도 동기화", "코드와 어긋나는 설명 업데이트"가 작업 범위로 명시됨.
- 직전 PR #182("test-structure 문서의 Mock Context 미존재 속성 사용 정정") description의 "후추 사람의 확인이 필요한 부분" 마지막 항목에서 "동일 패턴(`context.ip`)의 잘못된 사용이 다음 파일에도 남아 있습니다 ... 후속 nightly에서 정정 권장"으로 명시적으로 후속 작업 권장된 파일들입니다.
- 또한 #174에서도 `run-with-mock-context.mdx`의 `context.ip` 잘못된 사용을 정정한 적이 있어, 동일 패턴의 마지막 잔재를 정리하는 흐름입니다.

## 어떤 접근 방식을 채택했나요

출처 단일 근거: `modules/sonamu/src/api/context.ts`의 `BaseContext`/`Context` 정의를 사실로 삼고, 그 타입에 존재하지 않는 최상위 필드를 사용한 코드 예제만 정정했습니다.

- `context.ip` → `context.request.ip` (FastifyRequest의 표준 속성)
- `context.userAgent` → `context.headers[\"user-agent\"]` (IncomingHttpHeaders의 표준 키)
- `context.userId` → `context.user?.id` (better-auth User 객체의 id)
- `context.session`/`context.user`는 `null` 가능성을 함께 명시

faq/api.mdx의 'Context에는 어떤 정보가 있나요?' Accordion은 표 전체가 실제 타입과 어긋났기에, transport/headers/locale/naiteStore 등 실제 존재하는 필드를 함께 안내하도록 재구성하고, 사용자가 자주 혼동할 수 있는 매핑(userId/ip/userAgent)을 Info 블록으로 한 번 더 안내했습니다.

PR #174의 'IP 강제 설정 예제 → locale 강제 지정 예제' 같은 톤 전환은 본 PR의 예제들이 단순 'IP를 얻는 방법' 자체를 보여주는 것이라 의미가 달라 적용하지 않았고, 잘못된 필드 참조만 같은 의미의 올바른 표현으로 교체했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋나요

사용자가 이 세 파일의 예제를 그대로 복사해 사용할 때 다음과 같은 즉시적인 실패가 발생합니다:

- `context.ip` / `context.userId` / `context.userAgent` → TS2339: Property '...' does not exist on type 'Context'.
- 컴파일을 우회(`as any`)하더라도 런타임에 `undefined`가 반환되어 IP/User-Agent 기능이 항상 잘못 동작.
- 신규 사용자에게는 FAQ가 '첫 접점'이 되기 때문에 잘못된 멘탈모델을 학습시킬 위험이 가장 큽니다.

## 이 변경이 어떤 기능에 영향을 미치나요

런타임 코드/타입에는 영향 없음. **문서(MDX) 6파일만 수정**:

- `modules/docs/{ko,en}/faq/api.mdx` (Accordion 'Context에는 어떤 정보가 있나요?')
- `modules/docs/{ko,en}/faq/entity-and-model.mdx` (`getMyIP` 예제 1곳)
- `modules/docs/{ko,en}/frontend-integration/generated-services/using-services.mdx` (`console.log(context.ip)` 1곳)

## 이 변경의 영향을 확인하는 구체적인 방법

1. ko/en 동일 위치를 같이 열고 표/예제가 동일 구조로 동기화되었는지 확인.
2. `modules/sonamu/src/api/context.ts`의 `BaseContext`/`Context` 정의와 변경된 예제의 필드명·접근 경로가 1:1로 일치하는지 대조.
3. 다음 grep으로 미존재 필드 잔재가 사라졌는지 확인:
   ```sh
   grep -rn 'context\\.\\(ip\\|userAgent\\|userId\\)\\b' modules/docs
   ```
   결과: 0건 (custom-context.mdx의 `context.requestId`는 사용자가 ContextExtend로 직접 확장하는 예제이므로 본 PR 범위 외).
4. 로컬 미리보기: `pnpm --filter sonamu-docs dev` 후
   - `/ko/faq/api`, `/en/faq/api`
   - `/ko/faq/entity-and-model`, `/en/faq/entity-and-model`
   - `/ko/frontend-integration/generated-services/using-services`, `/en/.../using-services`
   각 페이지의 해당 코드블록이 의도대로 렌더링되는지 확인.

## 검증 결과

- 변경 범위는 문서 텍스트/표/코드블록 한정. 타입체크/빌드/테스트 영향 없음.
- root `pnpm check` (oxlint + oxfmt) 통과 (errors: 0, mdx 파일은 lint 대상 외).
- 영문판 Info 블록은 한국어판과 동일 매핑 표현을 채택해 ko/en 톤 일치.
- 커밋은 파일 그룹별로 3개로 분리:
  1. `docs(faq/api)`: Accordion 표 전체 재구성 (ko/en)
  2. `docs(faq/entity-and-model)`: getMyIP 1곳
  3. `docs(frontend-integration/using-services)`: console.log 1곳

## 추후 사람의 확인이 필요한 부분

- `modules/docs/{ko,en}/api-development/context/custom-context.mdx`에 `context.requestId` 사용이 남아 있는데, 이 문서는 사용자가 ContextExtend로 직접 필드를 확장하는 패턴을 가르치는 곳이라 본 PR 범위 외로 두었습니다. 다만 문서 상단의 `declare module \"sonamu\" { interface SonamuContext { ... } }` 부분은 실제 모듈 확장 인터페이스명(`ContextExtend`)과 다르며, 'request_id'/'tenant' 같이 ContextExtend로 확장한다는 안내가 분리되어 보이지 않습니다. 별도 nightly로 분리 처리하는 것이 적절해 보입니다.
- faq/api.mdx에 추가한 Info 블록은 한국어판/영문판 모두 동일 매핑을 단순 안내하도록 작성했습니다. 톤이 다른 표현을 선호한다면 자유롭게 수정해주세요.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)