### PR TITLE
[Nightly 2026-05-26] custom-context 문서의 미존재 SonamuContext 인터페이스를 ContextExtend로 정정 및 use-toast toastTimeouts Map 메모리 누수 수정

### DIFF
--- a/modules/docs/en/api-development/context/custom-context.mdx
+++ b/modules/docs/en/api-development/context/custom-context.mdx
@@ -3,7 +3,7 @@ title: "Custom Context"
 description: "Extending Context for your project"
 ---
 
-You can extend SonamuContext to add custom data needed for your project.
+You can extend the ContextExtend interface to add custom data to the Context for your project.
 
 ## Context Extension Overview
 
@@ -53,12 +53,7 @@ declare module "sonamu" {
 // types/context.ts
 
 declare module "sonamu" {
-  interface SonamuContext {
-    // Base fields
-    request: FastifyRequest;
-    reply: FastifyReply;
-    user?: ContextUser;
-
+  interface ContextExtend {
     // Add custom fields
     tenant?: {
       id: number;
@@ -67,14 +62,6 @@ declare module "sonamu" {
       features: string[];
     };
 
-    session?: {
-      id: string;
-      createdAt: Date;
-      expiresAt: Date;
-      data: Record<string, any>;
-    };
-
-    locale: string;
     timezone: string;
     requestId: string;
   }
@@ -82,8 +69,9 @@ declare module "sonamu" {
 ```
 
 <Info>
-  Use TypeScript's Declaration Merging to extend types. This enables IDE autocomplete and type
-  checking.
+  Use TypeScript's Declaration Merging to extend the `ContextExtend` interface.
+  Base fields such as `request`, `reply`, `user`, `session`, and `locale` are already included in the `Context` type,
+  so you don't need to redeclare them here. This enables IDE autocomplete and type checking.
 </Info>
 
 ## Injecting Data with Middleware

--- a/modules/docs/ko/api-development/context/custom-context.mdx
+++ b/modules/docs/ko/api-development/context/custom-context.mdx
@@ -3,7 +3,7 @@ title: "커스텀 Context"
 description: "프로젝트에 맞게 Context 확장하기"
 ---
 
-SonamuContext를 확장하여 프로젝트에 필요한 커스텀 데이터를 추가할 수 있습니다.
+ContextExtend 인터페이스를 확장하여 프로젝트에 필요한 커스텀 데이터를 Context에 추가할 수 있습니다.
 
 ## Context 확장 개요
 
@@ -53,12 +53,7 @@ declare module "sonamu" {
 // types/context.ts
 
 declare module "sonamu" {
-  interface SonamuContext {
-    // 기본 필드
-    request: FastifyRequest;
-    reply: FastifyReply;
-    user?: ContextUser;
-
+  interface ContextExtend {
     // 커스텀 필드 추가
     tenant?: {
       id: number;
@@ -67,14 +62,6 @@ declare module "sonamu" {
       features: string[];
     };
 
-    session?: {
-      id: string;
-      createdAt: Date;
-      expiresAt: Date;
-      data: Record<string, any>;
-    };
-
-    locale: string;
     timezone: string;
     requestId: string;
   }
@@ -82,8 +69,9 @@ declare module "sonamu" {
 ```
 
 <Info>
-  TypeScript의 Declaration Merging을 사용하여 타입을 확장합니다. 이렇게 하면 IDE에서 자동완성과 타입
-  체크가 작동합니다.
+  TypeScript의 Declaration Merging을 사용하여 `ContextExtend` 인터페이스를 확장합니다.
+  `request`, `reply`, `user`, `session`, `locale` 등 기본 필드는 이미 `Context` 타입에 포함되어 있으므로
+  여기서 다시 선언할 필요가 없습니다. 이렇게 하면 IDE에서 자동완성과 타입 체크가 작동합니다.
 </Info>
 
 ## 미들웨어로 데이터 주입

--- a/modules/react-components/src/hooks/use-toast.ts
+++ b/modules/react-components/src/hooks/use-toast.ts
@@ -73,11 +73,23 @@ const addToRemoveQueue = (toastId: string) => {
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
-    case "ADD_TOAST":
+    case "ADD_TOAST": {
+      const next = [action.toast, ...state.toasts].slice(0, TOAST_LIMIT);
+      const nextIds = new Set(next.map((t) => t.id));
+      for (const prev of state.toasts) {
+        if (!nextIds.has(prev.id)) {
+          const timeout = toastTimeouts.get(prev.id);
+          if (timeout) {
+            clearTimeout(timeout);
+            toastTimeouts.delete(prev.id);
+          }
+        }
+      }
       return {
         ...state,
-        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+        toasts: next,
       };
+    }
 
     case "UPDATE_TOAST":
       return {
@@ -112,6 +124,10 @@ export const reducer = (state: State, action: Action): State => {
     }
     case "REMOVE_TOAST":
       if (action.toastId === undefined) {
+        for (const [id, timeout] of toastTimeouts) {
+          clearTimeout(timeout);
+          toastTimeouts.delete(id);
+        }
         return {
           ...state,
           toasts: [],


### PR DESCRIPTION
## 이 PR은 무엇이며, 누가, 왜 만들었나요

이 PR은 issue #43(Nightly PR Directions)·#44(내일 새벽에 AI에게 맡길 일들)의 지침에 따라 AI(Claude)가 자동 생성한 nightly 개선 PR입니다. 문서의 잘못된 인터페이스 참조 정정과 React 컴포넌트의 메모리 누수 수정을 포함합니다.

## 어떤 issue를 참조했고, 왜 이 작업을 선정했나요

- issue #44에서 "코드에 예상치 못한 동작이나 버그 등 잠재적으로 위험한 포인트", "문서와 주석이 코드와 어긋나는 경우"가 작업 범위로 명시됨.
- PR #183의 "추후 사람의 확인이 필요한 부분"에서 custom-context.mdx의 `interface SonamuContext` 문제가 명시적으로 후속 작업 권장됨: "declare module "sonamu" { interface SonamuContext { ... } } 부분은 실제 모듈 확장 인터페이스명(ContextExtend)과 다르며... 별도 nightly로 분리 처리하는 것이 적절해 보입니다."
- use-toast.ts의 메모리 누수는 코드베이스 분석 중 새로 발견된 잠재적 버그로, `TOAST_REMOVE_DELAY = 1000000ms` (~278시간)에 의해 장기 실행 앱에서 timeout 참조가 무한히 축적됨.

## 어떤 접근 방식을 채택했나요

### 1. custom-context.mdx (ko/en 2파일)

출처 단일 근거: `modules/sonamu/src/api/context.ts`의 `ContextExtend` 인터페이스 정의(20행)와 `examples/miomock/api/src/typings/sonamu.d.ts`의 실제 사용 패턴을 사실로 삼았습니다.

- `interface SonamuContext` → `interface ContextExtend` (실제 module augmentation 대상 인터페이스)
- 예제에서 `request`, `reply`, `user`, `session`, `locale` 등 이미 `BaseContext`/`Context` 타입에 포함된 기본 필드를 제거하고, 커스텀 확장 필드(`tenant`, `timezone`, `requestId`)만 남김
- Info 블록에 기본 필드는 이미 포함되어 있다는 안내 추가

### 2. use-toast.ts (1파일)

shadcn/ui 기반 코드의 구조를 유지하면서 최소한의 변경으로 누수를 수정:

- `ADD_TOAST`: `TOAST_LIMIT`으로 slice 시 잘려나간 toast의 timeout을 `clearTimeout` 후 Map에서 제거
- `REMOVE_TOAST` (전체 삭제): `toastId === undefined`일 때 Map의 모든 timeout을 `clearTimeout` 후 Map 정리

## 이렇게 하지 않으면 어떤 점이 안 좋나요

### custom-context.mdx
- 사용자가 문서의 module augmentation 예제를 그대로 따라하면 `interface SonamuContext`는 존재하지 않는 인터페이스이므로 TypeScript Declaration Merging이 작동하지 않음
- 커스텀 필드가 Context 타입에 반영되지 않아 IDE 자동완성과 타입 체크가 실패
- 이 문서는 Context 확장의 '첫 접점'이므로 잘못된 멘탈모델을 학습시킬 위험이 큼

### use-toast.ts
- toast가 반복적으로 생성될 때 `toastTimeouts` Map에 clearTimeout 되지 않은 timeout 참조가 무한히 축적
- `TOAST_REMOVE_DELAY`가 ~278시간이므로 각 timeout이 매우 오래 살아남으며, 장기 실행 앱에서 메모리 누수 발생
- 전체 dismiss 후에도 Map이 정리되지 않아 GC 대상이 되지 않음

## 이 변경이 어떤 기능에 영향을 미치나요

- **문서 2파일**: 런타임 코드/타입에 영향 없음. custom-context.mdx의 module augmentation 코드 예제와 설명 텍스트만 수정.
- **코드 1파일**: `@sonamu-kit/react-components`의 `useToast` 훅. toast의 표시/숨김/삭제 동작 자체는 변경 없음. timeout 리소스 정리 로직만 추가.

## 이 변경의 영향을 확인하는 구체적인 방법

### custom-context.mdx
1. `modules/sonamu/src/api/context.ts:20`의 `export interface ContextExtend {}`와 변경된 예제의 인터페이스명이 일치하는지 대조.
2. `examples/miomock/api/src/typings/sonamu.d.ts:5`의 실제 사용 패턴과 문서 예제가 동일한 패턴인지 확인.
3. ko/en 동일 위치를 같이 열고 동일 구조로 동기화되었는지 확인.

### use-toast.ts
1. `pnpm --filter @sonamu-kit/react-components build` 빌드 성공 확인 (완료).
2. `pnpm check` lint/format 통과 확인 (완료, 에러 0건).
3. 수정 로직 검증:
   - `ADD_TOAST`에서 `nextIds`에 없는 이전 toast의 timeout이 `clearTimeout` 되는지 확인
   - `REMOVE_TOAST`에서 `toastId === undefined` 경로에서 Map 전체가 정리되는지 확인

## 검증 결과

- root `pnpm check` (oxlint + oxfmt) 통과: errors 0.
- `pnpm --filter @sonamu-kit/react-components build` 성공.
- 커밋은 변경 유형별 2개로 분리:
  1. `docs(custom-context)`: interface SonamuContext → ContextExtend 정정 (ko/en)
  2. `fix(react-components)`: use-toast toastTimeouts Map 메모리 누수 수정

## 추후 사람의 확인이 필요한 부분

- `modules/docs/{ko,en}/api-development/context/sonamu-context.mdx`에도 29-48행에 `interface SonamuContext { ... }` 형태의 타입 구조 설명이 있습니다. 이것은 module augmentation이 아닌 개념 설명이지만, 실제 `Context` 타입의 필드 구성(`request`, `headers`, `naiteStore`, `locale`, `user`, `session`, `transport`, `reply`, `createSSE` 등)과 상당히 다릅니다. 이 파일은 전체적인 재구성이 필요해 보여 본 PR 범위 외로 두었습니다.
- `modules/docs/{ko,en}/tools-and-cli/hmr/boundaries.mdx:375`에 `getSonamuContext().userId!` 사용이 남아 있습니다. `getSonamuContext()`는 프런트엔드 React Context의 함수이므로 백엔드 Context와는 다른 맥락이지만, 이 함수의 실제 반환 타입과 userId 필드 존재 여부는 별도 확인이 필요합니다.
- use-toast.ts의 `TOAST_REMOVE_DELAY = 1000000` (ms, ~278시간)은 의도적 설정인지 확인이 필요합니다. shadcn/ui 원본 코드에서는 동일한 값이 사용되므로 원작자의 의도를 존중하여 변경하지 않았습니다.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)