### PR TITLE
[Nightly 2026-06-02] DevVitestManager shutdown 메모리 누수 수정 및 @api 데코레이터 문서의 tanstack-mutation-multipart 클라이언트 타입 누락 보완 (ko/en)

### DIFF
--- a/modules/docs/en/core-concepts/model/api-decorator.mdx
+++ b/modules/docs/en/core-concepts/model/api-decorator.mdx
@@ -102,6 +102,7 @@ Specifies which client code types to generate.
 | `axios-multipart` | Axios for file uploads | Image uploads |
 | `tanstack-query` | Query hook | Data retrieval |
 | `tanstack-mutation` | Mutation hook | Data modification |
+| `tanstack-mutation-multipart` | Mutation hook for file uploads | File upload mutations |
 | `window-fetch` | Fetch API | Browser native |
 
 <CodeGroup>
@@ -126,12 +127,9 @@ async save(params: UserSaveParams[]): Promise<number[]> {
 ```
 
 ```typescript title="File Upload"
-@api({
-  httpMethod: "POST",
-  clients: ["axios-multipart"],
-})
 @upload()
 async uploadAvatar(): Promise<{ url: string }> {
+  // clients: ["axios-multipart", "tanstack-mutation-multipart"] auto-configured
   // ...
 }
 ```

--- a/modules/docs/ko/core-concepts/model/api-decorator.mdx
+++ b/modules/docs/ko/core-concepts/model/api-decorator.mdx
@@ -102,6 +102,7 @@ async findById(id: number) { }
 | `axios-multipart` | 파일 업로드용 Axios | 이미지 업로드 |
 | `tanstack-query` | Query hook | 데이터 조회 |
 | `tanstack-mutation` | Mutation hook | 데이터 변경 |
+| `tanstack-mutation-multipart` | 파일 업로드용 Mutation hook | 파일 업로드 변경 |
 | `window-fetch` | Fetch API | 브라우저 네이티브 |
 
 <CodeGroup>
@@ -126,12 +127,9 @@ async save(params: UserSaveParams[]): Promise<number[]> {
 ```
 
 ```typescript title="파일 업로드"
-@api({
-  httpMethod: "POST",
-  clients: ["axios-multipart"],
-})
 @upload()
 async uploadAvatar(): Promise<{ url: string }> {
+  // clients: ["axios-multipart", "tanstack-mutation-multipart"] 자동 설정
   // ...
 }
 ```

--- a/modules/sonamu/src/testing/dev-vitest-manager.ts
+++ b/modules/sonamu/src/testing/dev-vitest-manager.ts
@@ -184,6 +184,8 @@ export class DevVitestManager {
       }
     }
 
+    this.eventListeners.clear();
+
     if (this.vitest) {
       await this.vitest.close();
       this.vitest = null;


### PR DESCRIPTION
> 이 PR은 AI(Claude)에 의해 자동으로 생성되었습니다. 모든 변경사항은 기존 코드의 의도와 스타일을 존중하며, 최종 판단은 메인테이너에게 있습니다.

## 참조

- Issue: #44 (내일 새벽에 AI에게 맡길 일들)
- Issue: #43 (Nightly PR Directions)

## 작업 선정 이유

issue #44의 지침에 따라 "예상치 못한 동작이나 버그 등 잠재적으로 위험한 포인트"와 "문서와 주석이 코드와 어긋나는 경우"를 탐색했습니다. 다수의 후보 중 확신을 가지고 근거를 제시할 수 있는 2가지를 선정했습니다.

## 변경사항

### 1. DevVitestManager shutdown 시 eventListeners 미클리어 메모리 누수 수정

**파일**: `modules/sonamu/src/testing/dev-vitest-manager.ts`

**문제**: `DevVitestManager.shutdown()`이 호출될 때 큐 정리와 vitest 인스턴스 종료는 수행하지만, `eventListeners` Set을 클리어하지 않습니다. SSE 연결에서 `addEventListener()`로 등록된 리스너들의 참조가 shutdown 이후에도 남아있게 됩니다.

**접근 방식**: shutdown() 메서드에서 큐 정리 직후, vitest 종료 전에 `this.eventListeners.clear()`를 추가했습니다. vitest 종료 전에 클리어하는 이유는, vitest close 과정에서 reporter 콜백이 발생할 수 있고, 이때 이미 disconnect된 SSE 연결의 리스너에 이벤트를 보내는 것은 무의미하기 때문입니다.

**이렇게 하지 않으면**: DevVitestManager가 여러 번 start/shutdown 사이클을 거칠 경우(예: HMR 재시작), 이전 사이클의 SSE 리스너 참조가 GC되지 않고 누적될 수 있습니다.

**영향 범위**: dev 환경 전용 코드(dev-vitest-manager)이므로 프로덕션에는 영향 없음.

### 2. @api 데코레이터 core-concepts 문서에 tanstack-mutation-multipart 클라이언트 타입 누락 보완 (ko/en)

**파일**: `modules/docs/ko/core-concepts/model/api-decorator.mdx`, `modules/docs/en/core-concepts/model/api-decorator.mdx`

**문제**: 
- `clients` 옵션 테이블에 소스코드(`decorators.ts`의 `ServiceClient` 타입)에 정의된 `tanstack-mutation-multipart`가 누락되어 있습니다. api-reference 쪽 문서에는 이미 기재되어 있으나, 개발자가 더 자주 참고하는 core-concepts 가이드에는 빠져 있었습니다.
- 파일 업로드 예제에서 `@api({ clients: ["axios-multipart"] })` + `@upload()` 조합을 보여주고 있으나, 소스코드(decorators.ts:448-488)에서 `@upload`은 `@api` 없이 독립 사용이 가능하며 자동으로 `["axios-multipart", "tanstack-mutation-multipart"]`를 clients로 설정합니다. 기존 예제는 이 자동 설정을 무시하고 수동으로 불완전한 clients를 지정하는 잘못된 패턴을 보여주고 있었습니다.

**접근 방식**: 
- clients 테이블에 `tanstack-mutation-multipart` 행 추가
- 파일 업로드 예제를 `@upload()` 독립 사용 패턴으로 변경하고, 자동 설정되는 clients를 주석으로 명시

**이렇게 하지 않으면**: 개발자가 core-concepts 가이드만 보고 파일 업로드를 구현할 때 `tanstack-mutation-multipart` 클라이언트 타입의 존재를 모르거나, 불필요하게 `@api`를 함께 사용하며 clients를 수동 지정하는 안티패턴을 따르게 됩니다.

**영향 범위**: 문서만 변경. 런타임 동작에 영향 없음.

## 확인 방법

- 코드 변경: `pnpm --filter sonamu build` 빌드 성공, `pnpm --filter sonamu test:type` 39개 테스트 전부 통과, `pnpm check` 에러 0건 확인 완료
- 문서 변경: ko/en 양쪽 모두 동일하게 수정됨. `tanstack-mutation-multipart`가 `decorators.ts` line 35의 `ServiceClient` 타입 유니온과 일치함을 확인.

## 사람의 확인이 필요한 부분

- DevVitestManager의 `eventListeners.clear()` 타이밍이 vitest close 전인 것이 적절한지 확인 부탁드립니다. vitest close 과정에서 reporter 콜백이 아직 필요한 경우가 있다면 close 이후로 옮겨야 할 수 있습니다.
- 파일 업로드 예제를 `@upload()` 단독 사용으로 변경했는데, 기존에 `@api()` + `@upload()` 조합을 의도적으로 보여주고 싶었던 것이라면 원복이 필요합니다.