### PR TITLE
[Nightly 2026-06-05] 프론트엔드 설정 문서의 SonamuFile 타입 정의를 Base+Extend declaration merging 패턴으로 정정 및 UploadParams 인터페이스 누락 보완 (ko/en 2파일)

### DIFF
--- a/modules/docs/en/frontend-integration/getting-started/setup.mdx
+++ b/modules/docs/en/frontend-integration/getting-started/setup.mdx
@@ -231,15 +231,47 @@ export function Header() {
 ### Uploader Interface
 
 ```typescript
-type Uploader = (files: File[]) => Promise<SonamuFile[]>;
+type Uploader = (files: File[], params?: UploadParams) => Promise<SonamuFile[]>;
 
-type SonamuFile = {
+interface SonamuFileExtend {}
+
+type SonamuFileBase = {
   name: string;
   url: string;
   mime_type: string;
   size: number;
 };
+
+interface SonamuFile extends SonamuFileBase, SonamuFileExtend {}
+
+interface UploadParams {}
 ```
+
+<Info>
+**Extending SonamuFile and UploadParams**
+
+Both `SonamuFile` and `UploadParams` can be extended with project-specific fields via TypeScript declaration merging.
+
+```typescript
+// src/types/sonamu-file-extend.d.ts
+import "sonamu";
+
+declare module "sonamu" {
+  interface SonamuFileExtend {
+    thumbnailUrl?: string;
+    category?: string;
+  }
+
+  interface UploadParams {
+    directory?: string;
+    maxWidth?: number;
+  }
+}
+```
+
+This follows the same declaration merging pattern as `ContextExtend`.
+
+</Info>
 
 ### FileService Integration
 

--- a/modules/docs/ko/frontend-integration/getting-started/setup.mdx
+++ b/modules/docs/ko/frontend-integration/getting-started/setup.mdx
@@ -231,15 +231,47 @@ export function Header() {
 ### Uploader 인터페이스
 
 ```typescript
-type Uploader = (files: File[]) => Promise<SonamuFile[]>;
+type Uploader = (files: File[], params?: UploadParams) => Promise<SonamuFile[]>;
 
-type SonamuFile = {
+interface SonamuFileExtend {}
+
+type SonamuFileBase = {
   name: string;
   url: string;
   mime_type: string;
   size: number;
 };
+
+interface SonamuFile extends SonamuFileBase, SonamuFileExtend {}
+
+interface UploadParams {}
 ```
+
+<Info>
+**SonamuFile과 UploadParams 확장하기**
+
+`SonamuFile`과 `UploadParams`는 TypeScript의 declaration merging을 통해 프로젝트별 필드를 추가할 수 있습니다.
+
+```typescript
+// src/types/sonamu-file-extend.d.ts
+import "sonamu";
+
+declare module "sonamu" {
+  interface SonamuFileExtend {
+    thumbnailUrl?: string;
+    category?: string;
+  }
+
+  interface UploadParams {
+    directory?: string;
+    maxWidth?: number;
+  }
+}
+```
+
+이 패턴은 `ContextExtend`와 동일한 declaration merging 방식입니다.
+
+</Info>
 
 ### FileService 통합
 


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동으로 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 무엇을, 왜

`modules/docs/ko/frontend-integration/getting-started/setup.mdx` 및 영어 대응 문서에서 **Uploader 인터페이스** 섹션의 `SonamuFile` 타입 정의와 `Uploader` 시그니처가 실제 소스코드와 어긋나 있는 것을 발견하여 정정합니다.

### 배경

다음 커밋들에서 SonamuFile 관련 타입 구조가 크게 변경되었으나, 프론트엔드 설정 문서는 업데이트되지 않았습니다:

- `18f5cd54` — feat(SON-475): SonamuFile에 Base + Extend 패턴 도입
- `0c6d1b37` — feat(SON-477): FileInput uploader에 UploadParams 패턴 도입
- `18bb4391` — fix(SON-482): SonamuFileExtend declaration merging 지원

### 구체적인 불일치

| 항목 | 문서 (변경 전) | 실제 코드 |
|------|----------------|-----------|
| `SonamuFile` 타입 | 단순 4필드 type alias | `SonamuFileBase` + `SonamuFileExtend` declaration merging interface |
| `Uploader` 시그니처 | `(files: File[]) => Promise<SonamuFile[]>` | `(files: File[], params?: UploadParams) => Promise<SonamuFile[]>` |
| `UploadParams` | 언급 없음 | declaration merging으로 확장 가능한 인터페이스 |

## 접근 방식

- 기존 문서의 Uploader 인터페이스 섹션만 수정하여 영향 범위를 최소화했습니다.
- `ContextExtend`와 동일한 declaration merging 패턴이므로, 기존 문서에서 `ContextExtend`를 설명하는 방식과 일관되게 작성했습니다.
- 확장 예제를 `<Info>` 블록으로 추가하여 사용자가 프로젝트별 커스터마이징 방법을 파악할 수 있도록 했습니다.

## 이렇게 하지 않으면

- 문서를 보고 `SonamuFile` 타입을 단순 4필드로 알고 있는 사용자가 declaration merging으로 확장하는 기능을 모르게 됩니다.
- `Uploader` 시그니처가 달라 커스텀 uploader 구현 시 타입 에러가 발생할 수 있습니다.

## 영향 범위

- `modules/docs/ko/frontend-integration/getting-started/setup.mdx` — 한국어 프론트엔드 설정 문서
- `modules/docs/en/frontend-integration/getting-started/setup.mdx` — 영어 대응 문서
- 소스코드 변경 없음, 문서만 정정

## 확인 방법

1. 변경된 문서의 타입 정의가 `modules/sonamu/src/types/types.ts:323-340`과 일치하는지 확인
2. `modules/react-components/src/contexts/sonamu-context.tsx:21`의 uploader 시그니처와 일치하는지 확인
3. `pnpm check` 통과 확인 완료 (경고 8건, 에러 0건 — 기존과 동일)

## 사람의 확인이 필요한 부분

- declaration merging 확장 예제에서 사용한 필드명(`thumbnailUrl`, `category`, `directory`, `maxWidth`)은 설명용 예시입니다. 프로젝트에서 실제로 자주 사용되는 확장 필드가 있다면 예제를 조정하는 것이 좋을 수 있습니다.

Refs: #43, #44