### PR TITLE
[Nightly 2026-06-08] onClose 훅의 workflows.destroy() 이중 호출 수정 및 문서 내 미존재 BentoCache 옵션명·예외 클래스명 정정 (소스 1파일 + ko/en 13파일)

### DIFF
--- a/modules/docs/en/advanced-features/caching/cache-configuration.mdx
+++ b/modules/docs/en/advanced-features/caching/cache-configuration.mdx
@@ -24,7 +24,8 @@ BentoCache is a TypeScript cache library that supports multi-tier caching.
 Add cache configuration to the `server.cache` field in `sonamu.config.ts`:
 
 ```typescript
-import { drivers, store, type SonamuConfig } from "sonamu";
+import { drivers, store } from "sonamu/cache";
+import type { SonamuConfig } from "sonamu";
 
 export const config: SonamuConfig = {
   // ... other settings
@@ -358,7 +359,7 @@ export const config: SonamuConfig = {
 drivers.memory({
   maxSize: "100mb", // Maximum size (string or bytes)
   maxItems: 1000, // Maximum number of items
-  maxItemSize: "10mb", // Maximum size per item
+  maxEntrySize: "10mb", // Maximum size per entry
 });
 ```
 
@@ -378,7 +379,7 @@ const redis = new Redis({
 
 drivers.redis({
   connection: redis,
-  keyPrefix: "cache:", // Key prefix (optional)
+  prefix: "cache:", // Key prefix (optional)
 });
 ```
 
@@ -417,7 +418,7 @@ CREATE TABLE cache_items (
 ```typescript
 drivers.redisBus({
   connection: redis,
-  channelPrefix: "cache:", // Channel prefix (optional)
+  retryQueue: { enabled: true }, // Retry queue (optional)
 });
 ```
 

--- a/modules/docs/en/api-reference/decorators/api.mdx
+++ b/modules/docs/en/api-reference/decorators/api.mdx
@@ -109,7 +109,7 @@ async downloadFile(fileId: number, ctx: Context) {
     .first();
 
   if (!file) {
-    throw new NotFoundError("File not found");
+    throw new NotFoundException("File not found");
   }
 
   // Read file from storage

--- a/modules/docs/en/faq/testing.mdx
+++ b/modules/docs/en/faq/testing.mdx
@@ -303,7 +303,7 @@ describe("User API", () => {
 <Accordion title="How do I test errors?">
 
 ```typescript
-import { BadRequestError, NotFoundError } from "sonamu";
+import { BadRequestException, NotFoundException, UnauthorizedException } from "sonamu";
 
 describe("User API Errors", () => {
   test("createUser - duplicate email", async () => {
@@ -312,17 +312,17 @@ describe("User API Errors", () => {
         name: "Test",
         email: "john@example.com", // Already exists
       }),
-    ).rejects.toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestException);
   });
 
   test("findById - non-existent ID", async () => {
-    await expect(UserModel.findById(99999)).rejects.toThrow(NotFoundError);
+    await expect(UserModel.findById(99999)).rejects.toThrow(NotFoundException);
   });
 
   test("deleteUser - no permission", async () => {
     await expect(
       UserModel.deleteUser(1), // Permission check fails
-    ).rejects.toThrow(ForbiddenError);
+    ).rejects.toThrow(UnauthorizedException);
   });
 });
 ```

--- a/modules/docs/en/tools-and-cli/hmr/boundaries.mdx
+++ b/modules/docs/en/tools-and-cli/hmr/boundaries.mdx
@@ -325,7 +325,7 @@ export class ProductModel extends BaseModelClass {
 
   async reserveStock(quantity: number) {
     if (!this.hasStock(quantity)) {
-      throw new BadRequestError("Out of stock");
+      throw new BadRequestException("Out of stock");
     }
 
     await this.update({ stock: this.stock - quantity });

--- a/modules/docs/en/tools-and-cli/hmr/how-hmr-works.mdx
+++ b/modules/docs/en/tools-and-cli/hmr/how-hmr-works.mdx
@@ -231,7 +231,7 @@ async create(body: PostForm) {
   const user = await UserModel.findById(body.userId);
 
   if (!user.isActive()) {  // 👈 Use the method just added!
-    throw new BadRequestError("User is not active");
+    throw new BadRequestException("User is not active");
   }
 
   return PostModel.save(body);

--- a/modules/docs/ko/advanced-features/caching/cache-configuration.mdx
+++ b/modules/docs/ko/advanced-features/caching/cache-configuration.mdx
@@ -24,7 +24,8 @@ BentoCache는 Multi-tier 캐싱을 지원하는 TypeScript 캐시 라이브러�
 `sonamu.config.ts`의 `server.cache` 필드에 캐시 설정을 추가합니다:
 
 ```typescript
-import { drivers, store, type SonamuConfig } from "sonamu";
+import { drivers, store } from "sonamu/cache";
+import type { SonamuConfig } from "sonamu";
 
 export const config: SonamuConfig = {
   // ... 기타 설정
@@ -355,7 +356,7 @@ export const config: SonamuConfig = {
 drivers.memory({
   maxSize: "100mb", // 최대 크기 (문자열 또는 바이트 수)
   maxItems: 1000, // 최대 항목 수
-  maxItemSize: "10mb", // 항목당 최대 크기
+  maxEntrySize: "10mb", // 항목당 최대 크기
 });
 ```
 
@@ -375,7 +376,7 @@ const redis = new Redis({
 
 drivers.redis({
   connection: redis,
-  keyPrefix: "cache:", // 키 접두사 (선택)
+  prefix: "cache:", // 키 접두사 (선택)
 });
 ```
 
@@ -414,7 +415,7 @@ CREATE TABLE cache_items (
 ```typescript
 drivers.redisBus({
   connection: redis,
-  channelPrefix: "cache:", // 채널 접두사 (선택)
+  retryQueue: { enabled: true }, // 재시도 큐 (선택)
 });
 ```
 

--- a/modules/docs/ko/advanced-features/caching/cache-decorator.mdx
+++ b/modules/docs/ko/advanced-features/caching/cache-decorator.mdx
@@ -650,7 +650,7 @@ class DashboardModelClass extends BaseModelClass {
 
     // 권한 체크
     if (context.user?.id !== userId && context.user?.role !== "admin") {
-      throw new ForbiddenError();
+      throw new UnauthorizedException();
     }
 
     // 대시보드 데이터 조회

--- a/modules/docs/ko/api-reference/decorators/api.mdx
+++ b/modules/docs/ko/api-reference/decorators/api.mdx
@@ -109,7 +109,7 @@ async downloadFile(fileId: number, ctx: Context) {
     .first();
 
   if (!file) {
-    throw new NotFoundError("파일을 찾을 수 없습니다");
+    throw new NotFoundException("파일을 찾을 수 없습니다");
   }
 
   // Storage에서 파일 읽기

--- a/modules/docs/ko/database/subsets/nested-relations.mdx
+++ b/modules/docs/ko/database/subsets/nested-relations.mdx
@@ -857,7 +857,7 @@ class EmployeeModelClass extends BaseModelClass {
   ): EmployeeTreeNode {
     const employee = employeeMap.get(employeeId);
     if (!employee) {
-      throw new NotFoundError(`직원 ${employeeId}를 찾을 수 없습니다`);
+      throw new NotFoundException(`직원 ${employeeId}를 찾을 수 없습니다`);
     }
 
     // 직속 부하 찾기

--- a/modules/docs/ko/database/transactions/best-practices.mdx
+++ b/modules/docs/ko/database/transactions/best-practices.mdx
@@ -695,7 +695,7 @@ class InventoryModelClass extends BaseModelClass {
       const product = await wdb.table("products").where("id", item.productId).first();
 
       if (!product || product.stock < item.quantity) {
-        throw new BadRequestError(`상품 ${item.productId}의 재고가 부족합니다.`);
+        throw new BadRequestException(`상품 ${item.productId}의 재고가 부족합니다.`);
       }
 
       // 재고 차감
@@ -836,11 +836,11 @@ class ProductModelClass extends BaseModelClass {
       .first();
 
     if (!product) {
-      throw new NotFoundError("상품을 찾을 수 없습니다");
+      throw new NotFoundException("상품을 찾을 수 없습니다");
     }
 
     if (product.stock < quantity) {
-      throw new BadRequestError("재고가 부족합니다");
+      throw new BadRequestException("재고가 부족합니다");
     }
 
     // 재고 차감
@@ -947,7 +947,7 @@ class PaymentModelClass extends BaseModelClass {
     // 1. 주문 정보 조회 (읽기 전용)
     const order = await this.findOrderById(orderId);
     if (!order) {
-      throw new NotFoundError("주문을 찾을 수 없습니다");
+      throw new NotFoundException("주문을 찾을 수 없습니다");
     }
 
     // 2. 외부 결제 API 호출 (트랜잭션 밖)

--- a/modules/docs/ko/faq/testing.mdx
+++ b/modules/docs/ko/faq/testing.mdx
@@ -303,7 +303,7 @@ describe("User API", () => {
 <Accordion title="에러를 테스트하려면?">
 
 ```typescript
-import { BadRequestError, NotFoundError } from "sonamu";
+import { BadRequestException, NotFoundException, UnauthorizedException } from "sonamu";
 
 describe("User API Errors", () => {
   test("createUser - 이메일 중복", async () => {
@@ -312,17 +312,17 @@ describe("User API Errors", () => {
         name: "Test",
         email: "john@example.com", // 이미 존재
       }),
-    ).rejects.toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestException);
   });
 
   test("findById - 존재하지 않는 ID", async () => {
-    await expect(UserModel.findById(99999)).rejects.toThrow(NotFoundError);
+    await expect(UserModel.findById(99999)).rejects.toThrow(NotFoundException);
   });
 
   test("deleteUser - 권한 없음", async () => {
     await expect(
       UserModel.deleteUser(1), // 권한 체크 실패
-    ).rejects.toThrow(ForbiddenError);
+    ).rejects.toThrow(UnauthorizedException);
   });
 });
 ```

--- a/modules/docs/ko/tools-and-cli/hmr/boundaries.mdx
+++ b/modules/docs/ko/tools-and-cli/hmr/boundaries.mdx
@@ -325,7 +325,7 @@ export class ProductModel extends BaseModelClass {
 
   async reserveStock(quantity: number) {
     if (!this.hasStock(quantity)) {
-      throw new BadRequestError("Out of stock");
+      throw new BadRequestException("Out of stock");
     }
 
     await this.update({ stock: this.stock - quantity });

--- a/modules/docs/ko/tools-and-cli/hmr/how-hmr-works.mdx
+++ b/modules/docs/ko/tools-and-cli/hmr/how-hmr-works.mdx
@@ -231,7 +231,7 @@ async create(body: PostForm) {
   const user = await UserModel.findById(body.userId);
 
   if (!user.isActive()) {  // 👈 방금 추가한 메서드 바로 사용!
-    throw new BadRequestError("User is not active");
+    throw new BadRequestException("User is not active");
   }
 
   return PostModel.save(body);

--- a/modules/sonamu/src/api/sonamu.ts
+++ b/modules/sonamu/src/api/sonamu.ts
@@ -1916,7 +1916,6 @@ class SonamuClass {
 
     server.addHook("onClose", async () => {
       await options.lifecycle?.onShutdown?.(server);
-      await this.workflows.destroy();
       await this.destroy();
     });
 


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동으로 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 무엇을, 왜

3가지 독립적인 수정을 포함합니다:

### 1. `workflows.destroy()` 이중 호출 제거 (소스코드 버그)

`sonamu.ts`의 `boot()` 메서드에서, `onClose` 훅이 `this.workflows.destroy()`를 명시적으로 호출한 뒤 `this.destroy()`를 호출하고 있었습니다. 그런데 `this.destroy()` 내부(`Promise.allSettled` 블록)에서도 `this._workflows?.destroy()`를 다시 호출하여, 서버 shutdown 시 동일한 WorkflowManager가 두 번 정리되는 문제가 있었습니다.

`destroy()`가 이미 workflows, cache, vitestManager, watcher 등 모든 리소스의 정리를 담당하므로, onClose 훅의 중복 호출을 제거하였습니다.

### 2. cache-configuration 문서의 잘못된 BentoCache 옵션명 및 import 경로 수정

`cache-configuration.mdx` (ko/en)에서 실제 BentoCache 타입 정의와 어긋나는 3가지 옵션명을 사용하고 있었습니다:

| 항목 | 문서 (변경 전) | 실제 타입 (BentoCache) |
|------|---------------|----------------------|
| Memory 드라이버 | `maxItemSize` | `maxEntrySize` |
| Redis 드라이버 | `keyPrefix` | `prefix` (DriverCommonOptions) |
| redisBus 드라이버 | `channelPrefix` | 이 옵션 자체가 미존재 (BusOptions에는 `retryQueue`만 존재) |

또한 첫 번째 코드 예제에서 `import { drivers, store } from "sonamu"`로 되어 있었으나, `drivers`와 `store`는 `"sonamu"` 메인 엔트리에서 export되지 않고 서브패스 `"sonamu/cache"`에서만 export됩니다. 동일 문서의 다른 예제들(72행, 78행, 111행)은 이미 올바른 경로를 사용하고 있어, 첫 예제만 불일치하는 상태였습니다.

### 3. 문서 코드 예제의 미존재 예외 클래스명 수정 (ko/en 11파일)

여러 문서 파일에서 `BadRequestError`, `NotFoundError`, `ForbiddenError`라는 미존재 클래스를 사용하고 있었습니다. sonamu에서 실제로 export하는 예외 클래스는:

| 문서에서 사용 | 실제 클래스 (so-exceptions.ts) |
|-------------|-------------------------------|
| `BadRequestError` | `BadRequestException` |
| `NotFoundError` | `NotFoundException` |
| `ForbiddenError` | `UnauthorizedException` (403 대응 클래스 없음, 가장 가까운 401 클래스) |

## 참조한 issue

- #43 (Nightly PR Directions) - 작업 절차 및 PR 형식 지침
- #44 (작업 범위) - "잠재적으로 위험한 포인트 식별 및 제거", "문서와 주석이 코드와 어긋나는 경우 업데이트"

## 이 작업을 선정한 이유

- `workflows.destroy()` 이중 호출: shutdown 경로의 실제 버그로, 이미 정리된 리소스를 다시 정리하려 시도하면 예상치 못한 예외가 발생할 수 있습니다.
- cache-configuration 문서: 사용자가 문서를 보고 캐시를 설정할 때 존재하지 않는 옵션명(`maxItemSize`, `keyPrefix`, `channelPrefix`)을 사용하여 타입 에러가 발생하거나 설정이 무시될 수 있습니다.
- 예외 클래스명: 사용자가 에러 핸들링 코드를 작성할 때 `BadRequestError` 등을 import하면 모듈을 찾을 수 없다는 에러가 발생합니다.

## 접근 방식

- 소스코드 수정은 1줄 제거로 최소화하여 영향 범위를 줄였습니다.
- 문서 수정은 실제 타입 정의 파일(`bentocache/build/src/types/main.d.ts`, `so-exceptions.ts`)과 대조하여 정확한 이름을 확인한 후 수정하였습니다.
- `ForbiddenError`에 대응하는 403 예외 클래스가 sonamu에 존재하지 않아, 가장 의미론적으로 가까운 `UnauthorizedException`(401)으로 대체하였습니다.

## 이렇게 하지 않으면

- shutdown 시 `WorkflowManager.destroy()`가 두 번 실행되어, 이미 중지된 worker/schedule/backend를 다시 정리하려 할 때 예외가 발생하거나 예상치 못한 부작용이 있을 수 있습니다.
- 문서를 따라 캐시를 설정하는 사용자가 타입 에러나 무시되는 옵션으로 인해 혼란을 겪을 수 있습니다.
- 문서의 예외 클래스명으로 import를 시도하는 사용자가 컴파일 에러를 만나게 됩니다.

## 영향 범위

- `modules/sonamu/src/api/sonamu.ts` — 서버 shutdown 경로 (onClose 훅)
- `modules/docs/ko/advanced-features/caching/cache-configuration.mdx` — 한국어 캐시 설정 문서
- `modules/docs/en/advanced-features/caching/cache-configuration.mdx` — 영어 캐시 설정 문서
- `modules/docs/ko/**/*.mdx` (7파일) — 예외 클래스명 사용 한국어 문서
- `modules/docs/en/**/*.mdx` (4파일) — 예외 클래스명 사용 영어 문서

## 확인 방법

1. `pnpm check` 통과 확인 완료 (경고 8건, 에러 0건 — 기존과 동일)
2. `pnpm --filter sonamu build` 성공 확인 완료
3. `pnpm --filter sonamu test:type` 성공 확인 완료 (39 tests passed)
4. `pnpm --filter miomock-api test` 성공 확인 완료 (1414 tests passed)
5. `grep -rn "BadRequestError\|NotFoundError\|ForbiddenError" modules/docs/` 결과 0건으로 누락 없음 확인
6. `maxItemSize`/`keyPrefix`/`channelPrefix` → BentoCache 타입 정의와 대조 확인:
   - `bentocache/build/src/types/main.d.ts:772` → `maxEntrySize`
   - `bentocache/build/src/types/main.d.ts:714` → `prefix` (DriverCommonOptions)
   - `bentocache/build/src/types/main.d.ts:261-279` → BusOptions에 `channelPrefix` 없음

## 사람의 확인이 필요한 부분

- `ForbiddenError` → `UnauthorizedException` 대체: sonamu에 403 Forbidden에 대응하는 예외 클래스가 없어 401 Unauthorized에 대응하는 `UnauthorizedException`으로 대체하였습니다. 만약 403 전용 예외 클래스를 추가하거나 다른 클래스를 사용해야 한다면 해당 부분을 조정해 주시면 감사하겠습니다.
- redisBus 드라이버의 `channelPrefix` 제거: 이 옵션이 BentoCache에 존재하지 않아 실제로 존재하는 `retryQueue` 옵션 예제로 교체하였습니다. 문서의 의도가 "채널 접두사 설정"을 보여주는 것이었다면, `retryQueue` 외의 다른 옵션이 더 적절할 수 있습니다.