### PR TITLE
[Nightly 2026-06-09] Storage 문서(storage-drivers, storage-manager, url-builder)의 잘못된 drivers import 경로 수정 (ko/en 6파일)

### DIFF
--- a/modules/docs/en/advanced-features/storage/storage-drivers.mdx
+++ b/modules/docs/en/advanced-features/storage/storage-drivers.mdx
@@ -23,7 +23,8 @@ Stores files in the **local file system**.
 ### Basic Configuration
 
 ```typescript
-import { drivers, type SonamuConfig } from "sonamu";
+import type { SonamuConfig } from "sonamu";
+import { drivers } from "sonamu/storage";
 
 export const config: SonamuConfig = {
   server: {
@@ -179,7 +180,8 @@ Stores files in **AWS S3** or compatible storage.
 ### Basic Configuration
 
 ```typescript
-import { drivers, type SonamuConfig } from "sonamu";
+import type { SonamuConfig } from "sonamu";
+import { drivers } from "sonamu/storage";
 
 export const config: SonamuConfig = {
   server: {

--- a/modules/docs/en/advanced-features/storage/storage-manager.mdx
+++ b/modules/docs/en/advanced-features/storage/storage-manager.mdx
@@ -79,7 +79,8 @@ const fsDisk = Sonamu.storage.use("fs");
 ### sonamu.config.ts
 
 ```typescript
-import { drivers, type SonamuConfig } from "sonamu";
+import type { SonamuConfig } from "sonamu";
+import { drivers } from "sonamu/storage";
 
 export const config: SonamuConfig = {
   server: {

--- a/modules/docs/en/advanced-features/storage/url-builder.mdx
+++ b/modules/docs/en/advanced-features/storage/url-builder.mdx
@@ -33,7 +33,7 @@ The fs driver **requires urlBuilder configuration**.
 ### Basic Configuration
 
 ```typescript
-import { drivers } from "sonamu";
+import { drivers } from "sonamu/storage";
 
 storage: {
   default: 'fs',

--- a/modules/docs/ko/advanced-features/storage/storage-drivers.mdx
+++ b/modules/docs/ko/advanced-features/storage/storage-drivers.mdx
@@ -23,7 +23,8 @@ Sonamu는 **Flydrive** 기반으로 여러 스토리지 드라이버를 지원�
 ### 기본 설정
 
 ```typescript
-import { drivers, type SonamuConfig } from "sonamu";
+import type { SonamuConfig } from "sonamu";
+import { drivers } from "sonamu/storage";
 
 export const config: SonamuConfig = {
   server: {
@@ -176,7 +177,8 @@ http://localhost:3000/uploads/avatars/user-1.png
 ### 기본 설정
 
 ```typescript
-import { drivers, type SonamuConfig } from "sonamu";
+import type { SonamuConfig } from "sonamu";
+import { drivers } from "sonamu/storage";
 
 export const config: SonamuConfig = {
   server: {

--- a/modules/docs/ko/advanced-features/storage/storage-manager.mdx
+++ b/modules/docs/ko/advanced-features/storage/storage-manager.mdx
@@ -79,7 +79,8 @@ const fsDisk = Sonamu.storage.use("fs");
 ### sonamu.config.ts
 
 ```typescript
-import { drivers, type SonamuConfig } from "sonamu";
+import type { SonamuConfig } from "sonamu";
+import { drivers } from "sonamu/storage";
 
 export const config: SonamuConfig = {
   server: {

--- a/modules/docs/ko/advanced-features/storage/url-builder.mdx
+++ b/modules/docs/ko/advanced-features/storage/url-builder.mdx
@@ -33,7 +33,7 @@ fs 드라이버는 **반드시 urlBuilder 설정**이 필요합니다.
 ### 기본 설정
 
 ```typescript
-import { drivers } from "sonamu";
+import { drivers } from "sonamu/storage";
 
 storage: {
   default: 'fs',


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동으로 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 무엇을, 왜

Storage 관련 문서 3종(storage-drivers.mdx, storage-manager.mdx, url-builder.mdx)의 한국어/영어 버전에서 `drivers`를 `"sonamu"` 메인 엔트리에서 import하는 코드 예제가 있었습니다. 그러나 `drivers`는 `"sonamu"` 메인 엔트리(`src/index.ts`)에서 export되지 않고, 서브패스 `"sonamu/storage"`에서만 export됩니다.

### 변경 전 (잘못된 import)

```typescript
import { drivers, type SonamuConfig } from "sonamu";
```

### 변경 후 (올바른 import)

```typescript
import type { SonamuConfig } from "sonamu";
import { drivers } from "sonamu/storage";
```

## 참조한 issue

- #43 (Nightly PR Directions) - 작업 절차 및 PR 형식 지침
- #44 (작업 범위) - "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다."

## 이 작업을 선정한 이유

동일 저장소의 다른 문서들(installation.mdx, configuration/sonamu-config/storage.mdx, configuration/environment-variables/api-keys.mdx 등)은 이미 올바르게 `"sonamu/storage"`에서 import하고 있습니다. 반면 advanced-features/storage/ 하위 3개 문서만 잘못된 경로를 사용하고 있어, 사용자가 이 문서를 따라 설정하면 `"sonamu"` 패키지에서 `drivers`를 찾을 수 없다는 에러가 발생합니다.

### 근거

- `sonamu` 패키지의 `package.json` exports 필드: `"."` 엔트리는 `./dist/index.js`를 가리키고, `"./storage"` 엔트리는 `./dist/storage/index.js`를 가리킴
- `src/index.ts`에 `storage/` 관련 re-export 없음
- `src/storage/index.ts`에서만 `drivers` export

## 접근 방식

- `SonamuConfig` 타입은 `"sonamu"` 메인 엔트리에서 정상적으로 export되므로 그대로 유지
- `drivers`만 `"sonamu/storage"`로 분리
- 동일 저장소의 다른 문서(installation.mdx 등)에서 이미 사용 중인 패턴을 따름
- url-builder.mdx는 `SonamuConfig`를 import하지 않으므로 단순히 경로만 변경

## 이렇게 하지 않으면

사용자가 storage-drivers, storage-manager, url-builder 문서의 코드 예제를 그대로 복사하여 사용하면 다음과 같은 에러가 발생합니다:

```
Module '"sonamu"' has no exported member 'drivers'.
```

동일 문서 사이트 내 다른 페이지(installation, storage 설정)에서는 올바른 경로를 사용하고 있어, 사용자가 먼저 어느 페이지를 보느냐에 따라 혼란이 생길 수 있습니다.

## 영향 범위

- `modules/docs/ko/advanced-features/storage/storage-drivers.mdx` — fs/s3 기본 설정 코드 예제 2곳
- `modules/docs/ko/advanced-features/storage/storage-manager.mdx` — 기본 설정 코드 예제 1곳
- `modules/docs/ko/advanced-features/storage/url-builder.mdx` — fs 기본 설정 코드 예제 1곳
- `modules/docs/en/advanced-features/storage/storage-drivers.mdx` — 위 한국어 대응 영어 문서
- `modules/docs/en/advanced-features/storage/storage-manager.mdx` — 위 한국어 대응 영어 문서
- `modules/docs/en/advanced-features/storage/url-builder.mdx` — 위 한국어 대응 영어 문서

소스코드 변경 없음. 문서 코드 예제만 수정.

## 확인 방법

1. `pnpm check` 통과 확인 완료 (경고 8건, 에러 0건 — 기존과 동일)
2. `grep -rn 'from "sonamu"' modules/docs/ --include="*.mdx" | grep 'drivers' | grep -v 'sonamu/'` 결과에서 storage 관련 파일 0건 확인 (cache-configuration.mdx만 남아있으며 이는 PR #187에서 처리 중)
3. `modules/sonamu/package.json`의 exports 필드에서 `"./storage"` 엔트리 확인
4. `modules/sonamu/src/index.ts`에 storage 관련 re-export 없음 확인

## 사람의 확인이 필요한 부분

- 특별히 없습니다. 변경이 명확하고 동일 저장소의 다른 문서에서 이미 사용 중인 올바른 패턴을 따릅니다.