### PR TITLE
[Nightly 2026-06-11] Puri orderBy nulls 옵션·배열 형태 및 forUpdate/forShare 행 잠금 API 레퍼런스 문서화 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/api-reference/puri-methods/advanced-methods.mdx
+++ b/modules/docs/en/api-reference/puri-methods/advanced-methods.mdx
@@ -114,6 +114,71 @@ await puri.table("posts").where("posts.id", 123).increment("posts.views", 1);
 await puri.table("products").where("products.id", 456).decrement("products.stock", 5);
 ```
 
+## Row Locking
+
+Acquire locks on SELECTed rows within a transaction to prevent concurrent modifications by other transactions.
+
+### forUpdate
+
+Acquires an exclusive lock on selected rows, preventing other transactions from modifying or locking those rows.
+
+```typescript
+@transactional()
+async deductBalance(userId: number, amount: number) {
+  const wdb = this.getPuri("w");
+
+  const user = await wdb
+    .table("users")
+    .select({ id: "users.id", balance: "users.balance" })
+    .where("users.id", userId)
+    .forUpdate()
+    .first();
+
+  if (!user || user.balance < amount) {
+    throw new Error("Insufficient balance");
+  }
+
+  await wdb.table("users").where("users.id", userId).update({
+    balance: user.balance - amount,
+  });
+}
+
+// SELECT users.id, users.balance FROM users WHERE users.id = ? FOR UPDATE
+```
+
+### forShare
+
+Acquires a shared lock on selected rows, preventing other transactions from modifying those rows while still allowing reads.
+
+```typescript
+@transactional()
+async getBalanceSnapshot(userId: number) {
+  const wdb = this.getPuri("w");
+
+  const user = await wdb
+    .table("users")
+    .select({ id: "users.id", balance: "users.balance" })
+    .where("users.id", userId)
+    .forShare()
+    .first();
+
+  return user;
+}
+
+// SELECT users.id, users.balance FROM users WHERE users.id = ? FOR SHARE
+```
+
+**forUpdate vs forShare:**
+
+| Lock Type | Other Transaction Reads | Other Transaction Writes | When to Use |
+|---|---|---|---|
+| `forUpdate()` | Blocked | Blocked | When reading then modifying |
+| `forShare()` | Allowed | Blocked | When only read consistency is needed |
+
+<Warning>
+  `forUpdate()` and `forShare()` are only meaningful within a transaction. Without a transaction, the lock is released immediately.
+</Warning>
+
 ## Fetching Results
 
 ### first

--- a/modules/docs/en/api-reference/puri-methods/order-by.mdx
+++ b/modules/docs/en/api-reference/puri-methods/order-by.mdx
@@ -49,6 +49,74 @@ const users = await puri
 2. Second `orderBy` - Secondary sort (when primary is same)
 3. Third `orderBy` - Tertiary sort (when secondary is also same)
 
+## NULL Sort Order (nulls)
+
+The third argument `nulls` specifies where NULL values should be placed in the sort order.
+
+```typescript
+// NULL at the end
+const users = await puri
+  .table("users")
+  .select({ id: "users.id", name: "users.name", last_login: "users.last_login" })
+  .orderBy("users.last_login", "desc", "last");
+
+// ORDER BY users.last_login DESC NULLS LAST
+```
+
+```typescript
+// NULL first
+const posts = await puri
+  .table("posts")
+  .select({ id: "posts.id", title: "posts.title", deleted_at: "posts.deleted_at" })
+  .orderBy("posts.deleted_at", "asc", "first");
+
+// ORDER BY posts.deleted_at ASC NULLS FIRST
+```
+
+**`nulls` options:**
+
+| Value | Description |
+|---|---|
+| `"first"` | Place NULL values at the beginning of results |
+| `"last"` | Place NULL values at the end of results |
+| omitted | Database default behavior (PostgreSQL: ASC → NULLS LAST, DESC → NULLS FIRST) |
+
+## Array-style orderBy
+
+You can pass multiple sort conditions as an array in a single call.
+
+```typescript
+const products = await puri
+  .table("products")
+  .select({
+    id: "products.id",
+    name: "products.name",
+    price: "products.price",
+    rating: "products.rating",
+  })
+  .orderBy([
+    { column: "products.rating", order: "desc", nulls: "last" },
+    { column: "products.price", order: "asc" },
+  ]);
+
+// ORDER BY products.rating DESC NULLS LAST, products.price ASC
+```
+
+Each array item can be one of the following:
+
+- **string**: Column name only (defaults to ASC)
+- **SqlExpression**: SQL expression
+- **object**: `{ column, order?, nulls? }` for detailed specification
+
+```typescript
+// Mix different forms
+.orderBy([
+  "products.featured",                                         // string: ASC
+  { column: "products.rating", order: "desc" },                // object: DESC
+  { column: "products.price", order: "asc", nulls: "last" },  // object + nulls
+])
+```
+
 ## Practical Examples
 
 <Tabs>
@@ -152,14 +220,14 @@ const users = await puri
 
   <Tab title="NULL Handling" icon="ban">
     ```typescript
-    // NULL at the end
+    // Use the nulls option to explicitly control NULL placement
     const users = await puri.table("users")
       .select({
         id: "users.id",
         name: "users.name",
         last_login: "users.last_login"
       })
-      .orderBy("users.last_login", "desc");  // NULL automatically at the end
+      .orderBy("users.last_login", "desc", "last");  // NULL at the end
 
     // NULL first
     const posts = await puri.table("posts")
@@ -168,7 +236,7 @@ const users = await puri
         title: "posts.title",
         deleted_at: "posts.deleted_at"
       })
-      .orderBy("posts.deleted_at", "asc");  // NULL comes first
+      .orderBy("posts.deleted_at", "asc", "first");  // NULL comes first
     ```
 
   </Tab>
@@ -385,8 +453,9 @@ CREATE INDEX idx_products_category_price ON products(category, price);
 // PostgreSQL: NULL LAST (default)
 .orderBy("users.last_login", "desc")
 
-// To specify explicitly, use raw SQL
-.whereRaw("ORDER BY users.last_login DESC NULLS FIRST")
+// Use the nulls option to specify explicitly
+.orderBy("users.last_login", "desc", "first")  // NULLS FIRST
+.orderBy("users.last_login", "desc", "last")   // NULLS LAST
 ```
 
 ### 3. Case Sensitivity

--- a/modules/docs/ko/api-reference/puri-methods/advanced-methods.mdx
+++ b/modules/docs/ko/api-reference/puri-methods/advanced-methods.mdx
@@ -114,6 +114,71 @@ await puri.table("posts").where("posts.id", 123).increment("posts.views", 1);
 await puri.table("products").where("products.id", 456).decrement("products.stock", 5);
 ```
 
+## 행 잠금 (Row Locking)
+
+트랜잭션 내에서 SELECT한 행에 잠금을 걸어 다른 트랜잭션의 동시 수정을 방지합니다.
+
+### forUpdate
+
+선택된 행에 배타적 잠금(exclusive lock)을 걸어 다른 트랜잭션이 해당 행을 수정하거나 잠글 수 없도록 합니다.
+
+```typescript
+@transactional()
+async deductBalance(userId: number, amount: number) {
+  const wdb = this.getPuri("w");
+
+  const user = await wdb
+    .table("users")
+    .select({ id: "users.id", balance: "users.balance" })
+    .where("users.id", userId)
+    .forUpdate()
+    .first();
+
+  if (!user || user.balance < amount) {
+    throw new Error("Insufficient balance");
+  }
+
+  await wdb.table("users").where("users.id", userId).update({
+    balance: user.balance - amount,
+  });
+}
+
+// SELECT users.id, users.balance FROM users WHERE users.id = ? FOR UPDATE
+```
+
+### forShare
+
+선택된 행에 공유 잠금(shared lock)을 걸어 다른 트랜잭션이 해당 행을 수정할 수 없지만 읽기는 허용합니다.
+
+```typescript
+@transactional()
+async getBalanceSnapshot(userId: number) {
+  const wdb = this.getPuri("w");
+
+  const user = await wdb
+    .table("users")
+    .select({ id: "users.id", balance: "users.balance" })
+    .where("users.id", userId)
+    .forShare()
+    .first();
+
+  return user;
+}
+
+// SELECT users.id, users.balance FROM users WHERE users.id = ? FOR SHARE
+```
+
+**forUpdate vs forShare:**
+
+| 잠금 유형 | 다른 트랜잭션의 읽기 | 다른 트랜잭션의 수정 | 사용 시점 |
+|---|---|---|---|
+| `forUpdate()` | 대기 | 대기 | 읽은 뒤 수정할 때 |
+| `forShare()` | 허용 | 대기 | 읽기 일관성만 필요할 때 |
+
+<Warning>
+  `forUpdate()`와 `forShare()`는 트랜잭션 내에서만 의미가 있습니다. 트랜잭션 없이 사용하면 잠금이 즉시 해제됩니다.
+</Warning>
+
 ## 결과 가져오기
 
 ### first

--- a/modules/docs/ko/api-reference/puri-methods/order-by.mdx
+++ b/modules/docs/ko/api-reference/puri-methods/order-by.mdx
@@ -49,6 +49,74 @@ const users = await puri
 2. 두 번째 `orderBy` - 부 정렬 (주 정렬이 같을 때)
 3. 세 번째 `orderBy` - 삼차 정렬 (부 정렬도 같을 때)
 
+## NULL 정렬 순서 (nulls)
+
+세 번째 인자 `nulls`로 NULL 값의 정렬 위치를 명시할 수 있습니다.
+
+```typescript
+// NULL을 마지막으로
+const users = await puri
+  .table("users")
+  .select({ id: "users.id", name: "users.name", last_login: "users.last_login" })
+  .orderBy("users.last_login", "desc", "last");
+
+// ORDER BY users.last_login DESC NULLS LAST
+```
+
+```typescript
+// NULL을 먼저
+const posts = await puri
+  .table("posts")
+  .select({ id: "posts.id", title: "posts.title", deleted_at: "posts.deleted_at" })
+  .orderBy("posts.deleted_at", "asc", "first");
+
+// ORDER BY posts.deleted_at ASC NULLS FIRST
+```
+
+**`nulls` 옵션:**
+
+| 값 | 설명 |
+|---|---|
+| `"first"` | NULL 값을 결과의 맨 앞에 배치 |
+| `"last"` | NULL 값을 결과의 맨 뒤에 배치 |
+| 생략 | 데이터베이스 기본 동작 (PostgreSQL: ASC → NULLS LAST, DESC → NULLS FIRST) |
+
+## 배열 형태의 orderBy
+
+여러 정렬 조건을 배열로 한 번에 전달할 수 있습니다.
+
+```typescript
+const products = await puri
+  .table("products")
+  .select({
+    id: "products.id",
+    name: "products.name",
+    price: "products.price",
+    rating: "products.rating",
+  })
+  .orderBy([
+    { column: "products.rating", order: "desc", nulls: "last" },
+    { column: "products.price", order: "asc" },
+  ]);
+
+// ORDER BY products.rating DESC NULLS LAST, products.price ASC
+```
+
+배열의 각 항목은 다음 형태 중 하나입니다:
+
+- **문자열**: 컬럼명만 전달 (기본 ASC)
+- **SqlExpression**: SQL 표현식
+- **객체**: `{ column, order?, nulls? }` 형태로 상세 지정
+
+```typescript
+// 다양한 형태 혼합
+.orderBy([
+  "products.featured",                                         // 문자열: ASC
+  { column: "products.rating", order: "desc" },                // 객체: DESC
+  { column: "products.price", order: "asc", nulls: "last" },  // 객체 + nulls
+])
+```
+
 ## 실전 예시
 
 <Tabs>
@@ -152,14 +220,14 @@ const users = await puri
 
   <Tab title="NULL 처리" icon="ban">
     ```typescript
-    // NULL을 마지막으로
+    // nulls 옵션으로 NULL 위치를 명시적으로 지정
     const users = await puri.table("users")
       .select({
         id: "users.id",
         name: "users.name",
         last_login: "users.last_login"
       })
-      .orderBy("users.last_login", "desc");  // NULL은 자동으로 마지막
+      .orderBy("users.last_login", "desc", "last");  // NULL을 마지막으로
 
     // NULL을 먼저
     const posts = await puri.table("posts")
@@ -168,7 +236,7 @@ const users = await puri
         title: "posts.title",
         deleted_at: "posts.deleted_at"
       })
-      .orderBy("posts.deleted_at", "asc");  // NULL이 먼저 옴
+      .orderBy("posts.deleted_at", "asc", "first");  // NULL을 먼저
     ```
 
   </Tab>
@@ -385,8 +453,9 @@ CREATE INDEX idx_products_category_price ON products(category, price);
 // PostgreSQL: NULL LAST (기본)
 .orderBy("users.last_login", "desc")
 
-// 명시적으로 지정하려면 raw SQL
-.whereRaw("ORDER BY users.last_login DESC NULLS FIRST")
+// nulls 옵션으로 명시적으로 지정 가능
+.orderBy("users.last_login", "desc", "first")  // NULLS FIRST
+.orderBy("users.last_login", "desc", "last")   // NULLS LAST
 ```
 
 ### 3. 대소문자 구분


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동으로 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 무엇을, 왜

Puri API 레퍼런스 문서 4종(ko/en)에서 최근 추가된 기능 2건이 반영되지 않은 것을 수정합니다.

### 1. orderBy nulls 옵션 및 배열 orderBy (SON-491, 커밋 0b923ab)

`orderBy`에 세 번째 인자 `nulls: "first" | "last"`가 추가되었고, 배열 형태의 `orderBy([...])` 오버로드가 추가되었습니다. 그러나 기존 문서의 "NULL 처리" 탭과 "주의사항 > NULL 값" 섹션은 이를 반영하지 못하고 있었습니다.

**변경 전 (잘못된 안내):**
```typescript
// 명시적으로 지정하려면 raw SQL
.whereRaw("ORDER BY users.last_login DESC NULLS FIRST")
```

**변경 후 (올바른 안내):**
```typescript
// nulls 옵션으로 명시적으로 지정 가능
.orderBy("users.last_login", "desc", "first")  // NULLS FIRST
```

### 2. forUpdate/forShare 행 잠금 (SON-487, 커밋 0ddaba1)

Puri 체이닝에 `forUpdate()`와 `forShare()` 메서드가 추가되었으나 API 레퍼런스(`puri-methods/advanced-methods.mdx`)에 문서화되어 있지 않았습니다. 트랜잭션 best-practices 문서에서는 예제로 사용되고 있었지만, API 레퍼런스에서는 찾을 수 없었습니다.

## 참조한 issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (작업 범위) — "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다."

## 이 작업을 선정한 이유

두 기능 모두 2026-06-08~09에 머지된 최신 기능이지만 문서가 미반영 상태입니다. 특히 `orderBy`의 `nulls` 옵션은 기존 문서가 "raw SQL을 사용하라"(`whereRaw("ORDER BY ... NULLS FIRST")`)고 안내하고 있어, 사용자가 새로운 API를 발견하지 못하고 비효율적인 방법을 사용하게 됩니다.

### 근거

- `modules/sonamu/src/database/puri.ts` 892~948행에서 `orderBy` 오버로드와 `forUpdate`/`forShare` 메서드를 확인
- `modules/sonamu/src/database/puri.types.test-d.ts`에서 타입 테스트 확인
- 기존 Nightly PR에서 이 부분이 다뤄진 적 없음을 확인

## 접근 방식

- 기존 문서 구조와 스타일을 그대로 따름
- `nulls` 옵션: 기존 "NULL 처리" 탭 코드를 새 API로 교체, "주의사항" NULL 섹션의 raw SQL 안내를 새 API로 정정, 별도의 "NULL 정렬 순서" 섹션과 "배열 형태의 orderBy" 섹션을 추가
- `forUpdate`/`forShare`: advanced-methods.mdx의 "데이터 수정"과 "결과 가져오기" 사이에 "행 잠금" 섹션을 신설. 트랜잭션 문서에서 이미 사용 중인 코드 패턴과 일관되게 작성

## 이렇게 하지 않으면

- `orderBy` nulls: 사용자가 NULL 정렬 순서를 제어하려면 `whereRaw("ORDER BY ... NULLS FIRST")`라는 잘못된 패턴(WHERE 절에 ORDER BY를 넣는 패턴)을 사용하게 되며, 이미 존재하는 타입 안전한 API를 발견하지 못함
- `forUpdate`/`forShare`: 트랜잭션 예제에서 `.forUpdate()` 체이닝을 보고도, API 레퍼런스에서 해당 메서드를 찾을 수 없어 혼란을 겪을 수 있음

## 영향 범위

- `modules/docs/ko/api-reference/puri-methods/order-by.mdx` — nulls 옵션, 배열 orderBy 추가, raw SQL 안내 정정
- `modules/docs/en/api-reference/puri-methods/order-by.mdx` — 동일 (영어)
- `modules/docs/ko/api-reference/puri-methods/advanced-methods.mdx` — forUpdate/forShare 섹션 추가
- `modules/docs/en/api-reference/puri-methods/advanced-methods.mdx` — 동일 (영어)

소스 코드 변경 없음. 문서만 변경.

## 확인 방법

1. `pnpm --filter sonamu-docs dev`로 로컬 문서 서버 실행
2. `/ko/api-reference/puri-methods/order-by` 페이지에서 "NULL 정렬 순서", "배열 형태의 orderBy" 섹션 확인
3. `/ko/api-reference/puri-methods/advanced-methods` 페이지에서 "행 잠금" 섹션 확인
4. 영어(`/en/...`) 버전도 동일하게 확인

## 사람의 확인이 필요한 부분

- `forUpdate`/`forShare` 문서에서 사용한 예제(잔액 차감, 스냅샷 조회)가 프로젝트의 실제 사용 패턴과 부합하는지 확인 필요
- `nulls` 옵션 표에서 PostgreSQL 기본 동작(ASC → NULLS LAST, DESC → NULLS FIRST)이 Sonamu가 지원하는 DB 환경에서 정확한지 확인 필요