### PR TITLE
[Nightly 2026-06-12] Puri returning() 예제의 미존재 객체 매핑 문법을 실제 API(string | string[]) 시그니처로 일괄 정정 (ko/en 36파일)

### DIFF
--- a/modules/docs/en/api-development/authentication/protected-routes.mdx
+++ b/modules/docs/en/api-development/authentication/protected-routes.mdx
@@ -114,7 +114,7 @@ class PostModel extends BaseModelClass {
         content,
         created_at: new Date(),
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { postId: post.id };
   }

--- a/modules/docs/en/api-development/context/custom-context.mdx
+++ b/modules/docs/en/api-development/context/custom-context.mdx
@@ -320,7 +320,7 @@ class ProductModel extends BaseModelClass {
         ...params,
         tenant_id: context.tenant.id,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { productId: product.id };
   }
@@ -353,7 +353,7 @@ class UserModel extends BaseModelClass {
     this.requirePermission("user:create");
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: user.id };
   }
@@ -448,7 +448,7 @@ class UserModel extends BaseModelClass {
   @api({ httpMethod: "POST" })
   async create(params: UserSaveParams): Promise<{ userId: number }> {
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     // Auto audit log
     await this.audit("CREATE", "user", user.id, { email: params.email });

--- a/modules/docs/en/api-development/context/getting-context.mdx
+++ b/modules/docs/en/api-development/context/getting-context.mdx
@@ -85,7 +85,7 @@ class PostModelClass extends BaseModelClass<
         user_id: context.user.id,
         author: context.user.username,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { postId: post.id };
   }

--- a/modules/docs/en/api-development/context/sonamu-context.mdx
+++ b/modules/docs/en/api-development/context/sonamu-context.mdx
@@ -116,7 +116,7 @@ class UserModel extends BaseModelClass {
 
     // Create User
     const wdb = this.getPuri("w");
-    const [userId] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [userId] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: userId.id };
   }
@@ -169,7 +169,7 @@ class PostModel extends BaseModelClass {
         user_id: context.user.id,
         author: context.user.username,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { postId: post.id };
   }
@@ -265,7 +265,7 @@ class OrderModel extends BaseModelClass {
         user_id: context.user!.id,
         ip_address: context.request.ip,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { orderId: order.id };
   }

--- a/modules/docs/en/api-development/creating-apis/api-decorator.mdx
+++ b/modules/docs/en/api-development/creating-apis/api-decorator.mdx
@@ -88,7 +88,7 @@ class UserModelClass extends BaseModelClass<
   @api({ httpMethod: "POST" })
   async create(params: UserSaveParams): Promise<{ userId: number }> {
     const wdb = this.getPuri("w");
-    const [userId] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [userId] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: userId.id };
   }
@@ -289,7 +289,7 @@ class OrderModelClass extends BaseModelClass<
         shipping_address: shippingAddress,
         status: "pending",
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     // Save order items
     for (const item of items) {
@@ -681,7 +681,7 @@ class UserModelClass extends BaseModelClass<
     const wdb = this.getPuri("w");
 
     try {
-      const [userId] = await wdb.table("users").insert(params).returning({ id: "id" });
+      const [userId] = await wdb.table("users").insert(params).returning("id");
 
       return { userId: userId.id };
     } catch (error) {
@@ -851,7 +851,7 @@ class OrderModelClass extends BaseModelClass<
         payment_method: params.paymentMethod,
         status: "pending",
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     // 4. Create order items
     for (const item of params.items) {
@@ -911,7 +911,7 @@ class UserModelClass extends BaseModelClass<
         password: params.password,
         role: params.role,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { userId: userId.id };
   }

--- a/modules/docs/en/api-development/creating-apis/http-methods.mdx
+++ b/modules/docs/en/api-development/creating-apis/http-methods.mdx
@@ -200,7 +200,7 @@ class UserModel extends BaseModelClass {
         password: params.password, // Should be hashed in practice
         role: params.role,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { userId: user.id };
   }

--- a/modules/docs/en/api-development/creating-apis/parameters.mdx
+++ b/modules/docs/en/api-development/creating-apis/parameters.mdx
@@ -107,7 +107,7 @@ class UserModel extends BaseModelClass {
         password: params.password,
         role: params.role,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { userId: user.id };
   }
@@ -462,7 +462,7 @@ class UserModel extends BaseModelClass {
         age: validated.age,
         role: validated.role,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { userId: user.id };
   }

--- a/modules/docs/en/api-development/creating-apis/return-types.mdx
+++ b/modules/docs/en/api-development/creating-apis/return-types.mdx
@@ -145,7 +145,7 @@ class UserModel extends BaseModelClass {
   }> {
     const wdb = this.getPuri("w");
 
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     return {
       userId: user.id,
@@ -557,7 +557,7 @@ class UserModel extends BaseModelClass {
 
     for (let i = 0; i < users.length; i++) {
       try {
-        const [user] = await wdb.table("users").insert(users[i]).returning({ id: "id" });
+        const [user] = await wdb.table("users").insert(users[i]).returning("id");
 
         created.push(user.id);
       } catch (error) {

--- a/modules/docs/en/api-development/file-upload/saving-files.mdx
+++ b/modules/docs/en/api-development/file-upload/saving-files.mdx
@@ -526,7 +526,7 @@ class FileModel extends BaseModelClass {
         tags: tags ? JSON.stringify(tags) : null,
         uploaded_at: new Date(),
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       fileId: record.id,

--- a/modules/docs/en/api-development/file-upload/setup.mdx
+++ b/modules/docs/en/api-development/file-upload/setup.mdx
@@ -77,7 +77,7 @@ class FileModelClass extends BaseModelClass<
         url,
         title,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       fileId: record.id,
@@ -133,7 +133,7 @@ class FileModelClass extends BaseModelClass<
           url,
           category,
         })
-        .returning({ id: "id" });
+        .returning("id");
 
       uploadedFiles.push({
         fileId: record.id,
@@ -353,7 +353,7 @@ class ImageModelClass extends BaseModelClass<
         size: image.size,
         url,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       imageId: record.id,
@@ -437,7 +437,7 @@ class UserModelClass extends BaseModelClass<
         size: image.size,
         url,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       imageId: record.id,
@@ -484,7 +484,7 @@ class PostModelClass extends BaseModelClass<
         title,
         content,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     const attachmentUrls: string[] = [];
 

--- a/modules/docs/en/api-development/file-upload/uploaded-file-class.mdx
+++ b/modules/docs/en/api-development/file-upload/uploaded-file-class.mdx
@@ -435,7 +435,7 @@ class UserModel extends BaseModelClass {
         mime_type: image.mimetype,
         size: image.size,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       imageId: record.id,
@@ -513,7 +513,7 @@ class FileModel extends BaseModelClass {
           url,
           category,
         })
-        .returning({ id: "id" });
+        .returning("id");
 
       uploadedFiles.push({
         fileId: record.id,

--- a/modules/docs/en/api-development/file-upload/url-generation.mdx
+++ b/modules/docs/en/api-development/file-upload/url-generation.mdx
@@ -500,7 +500,7 @@ class FileModel extends BaseModelClass {
         size,
         url: await disk.getUrl(key),
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       fileId: record.id,

--- a/modules/docs/en/api-development/validation/automatic-validation.mdx
+++ b/modules/docs/en/api-development/validation/automatic-validation.mdx
@@ -68,7 +68,7 @@ class UserModelClass extends BaseModelClass<
     const validated = CreateUserSchema.parse(params);
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(validated).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(validated).returning("id");
 
     return { userId: user.id };
   }
@@ -95,7 +95,7 @@ class UserModelClass extends BaseModelClass<
       const validated = CreateUserSchema.parse(params);
 
       const wdb = this.getPuri("w");
-      const [user] = await wdb.table("users").insert(validated).returning({ id: "id" });
+      const [user] = await wdb.table("users").insert(validated).returning("id");
 
       return { userId: user.id };
     } catch (error) {
@@ -284,7 +284,7 @@ class AuthModelClass extends BaseModelClass<
         ...userData,
         role: "normal",
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { userId: user.id };
   }
@@ -590,7 +590,7 @@ class UserModelClass extends BaseModelClass<
     const validated = result.data;
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(validated).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(validated).returning("id");
 
     return { userId: user.id };
   }

--- a/modules/docs/en/api-development/validation/custom-validation.mdx
+++ b/modules/docs/en/api-development/validation/custom-validation.mdx
@@ -34,7 +34,7 @@ class UserModel extends BaseModelClass {
     await this.validateCreateParams(params);
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: user.id };
   }
@@ -168,7 +168,7 @@ class UserModel extends BaseModelClass {
 
     // Create
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: user.id };
   }
@@ -568,7 +568,7 @@ class UserModel extends BaseModelClass {
 
     // 3. Create
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(validated).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(validated).returning("id");
 
     return { userId: user.id };
   }

--- a/modules/docs/en/api-development/validation/error-handling.mdx
+++ b/modules/docs/en/api-development/validation/error-handling.mdx
@@ -123,7 +123,7 @@ class UserModel extends BaseModelClass {
     }
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: user.id };
   }
@@ -201,7 +201,7 @@ class UserModel extends BaseModelClass {
     const validated = result.data;
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(validated).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(validated).returning("id");
 
     return { userId: user.id };
   }
@@ -327,7 +327,7 @@ class UserModel extends BaseModelClass {
 
     // 4. Create
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(data).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(data).returning("id");
 
     return { userId: user.id };
   }

--- a/modules/docs/en/database/puri/basic-queries.mdx
+++ b/modules/docs/en/database/puri/basic-queries.mdx
@@ -196,10 +196,10 @@ const inserted = await db
     password: "hashed_password",
     role: "normal",
   })
-  .returning({ id: "id", name: "username" });
+  .returning(["id", "username"]);
 
 console.log(inserted);
-// [{ id: 1, name: "john" }]
+// [{ id: 1, username: "john" }]
 ```
 
 ### Insert Multiple Records
@@ -497,11 +497,7 @@ async createPost(data: {
       status: "draft",
       created_at: new Date(),
     })
-    .returning({
-      id: "id",
-      title: "title",
-      createdAt: "created_at",
-    });
+    .returning(["id", "title", "created_at"]);
 
   return inserted[0];
 }

--- a/modules/docs/en/database/transactions/best-practices.mdx
+++ b/modules/docs/en/database/transactions/best-practices.mdx
@@ -88,7 +88,7 @@ class OrderModel extends BaseModelClass {
     await this.sendEmail(user.email);
 
     // Actual data save
-    const [orderId] = await wdb.table("orders").insert({ user_id: userId }).returning({ id: "id" });
+    const [orderId] = await wdb.table("orders").insert({ user_id: userId }).returning("id");
 
     return orderId.id;
   }
@@ -223,7 +223,7 @@ class OrderModel extends BaseModelClass {
     const [orderId] = await wdb
       .table("orders")
       .insert({ user_id: userId, status: "pending" })
-      .returning({ id: "id" });
+      .returning("id");
 
     // 2. Create order items (partial transaction)
     for (const item of items) {

--- a/modules/docs/en/database/transactions/manual-transactions.mdx
+++ b/modules/docs/en/database/transactions/manual-transactions.mdx
@@ -78,7 +78,7 @@ class UserModel extends BaseModelClass {
 
     return wdb.transaction(async (trx) => {
       // 1. Create User
-      const [user] = await trx.table("users").insert(userData).returning({ id: "id" });
+      const [user] = await trx.table("users").insert(userData).returning("id");
 
       // 2. Update Profile
       await trx.table("users").where("id", user.id).update({ bio: profileData.bio });
@@ -112,7 +112,7 @@ class OrderModel extends BaseModelClass {
       const [order] = await trx
         .table("orders")
         .insert({ user_id: userId, status: "pending" })
-        .returning({ id: "id" });
+        .returning("id");
 
       // 3. Decrement stock
       for (const item of items) {
@@ -259,7 +259,7 @@ class OrderModel extends BaseModelClass {
       const [order] = await trx
         .table("orders")
         .insert({ user_id: userId, status: "pending" })
-        .returning({ id: "id" });
+        .returning("id");
 
       // 2. Validation
       const totalAmount = await this.calculateTotal(items);
@@ -358,7 +358,7 @@ class UserModel extends BaseModelClass {
         }
 
         // Create User
-        const [user] = await trx.table("users").insert(data).returning({ id: "id" });
+        const [user] = await trx.table("users").insert(data).returning("id");
 
         return user.id;
       });
@@ -431,7 +431,7 @@ class UserModel extends BaseModelClass {
       .transaction(async (trx) => {
         console.log("[TRX] Inside transaction");
 
-        const [userId] = await trx.table("users").insert(data).returning({ id: "id" });
+        const [userId] = await trx.table("users").insert(data).returning("id");
 
         console.log("[TRX] User created:", userId);
 
@@ -536,7 +536,7 @@ class UserModel extends BaseModelClass {
     return wdb.transaction(async (trx) => {
       // Conditional work
       if (await this.shouldCreateUser(data)) {
-        const [id] = await trx.table("users").insert(data).returning({ id: "id" });
+        const [id] = await trx.table("users").insert(data).returning("id");
         return id.id;
       }
 

--- a/modules/docs/ko/api-development/authentication/protected-routes.mdx
+++ b/modules/docs/ko/api-development/authentication/protected-routes.mdx
@@ -114,7 +114,7 @@ class PostModel extends BaseModelClass {
         content,
         created_at: new Date(),
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { postId: post.id };
   }

--- a/modules/docs/ko/api-development/context/custom-context.mdx
+++ b/modules/docs/ko/api-development/context/custom-context.mdx
@@ -320,7 +320,7 @@ class ProductModel extends BaseModelClass {
         ...params,
         tenant_id: context.tenant.id,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { productId: product.id };
   }
@@ -353,7 +353,7 @@ class UserModel extends BaseModelClass {
     this.requirePermission("user:create");
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: user.id };
   }
@@ -448,7 +448,7 @@ class UserModel extends BaseModelClass {
   @api({ httpMethod: "POST" })
   async create(params: UserSaveParams): Promise<{ userId: number }> {
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     // 감사 로그 자동 기록
     await this.audit("CREATE", "user", user.id, { email: params.email });

--- a/modules/docs/ko/api-development/context/getting-context.mdx
+++ b/modules/docs/ko/api-development/context/getting-context.mdx
@@ -85,7 +85,7 @@ class PostModelClass extends BaseModelClass<
         user_id: context.user.id,
         author: context.user.username,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { postId: post.id };
   }

--- a/modules/docs/ko/api-development/context/sonamu-context.mdx
+++ b/modules/docs/ko/api-development/context/sonamu-context.mdx
@@ -116,7 +116,7 @@ class UserModel extends BaseModelClass {
 
     // User 생성
     const wdb = this.getPuri("w");
-    const [userId] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [userId] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: userId.id };
   }
@@ -169,7 +169,7 @@ class PostModel extends BaseModelClass {
         user_id: context.user.id,
         author: context.user.username,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { postId: post.id };
   }
@@ -265,7 +265,7 @@ class OrderModel extends BaseModelClass {
         user_id: context.user!.id,
         ip_address: context.request.ip,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { orderId: order.id };
   }

--- a/modules/docs/ko/api-development/creating-apis/api-decorator.mdx
+++ b/modules/docs/ko/api-development/creating-apis/api-decorator.mdx
@@ -88,7 +88,7 @@ class UserModelClass extends BaseModelClass<
   @api({ httpMethod: "POST" })
   async create(params: UserSaveParams): Promise<{ userId: number }> {
     const wdb = this.getPuri("w");
-    const [userId] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [userId] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: userId.id };
   }
@@ -289,7 +289,7 @@ class OrderModelClass extends BaseModelClass<
         shipping_address: shippingAddress,
         status: "pending",
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     // 주문 아이템 저장
     for (const item of items) {
@@ -681,7 +681,7 @@ class UserModelClass extends BaseModelClass<
     const wdb = this.getPuri("w");
 
     try {
-      const [userId] = await wdb.table("users").insert(params).returning({ id: "id" });
+      const [userId] = await wdb.table("users").insert(params).returning("id");
 
       return { userId: userId.id };
     } catch (error) {
@@ -851,7 +851,7 @@ class OrderModelClass extends BaseModelClass<
         payment_method: params.paymentMethod,
         status: "pending",
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     // 4. 주문 아이템 생성
     for (const item of params.items) {
@@ -911,7 +911,7 @@ class UserModelClass extends BaseModelClass<
         password: params.password,
         role: params.role,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { userId: userId.id };
   }

--- a/modules/docs/ko/api-development/creating-apis/http-methods.mdx
+++ b/modules/docs/ko/api-development/creating-apis/http-methods.mdx
@@ -200,7 +200,7 @@ class UserModel extends BaseModelClass {
         password: params.password, // 실제로는 해시 필요
         role: params.role,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { userId: user.id };
   }

--- a/modules/docs/ko/api-development/creating-apis/parameters.mdx
+++ b/modules/docs/ko/api-development/creating-apis/parameters.mdx
@@ -107,7 +107,7 @@ class UserModel extends BaseModelClass {
         password: params.password,
         role: params.role,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { userId: user.id };
   }
@@ -462,7 +462,7 @@ class UserModel extends BaseModelClass {
         age: validated.age,
         role: validated.role,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { userId: user.id };
   }

--- a/modules/docs/ko/api-development/creating-apis/return-types.mdx
+++ b/modules/docs/ko/api-development/creating-apis/return-types.mdx
@@ -145,7 +145,7 @@ class UserModel extends BaseModelClass {
   }> {
     const wdb = this.getPuri("w");
 
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     return {
       userId: user.id,
@@ -557,7 +557,7 @@ class UserModel extends BaseModelClass {
 
     for (let i = 0; i < users.length; i++) {
       try {
-        const [user] = await wdb.table("users").insert(users[i]).returning({ id: "id" });
+        const [user] = await wdb.table("users").insert(users[i]).returning("id");
 
         created.push(user.id);
       } catch (error) {

--- a/modules/docs/ko/api-development/file-upload/saving-files.mdx
+++ b/modules/docs/ko/api-development/file-upload/saving-files.mdx
@@ -524,7 +524,7 @@ class FileModel extends BaseModelClass {
         tags: tags ? JSON.stringify(tags) : null,
         uploaded_at: new Date(),
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       fileId: record.id,

--- a/modules/docs/ko/api-development/file-upload/setup.mdx
+++ b/modules/docs/ko/api-development/file-upload/setup.mdx
@@ -77,7 +77,7 @@ class FileModelClass extends BaseModelClass<
         url,
         title,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       fileId: record.id,
@@ -133,7 +133,7 @@ class FileModelClass extends BaseModelClass<
           url,
           category,
         })
-        .returning({ id: "id" });
+        .returning("id");
 
       uploadedFiles.push({
         fileId: record.id,
@@ -353,7 +353,7 @@ class ImageModelClass extends BaseModelClass<
         size: image.size,
         url,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       imageId: record.id,
@@ -437,7 +437,7 @@ class UserModelClass extends BaseModelClass<
         size: image.size,
         url,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       imageId: record.id,
@@ -487,7 +487,7 @@ class PostModelClass extends BaseModelClass<
         title,
         content,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     const attachmentUrls: string[] = [];
 

--- a/modules/docs/ko/api-development/file-upload/uploaded-file-class.mdx
+++ b/modules/docs/ko/api-development/file-upload/uploaded-file-class.mdx
@@ -435,7 +435,7 @@ class UserModel extends BaseModelClass {
         mime_type: image.mimetype,
         size: image.size,
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       imageId: record.id,
@@ -513,7 +513,7 @@ class FileModel extends BaseModelClass {
           url,
           category,
         })
-        .returning({ id: "id" });
+        .returning("id");
 
       uploadedFiles.push({
         fileId: record.id,

--- a/modules/docs/ko/api-development/file-upload/url-generation.mdx
+++ b/modules/docs/ko/api-development/file-upload/url-generation.mdx
@@ -500,7 +500,7 @@ class FileModel extends BaseModelClass {
         size,
         url: await disk.getUrl(key),
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return {
       fileId: record.id,

--- a/modules/docs/ko/api-development/validation/automatic-validation.mdx
+++ b/modules/docs/ko/api-development/validation/automatic-validation.mdx
@@ -68,7 +68,7 @@ class UserModelClass extends BaseModelClass<
     const validated = CreateUserSchema.parse(params);
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(validated).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(validated).returning("id");
 
     return { userId: user.id };
   }
@@ -95,7 +95,7 @@ class UserModelClass extends BaseModelClass<
       const validated = CreateUserSchema.parse(params);
 
       const wdb = this.getPuri("w");
-      const [user] = await wdb.table("users").insert(validated).returning({ id: "id" });
+      const [user] = await wdb.table("users").insert(validated).returning("id");
 
       return { userId: user.id };
     } catch (error) {
@@ -284,7 +284,7 @@ class AuthModelClass extends BaseModelClass<
         ...userData,
         role: "normal",
       })
-      .returning({ id: "id" });
+      .returning("id");
 
     return { userId: user.id };
   }
@@ -590,7 +590,7 @@ class UserModelClass extends BaseModelClass<
     const validated = result.data;
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(validated).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(validated).returning("id");
 
     return { userId: user.id };
   }

--- a/modules/docs/ko/api-development/validation/custom-validation.mdx
+++ b/modules/docs/ko/api-development/validation/custom-validation.mdx
@@ -34,7 +34,7 @@ class UserModel extends BaseModelClass {
     await this.validateCreateParams(params);
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: user.id };
   }
@@ -168,7 +168,7 @@ class UserModel extends BaseModelClass {
 
     // 생성
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: user.id };
   }
@@ -568,7 +568,7 @@ class UserModel extends BaseModelClass {
 
     // 3. 생성
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(validated).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(validated).returning("id");
 
     return { userId: user.id };
   }

--- a/modules/docs/ko/api-development/validation/error-handling.mdx
+++ b/modules/docs/ko/api-development/validation/error-handling.mdx
@@ -123,7 +123,7 @@ class UserModel extends BaseModelClass {
     }
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(params).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(params).returning("id");
 
     return { userId: user.id };
   }
@@ -201,7 +201,7 @@ class UserModel extends BaseModelClass {
     const validated = result.data;
 
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(validated).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(validated).returning("id");
 
     return { userId: user.id };
   }
@@ -327,7 +327,7 @@ class UserModel extends BaseModelClass {
 
     // 4. 생성
     const wdb = this.getPuri("w");
-    const [user] = await wdb.table("users").insert(data).returning({ id: "id" });
+    const [user] = await wdb.table("users").insert(data).returning("id");
 
     return { userId: user.id };
   }

--- a/modules/docs/ko/database/puri/basic-queries.mdx
+++ b/modules/docs/ko/database/puri/basic-queries.mdx
@@ -196,10 +196,10 @@ const inserted = await db
     password: "hashed_password",
     role: "normal",
   })
-  .returning({ id: "id", name: "username" });
+  .returning(["id", "username"]);
 
 console.log(inserted);
-// [{ id: 1, name: "john" }]
+// [{ id: 1, username: "john" }]
 ```
 
 ### 여러 레코드 추가
@@ -497,11 +497,7 @@ async createPost(data: {
       status: "draft",
       created_at: new Date(),
     })
-    .returning({
-      id: "id",
-      title: "title",
-      createdAt: "created_at",
-    });
+    .returning(["id", "title", "created_at"]);
 
   return inserted[0];
 }

--- a/modules/docs/ko/database/transactions/best-practices.mdx
+++ b/modules/docs/ko/database/transactions/best-practices.mdx
@@ -88,7 +88,7 @@ class OrderModel extends BaseModelClass {
     await this.sendEmail(user.email);
 
     // 실제 데이터 저장
-    const [orderId] = await wdb.table("orders").insert({ user_id: userId }).returning({ id: "id" });
+    const [orderId] = await wdb.table("orders").insert({ user_id: userId }).returning("id");
 
     return orderId.id;
   }
@@ -223,7 +223,7 @@ class OrderModel extends BaseModelClass {
     const [orderId] = await wdb
       .table("orders")
       .insert({ user_id: userId, status: "pending" })
-      .returning({ id: "id" });
+      .returning("id");
 
     // 2. 주문 아이템 생성 (부분 트랜잭션)
     for (const item of items) {

--- a/modules/docs/ko/database/transactions/manual-transactions.mdx
+++ b/modules/docs/ko/database/transactions/manual-transactions.mdx
@@ -78,7 +78,7 @@ class UserModel extends BaseModelClass {
 
     return wdb.transaction(async (trx) => {
       // 1. User 생성
-      const [user] = await trx.table("users").insert(userData).returning({ id: "id" });
+      const [user] = await trx.table("users").insert(userData).returning("id");
 
       // 2. Profile 업데이트
       await trx.table("users").where("id", user.id).update({ bio: profileData.bio });
@@ -112,7 +112,7 @@ class OrderModel extends BaseModelClass {
       const [order] = await trx
         .table("orders")
         .insert({ user_id: userId, status: "pending" })
-        .returning({ id: "id" });
+        .returning("id");
 
       // 3. 재고 차감
       for (const item of items) {
@@ -258,7 +258,7 @@ class OrderModel extends BaseModelClass {
       const [order] = await trx
         .table("orders")
         .insert({ user_id: userId, status: "pending" })
-        .returning({ id: "id" });
+        .returning("id");
 
       // 2. 유효성 검사
       const totalAmount = await this.calculateTotal(items);
@@ -356,7 +356,7 @@ class UserModel extends BaseModelClass {
         }
 
         // User 생성
-        const [user] = await trx.table("users").insert(data).returning({ id: "id" });
+        const [user] = await trx.table("users").insert(data).returning("id");
 
         return user.id;
       });
@@ -429,7 +429,7 @@ class UserModel extends BaseModelClass {
       .transaction(async (trx) => {
         console.log("[TRX] Inside transaction");
 
-        const [userId] = await trx.table("users").insert(data).returning({ id: "id" });
+        const [userId] = await trx.table("users").insert(data).returning("id");
 
         console.log("[TRX] User created:", userId);
 
@@ -534,7 +534,7 @@ class UserModel extends BaseModelClass {
     return wdb.transaction(async (trx) => {
       // 조건부 작업
       if (await this.shouldCreateUser(data)) {
-        const [id] = await trx.table("users").insert(data).returning({ id: "id" });
+        const [id] = await trx.table("users").insert(data).returning("id");
         return id.id;
       }
 


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동으로 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 무엇을, 왜

문서 전체(ko/en 36파일)에 걸쳐 Puri의 `returning()` 메서드에 미존재하는 객체 매핑 문법 `.returning({ id: "id" })`가 사용되고 있었습니다. 이를 실제 API 시그니처인 `.returning("id")` 또는 `.returning(["id", "username"])` 형태로 정정합니다.

## 참조한 issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (작업 범위) — "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다."

## 이 작업을 선정한 이유

`puri.ts:1833`의 `returning()` 구현은 `(columnOrColumns: string | string[]) => ResolvedPuri`로, 문자열 또는 문자열 배열만 받습니다. knex의 `returning()` 타입 정의도 동일하게 `string | string[]`만 지원합니다. 그러나 문서에서는 `.returning({ id: "id" })` 형태의 객체 매핑 문법이 90곳 이상에 걸쳐 일관되게 사용되고 있었습니다.

이 문법은:
- TypeScript 컴파일 시 타입 오류를 발생시킵니다 (Puri의 오버로드 시그니처에 `Record<string, string>` 타입이 없음)
- 런타임에서 knex에 객체가 전달되면 `[object Object]`로 변환되어 의도한 동작을 하지 않습니다
- API 레퍼런스 문서(`advanced-methods.mdx`)에서는 이미 올바른 문법을 사용하고 있어, 같은 문서 체계 안에서 불일치가 존재합니다

### 근거

- `modules/sonamu/src/database/puri.ts` 1823~1836행: `returning()` 오버로드 시그니처와 구현 확인 — `string | string[]`만 지원
- 소스 코드 내 실제 사용례: `returning("*")`, `returning("dedupe_key")`, `returning(selectFields)` — 모두 문자열/배열 형태
- `api-reference/puri-methods/advanced-methods.mdx`: 올바른 `.returning("*")`, `.returning(["id", "email"])` 사용
- 기존 Nightly PR에서 이 부분이 다뤄진 적 없음

## 접근 방식

기계적이고 안전한 일괄 치환을 채택했습니다:

1. **단일 컬럼 패턴** (90곳): `.returning({ id: "id" })` → `.returning("id")`
   - 결과 타입 `[{ id: number }]`은 동일하므로 주변 destructuring 코드 변경 불필요
2. **복수 컬럼 패턴** (4곳, ko/en 각 2): `.returning({ id: "id", name: "username" })` → `.returning(["id", "username"])`
   - 주석의 예상 출력도 함께 정정 (`name` 키 → 실제 컬럼명 `username`)
3. **멀티라인 패턴** (2곳, ko/en 각 1): `.returning({ id: "id", title: "title", createdAt: "created_at" })` → `.returning(["id", "title", "created_at"])`

API 레퍼런스(`advanced-methods.mdx`)는 이미 올바른 문법을 사용하고 있으므로 변경하지 않았습니다.

## 이렇게 하지 않으면

- 사용자가 문서의 코드 예제를 복사하면 TypeScript 컴파일 오류가 발생합니다
- 타입 오류를 무시하고 실행하더라도 `returning`이 `[object Object]` 컬럼을 요청하게 되어 의도한 결과를 얻지 못합니다
- 같은 문서 체계 안에서 API 레퍼런스와 가이드 문서의 `returning` 문법이 서로 불일치합니다

## 영향 범위

- **소스 코드 변경 없음** — 문서(`.mdx`)만 수정
- 한국어 문서 18파일, 영어 문서 18파일, 총 36파일의 코드 예제 수정
- 수정 대상 영역: database/puri, database/transactions, api-development/context, api-development/creating-apis, api-development/file-upload, api-development/validation, api-development/authentication

## 영향 확인 방법

1. `pnpm check` 통과 확인 (0 errors)
2. 수정된 문서의 코드 예제에서 `returning()` 호출이 `puri.ts`의 오버로드 시그니처와 일치하는지 대조
3. Mintlify 프리뷰 배포에서 문서 렌더링 확인

## 추후 확인이 필요한 부분

- `getting-context.mdx`와 `custom-context.mdx`에서 `context.user.role`, `context.user.username` 등 better-auth의 기본 `User` 타입(`id`, `email`, `name`, `image`, `emailVerified`, `createdAt`, `updatedAt`)에 존재하지 않는 필드를 사용하는 예제가 있습니다. 이것이 `ContextExtend`를 통한 프로젝트별 확장 예시로 의도된 것인지, 아니면 수정이 필요한 것인지 메인테이너의 판단이 필요합니다.