### PR TITLE
isLocalHost 판별식에서 ".local"로 끝나는 host도 로컬호스트로 간주하도록 변경

### DIFF
--- a/modules/sonamu/src/api/sonamu.ts
+++ b/modules/sonamu/src/api/sonamu.ts
@@ -2006,7 +2006,7 @@ function formatTime(ms: number): string {
 
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1"]);
 function isLocalHost(host: string): boolean {
-  return LOCAL_HOSTS.has(host);
+  return LOCAL_HOSTS.has(host) || host.endsWith(".local");
 }
 
 // `.every()`가 첫 guard 이후 순회를 멈추는 문제가 있어 `for...of`로 모든 guard를 순서대로 실행하도록 고정함


### PR DESCRIPTION
## 작업 목적

<!-- 이 PR이 해결하려는 문제와 사용자가 받는 영향을 작성해주세요. -->

Sonamu는 시작 단계에서 DB 설정을 읽어, 현재 실행 위치가 `isLocal`이면서 DB host가 `isLocalHost`가 아닌 config에 대해 `⚠ remote`로 경고를 띄워주고 있는데, 여기서 `postgres.myservice.local`같은 형태의 host가 `["localhost", "127.0.0.1", "0.0.0.0", "::1"]` 중 하나에 해당하지 않음으로 인해 원격지로 분류되는 문제가 있습니다. 이를 해결합니다. 

## 작업 내용

<!-- 주요 변경 사항을 작성자가 이해한 범위에서 직접 설명해주세요. -->

- `host.endsWith(".local")`인 경우에도 로컬호스트로 판정합니다.

## 실패 케이스와 사용자 영향

<!-- 고려한 실패 케이스, 예외 상황, 사용자/운영 영향, 되돌리기 방법을 적어주세요. -->

- `isLocalHost`는 딱 저 로깅에만 쓰이는(only 1 usage) 함수라서 다른 사이드 이펙트 전혀 없습니다.