### PR TITLE
[Nightly 2026-06-15] Entity partial index(where 절) 지원의 영어 migration 문서 동기화 (en 2파일)

### DIFF
--- a/modules/docs/en/database/migrations/creating-migrations.mdx
+++ b/modules/docs/en/database/migrations/creating-migrations.mdx
@@ -223,7 +223,13 @@ export async function down(knex: Knex): Promise<void> {
 {
   "indexes": [
     { "type": "unique", "column": "email" },
-    { "type": "index", "column": "username" } // ← Added
+    { "type": "index", "column": "username" }, // ← Added
+    {
+      "type": "unique",
+      "name": "users_email_active_unique",
+      "columns": [{ "name": "email" }],
+      "where": "deleted_at IS NULL"
+    }
   ]
 }
 ```
@@ -236,14 +242,22 @@ export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable("users", (table) => {
     table.index(["username"], "users_username_index");
   });
+  await knex.raw(
+    `CREATE UNIQUE INDEX users_email_active_unique ON users (email) WHERE deleted_at IS NULL`,
+  );
 }
 
 export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`DROP INDEX IF EXISTS users_email_active_unique`);
   await knex.schema.alterTable("users", (table) => {
     table.dropIndex(["username"], "users_username_index");
   });
 }
 ```
+
+`where` is a raw SQL predicate used directly as a PostgreSQL partial index condition. Do not combine it
+with user input — only declare stable column conditions. Even when PostgreSQL introspection returns
+the predicate wrapped in parentheses, Sonamu treats it as the same condition in migration diffs.
 
 ### Adding Foreign Key
 

--- a/modules/docs/en/database/migrations/how-migrations-work.mdx
+++ b/modules/docs/en/database/migrations/how-migrations-work.mdx
@@ -325,14 +325,27 @@ table.foreign("user_id")
 {
   "indexes": [
     { "type": "unique", "column": "email" },
-    { "type": "index", "columns": ["username", "created_at"] }
+    { "type": "index", "columns": ["username", "created_at"] },
+    {
+      "type": "unique",
+      "name": "users_email_active_unique",
+      "columns": ["email"],
+      "where": "deleted_at IS NULL"
+    }
   ]
 }
 
 // Migration
 table.unique(["email"], "users_email_unique");
 table.index(["username", "created_at"], "users_username_created_at_index");
+await knex.raw(
+  `CREATE UNIQUE INDEX users_email_active_unique ON users (email) WHERE deleted_at IS NULL`,
+);
 ```
+
+`where` is a raw SQL predicate for creating a PostgreSQL partial index. Sonamu compares the
+predicate from DB introspection with the one in entity.json, and does not generate an additional
+migration if the conditions are equivalent.
 
 ## Advanced Features
 


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동으로 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 무엇을, 왜

영어 migration 문서 2개에서 entity partial index(`where` 절) 지원이 누락된 것을 수정합니다.

커밋 `71f68354`(SON-493)에서 entity에 `where` 속성을 통한 PostgreSQL partial index 선언 기능이 추가되었고, 한국어 문서는 같은 커밋에서 함께 업데이트되었습니다. 그러나 영어 migration 문서 2개에는 이 변경이 반영되지 않았습니다.

### 변경 내용

**`creating-migrations.mdx`** — "Adding Index" 섹션:
- Entity JSON 예제에 `where: "deleted_at IS NULL"` 항목 추가
- 생성되는 Migration에 `CREATE UNIQUE INDEX ... WHERE` 구문과 `DROP INDEX IF EXISTS` 롤백 추가
- `where`가 raw SQL predicate임을 안내하는 주의사항 추가

**`how-migrations-work.mdx`** — "Indexes" 섹션:
- Entity 인덱스 예제에 partial index 항목 추가
- 대응하는 migration 코드(`knex.raw`로 partial index 생성) 추가
- DB introspection과 entity.json 간 predicate 비교 동작 설명 추가

## 참조한 issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (작업 범위) — "문서와 주석이 코드와 어긋나는 경우" 및 "ko 문서 업데이트 후 en 문서도 업데이트"

## 이 작업을 선정한 이유

이슈 #44는 한국어 문서 업데이트 이후 영어 문서도 동기화해야 한다고 명시합니다. 커밋 `71f68354`에서 한국어 migration 문서는 partial index 지원으로 업데이트되었으나, 영어 문서는 누락되었습니다.

### 근거

- `modules/docs/ko/database/migrations/creating-migrations.mdx` (lines 222-262): partial index 예제, migration 코드, raw SQL 주의사항 포함 — **이미 반영됨**
- `modules/docs/ko/database/migrations/how-migrations-work.mdx` (lines 322-348): partial index 예제, migration 코드, introspection 설명 포함 — **이미 반영됨**
- `modules/docs/en/database/migrations/creating-migrations.mdx` (lines 218-246): partial index 누락 — **이번에 수정**
- `modules/docs/en/database/migrations/how-migrations-work.mdx` (lines 320-335): partial index 누락 — **이번에 수정**
- 기존 Nightly PR에서 이 부분이 다뤄진 적 없음

## 접근 방식

한국어 문서의 구조와 내용을 충실히 영어로 번역하여 동기화했습니다. 기존 영어 문서의 문체와 포매팅 패턴을 그대로 유지했습니다.

## 이렇게 하지 않으면

- 한국어 문서에서는 partial index 선언 방법과 migration 생성 결과를 확인할 수 있지만, 영어 문서에서는 `where` 속성에 대한 안내가 전혀 없어 영어권 사용자가 이 기능을 발견하지 못합니다.
- `en/tools-and-cli/sonamu-ui/entity-management.mdx`에서는 UI의 "Where" 필드가 이미 문서화되어 있어, UI 문서와 migration 문서 간 불일치가 발생합니다.

## 영향 범위

- **소스 코드 변경 없음** — 문서(`.mdx`)만 수정
- `modules/docs/en/database/migrations/creating-migrations.mdx`
- `modules/docs/en/database/migrations/how-migrations-work.mdx`

## 영향 확인 방법

1. `pnpm check` 통과 확인 (0 errors)
2. 수정된 영어 문서의 Entity JSON 예제와 migration 코드가 한국어 문서 및 실제 소스 코드(`code-generation.ts`)와 일치하는지 대조
3. Mintlify 프리뷰 배포에서 문서 렌더링 확인

## 추후 확인이 필요한 부분

없음. 한국어 문서에 이미 검증된 내용을 영어로 옮기는 작업이며, 소스 코드 변경이 없습니다.