### PR TITLE
[Nightly 2026-06-16] Entity 정의 문서에 partial index(where) 지원 추가 및 SSE 문서 기본 사용법 예제의 Context import 누락·return sse 패턴 수정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/advanced-features/sse/creating-sse-endpoints.mdx
+++ b/modules/docs/en/advanced-features/sse/creating-sse-endpoints.mdx
@@ -12,7 +12,7 @@ A decorator for defining SSE endpoints.
 ### Basic Usage
 
 ```typescript
-import { BaseModelClass, stream, z } from "sonamu";
+import { type Context, BaseModelClass, stream, z } from "sonamu";
 
 class NotificationModelClass extends BaseModelClass {
   @stream({
@@ -24,7 +24,7 @@ class NotificationModelClass extends BaseModelClass {
       }),
     }),
   })
-  async streamNotifications(userId: number, ctx: Context) {
+  async streamNotifications(userId: number, ctx: Context): Promise<void> {
     const sse = ctx.createSSE(
       z.object({
         notification: z.object({
@@ -42,8 +42,6 @@ class NotificationModelClass extends BaseModelClass {
 
     // Close connection
     await sse.end();
-
-    return sse;
   }
 }
 ```

--- a/modules/docs/en/core-concepts/entity/defining-entities.mdx
+++ b/modules/docs/en/core-concepts/entity/defining-entities.mdx
@@ -155,6 +155,25 @@ Defines database indexes.
 - `hnsw` - HNSW index for Vector search
 - `ivfflat` - IVFFlat index for Vector search
 
+**Partial Index**:
+
+Use the `where` field to define a PostgreSQL partial index. A partial index covers only rows matching the given condition, reducing index size and improving performance.
+
+```json
+{
+  "indexes": [
+    {
+      "type": "unique",
+      "name": "users_email_active_unique",
+      "columns": [{ "name": "email" }],
+      "where": "deleted_at IS NULL"
+    }
+  ]
+}
+```
+
+The `where` value is a raw SQL predicate without the `WHERE` keyword. It is used as-is in the generated migration, so never concatenate user input into this field.
+
 ### subsets
 
 Defines field combinations for API responses.

--- a/modules/docs/ko/advanced-features/sse/creating-sse-endpoints.mdx
+++ b/modules/docs/ko/advanced-features/sse/creating-sse-endpoints.mdx
@@ -12,7 +12,7 @@ SSE 엔드포인트를 정의하는 데코레이터입니다.
 ### 기본 사용법
 
 ```typescript
-import { BaseModelClass, stream, z } from "sonamu";
+import { type Context, BaseModelClass, stream, z } from "sonamu";
 
 class NotificationModelClass extends BaseModelClass {
   @stream({
@@ -24,7 +24,7 @@ class NotificationModelClass extends BaseModelClass {
       }),
     }),
   })
-  async streamNotifications(userId: number, ctx: Context) {
+  async streamNotifications(userId: number, ctx: Context): Promise<void> {
     const sse = ctx.createSSE(
       z.object({
         notification: z.object({
@@ -42,8 +42,6 @@ class NotificationModelClass extends BaseModelClass {
 
     // 연결 종료
     await sse.end();
-
-    return sse;
   }
 }
 ```

--- a/modules/docs/ko/core-concepts/entity/defining-entities.mdx
+++ b/modules/docs/ko/core-concepts/entity/defining-entities.mdx
@@ -152,6 +152,25 @@ Entity의 속성(컬럼) 배열입니다. 각 속성은 타입과 옵션을 정�
 - `hnsw` - Vector 검색용 HNSW 인덱스
 - `ivfflat` - Vector 검색용 IVFFlat 인덱스
 
+**Partial Index (조건부 인덱스)**:
+
+`where` 필드를 사용하면 PostgreSQL partial index를 정의할 수 있습니다. 특정 조건을 만족하는 행에만 인덱스를 생성하여 인덱스 크기를 줄이고 성능을 높일 수 있습니다.
+
+```json
+{
+  "indexes": [
+    {
+      "type": "unique",
+      "name": "users_email_active_unique",
+      "columns": [{ "name": "email" }],
+      "where": "deleted_at IS NULL"
+    }
+  ]
+}
+```
+
+`where`에는 `WHERE` 키워드를 제외한 SQL 조건식을 입력합니다. 이 값은 마이그레이션 생성 시 그대로 사용되므로 사용자 입력을 조합하지 마세요.
+
 ### subsets
 
 API 응답에서 사용할 필드 조합을 정의합니다.


### PR DESCRIPTION
이 PR은 AI(Claude)에 의해 자동 생성되었습니다. 코드베이스 ownership은 여전히 사람에게 있으며, 이 PR의 모든 변경은 리뷰어의 판단에 따라 수정·보류·거부될 수 있습니다.

## 참조한 Issue

- #44 (내일 새벽에 AI에게 맡길 일들)
- #43 (Nightly PR Directions)

## 이 PR은 무엇인가

sonamu-docs의 한국어/영어 문서 4개 파일에서 발견된 코드-문서 불일치 2건을 수정합니다.

## 왜 이 작업을 선정했는가

1. **Entity 정의 문서의 partial index 누락**: SON-493에서 `entity partial index` 지원이 추가되었고 `creating-migrations.mdx`에는 `where` 절이 이미 문서화되어 있지만, 사용자가 entity를 정의할 때 가장 먼저 참조하는 `defining-entities.mdx`의 `indexes` 섹션에는 `where` 필드가 언급되지 않았습니다. 사용자가 partial index 기능의 존재 자체를 인지하지 못할 수 있습니다.

2. **SSE 기본 사용법 예제의 오류**: `creating-sse-endpoints.mdx`의 기본 사용법(Basic Usage) 코드 예제에서 `Context` type을 import하지 않고 사용하고 있었고, 메서드가 `return sse`로 끝나는데 이는 나머지 모든 실전 예제(`Promise<void>` 반환, return 없음)와 일관되지 않습니다. 이 예제를 그대로 따라하면 TypeScript에서 `Context`를 찾을 수 없다는 에러가 발생합니다.

## 어떤 접근 방식을 채택했는가

- **Entity 문서**: `EntityIndex` 타입 정의(`types.ts:413`)의 `where?: string` 필드와 `creating-migrations.mdx`의 기존 partial index 설명을 근거로, `defining-entities.mdx`의 인덱스 타입 목록 바로 뒤에 Partial Index 섹션을 추가했습니다. `deleted_at IS NULL` 조건의 unique index 예제를 포함하여 실용적인 사용법을 보여줍니다.
- **SSE 문서**: 기본 사용법 예제만 수정했습니다. `import { type Context, BaseModelClass, stream, z } from "sonamu"`로 Context import를 추가하고, 반환 타입을 `Promise<void>`로 명시하며, `return sse` 행을 제거했습니다. 나머지 실전 예제들은 이미 올바른 패턴을 사용하고 있어 수정하지 않았습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가

- Entity partial index 기능이 코드에는 존재하지만 정의 문서에서 발견할 수 없어, 사용자가 partial index를 쓰려면 migration 문서나 타입 정의를 직접 뒤져야 합니다.
- SSE 문서의 기본 사용법을 그대로 복사하면 `Context` type을 찾을 수 없다는 컴파일 에러가 발생합니다.

## 영향 범위

문서 전용 변경이며 소스 코드에는 영향이 없습니다.

| 파일 | 변경 내용 |
|------|-----------|
| `modules/docs/ko/core-concepts/entity/defining-entities.mdx` | indexes 섹션에 Partial Index(where) 설명 추가 |
| `modules/docs/en/core-concepts/entity/defining-entities.mdx` | 동일 내용 영어 동기화 |
| `modules/docs/ko/advanced-features/sse/creating-sse-endpoints.mdx` | Context import 추가, return sse 제거, Promise<void> 반환 타입 명시 |
| `modules/docs/en/advanced-features/sse/creating-sse-endpoints.mdx` | 동일 내용 영어 동기화 |

## 변경 영향 확인 방법

1. `pnpm check` 통과 확인 (에러 0건)
2. `defining-entities.mdx`에서 "Partial Index" 섹션이 인덱스 타입 목록과 subsets 섹션 사이에 위치하는지 확인
3. `creating-sse-endpoints.mdx`의 기본 사용법 예제에서 `import { type Context, ...}` 구문이 있고 `return sse`가 없는지 확인

## 사람의 확인이 필요한 부분

- Entity partial index 예제에서 `deleted_at IS NULL` 조건을 사용했는데, 프로젝트에서 더 대표적인 partial index 사용 사례가 있다면 예제를 교체해도 좋습니다.
- SSE 기본 사용법의 `ctx.createSSE()`에 events 스키마를 중복 전달하는 패턴은 현재 API 시그니처의 제약이므로 그대로 두었습니다. 향후 `context.ts:4`의 NOTE에 언급된 대로 createSSE가 인자 없이 호출 가능해지면 예제도 함께 정리하면 좋겠습니다.