### PR TITLE
[Nightly 2026-06-17] forUpdate/forShare 잠금 호환성 표의 일반 SELECT 차단 오기재 수정 및 프론트엔드 SonamuFile declaration merging 대상 모듈 정정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/api-reference/puri-methods/advanced-methods.mdx
+++ b/modules/docs/en/api-reference/puri-methods/advanced-methods.mdx
@@ -170,10 +170,14 @@ async getBalanceSnapshot(userId: number) {
 
 **forUpdate vs forShare:**
 
-| Lock Type | Other Transaction Reads | Other Transaction Writes | When to Use |
-|---|---|---|---|
-| `forUpdate()` | Blocked | Blocked | When reading then modifying |
-| `forShare()` | Allowed | Blocked | When only read consistency is needed |
+| Lock Type | Plain SELECT | Other Lock Requests (FOR UPDATE / FOR SHARE) | Writes (UPDATE / DELETE) | When to Use |
+|---|---|---|---|---|
+| `forUpdate()` | Allowed | Blocked | Blocked | When reading then modifying |
+| `forShare()` | Allowed | FOR UPDATE only | Blocked | When only read consistency is needed |
+
+<Note>
+  Under PostgreSQL MVCC, row-level locks (`FOR UPDATE` / `FOR SHARE`) do not block plain `SELECT` reads. Only other lock requests and write operations on the same rows are blocked.
+</Note>
 
 <Warning>
   `forUpdate()` and `forShare()` are only meaningful within a transaction. Without a transaction, the lock is released immediately.

--- a/modules/docs/en/frontend-integration/getting-started/setup.mdx
+++ b/modules/docs/en/frontend-integration/getting-started/setup.mdx
@@ -254,9 +254,9 @@ Both `SonamuFile` and `UploadParams` can be extended with project-specific field
 
 ```typescript
 // src/types/sonamu-file-extend.d.ts
-import "sonamu";
+import "@sonamu-kit/react-components";
 
-declare module "sonamu" {
+declare module "@sonamu-kit/react-components" {
   interface SonamuFileExtend {
     thumbnailUrl?: string;
     category?: string;
@@ -269,7 +269,7 @@ declare module "sonamu" {
 }
 ```
 
-This follows the same declaration merging pattern as `ContextExtend`.
+Since the frontend imports `SonamuFile` and `UploadParams` from `@sonamu-kit/react-components`, the declaration merging target must be the same module.
 
 </Info>
 

--- a/modules/docs/ko/api-reference/puri-methods/advanced-methods.mdx
+++ b/modules/docs/ko/api-reference/puri-methods/advanced-methods.mdx
@@ -170,10 +170,14 @@ async getBalanceSnapshot(userId: number) {
 
 **forUpdate vs forShare:**
 
-| 잠금 유형 | 다른 트랜잭션의 읽기 | 다른 트랜잭션의 수정 | 사용 시점 |
-|---|---|---|---|
-| `forUpdate()` | 대기 | 대기 | 읽은 뒤 수정할 때 |
-| `forShare()` | 허용 | 대기 | 읽기 일관성만 필요할 때 |
+| 잠금 유형 | 일반 SELECT | 다른 잠금 요청 (FOR UPDATE / FOR SHARE) | 수정 (UPDATE / DELETE) | 사용 시점 |
+|---|---|---|---|---|
+| `forUpdate()` | 허용 | 대기 | 대기 | 읽은 뒤 수정할 때 |
+| `forShare()` | 허용 | FOR UPDATE만 대기 | 대기 | 읽기 일관성만 필요할 때 |
+
+<Note>
+  PostgreSQL MVCC 하에서 행 잠금(`FOR UPDATE` / `FOR SHARE`)은 일반 `SELECT` 읽기를 차단하지 않습니다. 차단되는 것은 같은 행에 대한 다른 잠금 요청과 수정 작업입니다.
+</Note>
 
 <Warning>
   `forUpdate()`와 `forShare()`는 트랜잭션 내에서만 의미가 있습니다. 트랜잭션 없이 사용하면 잠금이 즉시 해제됩니다.

--- a/modules/docs/ko/frontend-integration/getting-started/setup.mdx
+++ b/modules/docs/ko/frontend-integration/getting-started/setup.mdx
@@ -254,9 +254,9 @@ interface UploadParams {}
 
 ```typescript
 // src/types/sonamu-file-extend.d.ts
-import "sonamu";
+import "@sonamu-kit/react-components";
 
-declare module "sonamu" {
+declare module "@sonamu-kit/react-components" {
   interface SonamuFileExtend {
     thumbnailUrl?: string;
     category?: string;
@@ -269,7 +269,7 @@ declare module "sonamu" {
 }
 ```
 
-이 패턴은 `ContextExtend`와 동일한 declaration merging 방식입니다.
+프론트엔드에서 `SonamuFile`과 `UploadParams`는 `@sonamu-kit/react-components`에서 import하므로, declaration merging 대상도 동일한 모듈이어야 합니다.
 
 </Info>
 


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 참조한 Issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (내일 새벽에 AI에게 맡길 일들) — "문서와 주석이 코드와 어긋나는 경우 업데이트"
- #189 (Nightly로 올린 PR의 Comment 확인) — chatgpt-codex-connector의 미조치 코멘트 반영 의무

## 이 PR은 무엇인가

기존 Nightly PR에 달렸으나 아직 조치되지 않은 chatgpt-codex-connector 리뷰 코멘트 2건을 수정합니다.

## 왜 이 작업을 선정했는가

issue #189에 따르면, Nightly PR에 chatgpt-codex-connector의 comment가 달리면 반드시 확인하고 수용 시 수정해야 합니다. 다음 2건의 코멘트가 아직 미조치 상태였으며, 두 건 모두 실제 소스 코드와 대조한 결과 지적이 타당하다고 판단했습니다:

1. **PR #190 코멘트**: forUpdate/forShare 잠금 호환성 표에서 `forUpdate()`가 "다른 트랜잭션의 읽기"를 차단(대기)한다고 표기되어 있으나, PostgreSQL MVCC에서 행 잠금은 일반 SELECT를 차단하지 않음
2. **PR #186 코멘트**: 프론트엔드 설정 문서에서 `declare module "sonamu"`로 `SonamuFileExtend`/`UploadParams`를 augment하도록 안내하고 있으나, 실제 프론트엔드에서 이 타입들은 `@sonamu-kit/react-components`에서 import하므로 declaration merging 대상이 잘못됨

## 어떤 접근 방식을 채택했는가

### 수정 1: forUpdate/forShare 잠금 호환성 표 (ko/en 2파일)

기존의 "다른 트랜잭션의 읽기 / 수정" 2열 구조를 **"일반 SELECT / 다른 잠금 요청 / 수정"** 3열로 개편하여, PostgreSQL의 실제 잠금 동작을 정확하게 반영했습니다:

| 잠금 유형 | 일반 SELECT | 다른 잠금 요청 (FOR UPDATE / FOR SHARE) | 수정 (UPDATE / DELETE) |
|---|---|---|---|
| `forUpdate()` | 허용 | 대기 | 대기 |
| `forShare()` | 허용 | FOR UPDATE만 대기 | 대기 |

또한 MVCC 동작을 명시하는 Note 블록을 추가하여, 행 잠금이 일반 읽기를 차단하지 않는다는 점을 강조했습니다.

**근거**: PostgreSQL 공식 문서(Explicit Locking)에 따르면, FOR UPDATE는 같은 행에 대한 다른 FOR UPDATE/FOR SHARE/FOR NO KEY UPDATE/FOR KEY SHARE 잠금과 UPDATE/DELETE만 차단하며, 일반 SELECT는 MVCC 스냅샷을 통해 항상 읽을 수 있습니다. sonamu의 `puri.ts:940-948`에서 `forUpdate()`/`forShare()`는 Knex의 동명 메서드를 직접 위임하므로, PostgreSQL의 기본 동작이 그대로 적용됩니다.

### 수정 2: SonamuFile/UploadParams declaration merging 대상 모듈 (ko/en 2파일)

`declare module "sonamu"` → `declare module "@sonamu-kit/react-components"`로 수정했습니다.

**근거**: `modules/react-components/src/contexts/types.ts`의 주석(7행, 24행)에서 명시적으로 `declare module "@sonamu-kit/react-components"`를 사용하도록 안내하고 있으며, 프론트엔드 설정 문서의 import 구문(49행)도 `@sonamu-kit/react-components`에서 `SonamuFile`을 import하고 있습니다. TypeScript의 declaration merging은 import 소스와 동일한 모듈을 대상으로 해야 실제로 타입이 확장됩니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가

1. **잠금 호환성 표**: 사용자가 forUpdate()가 다른 트랜잭션의 읽기를 차단한다고 오해하여, 불필요하게 트랜잭션 범위를 줄이거나 forShare()로 전환하는 등의 최적화 노력을 하게 됩니다. 실제로 PostgreSQL에서 일반 SELECT는 어떤 행 잠금에도 차단되지 않으므로, 이런 최적화는 의미가 없습니다.
2. **declaration merging 대상**: `declare module "sonamu"`로 augment하면, 프론트엔드에서 `@sonamu-kit/react-components`에서 import한 `SonamuFile` 타입에 추가 필드가 반영되지 않습니다. 사용자가 문서를 따라 했는데 확장 필드가 보이지 않아 혼란을 겪게 됩니다.

## 영향 범위

문서 전용 변경이며 소스 코드에는 영향이 없습니다.

| 파일 | 변경 내용 |
|------|-----------|
| `modules/docs/ko/api-reference/puri-methods/advanced-methods.mdx` | 잠금 호환성 표 3열 개편 + MVCC Note 추가 |
| `modules/docs/en/api-reference/puri-methods/advanced-methods.mdx` | 동일 (영어) |
| `modules/docs/ko/frontend-integration/getting-started/setup.mdx` | `declare module` 대상을 `@sonamu-kit/react-components`로 변경 |
| `modules/docs/en/frontend-integration/getting-started/setup.mdx` | 동일 (영어) |

## 확인 방법

1. `pnpm check` 통과 확인 완료 (경고 8건, 에러 0건 — 기존과 동일)
2. `grep -rn 'declare module "sonamu"' modules/docs/` 결과 0건으로 잘못된 augment 패턴 잔존 없음 확인
3. 잠금 호환성 표는 PostgreSQL 공식 문서(Explicit Locking 섹션)와 대조하여 검증함

## 사람의 확인이 필요한 부분

- **잠금 호환성 표의 forShare() 행**: `forShare()`가 다른 `FOR SHARE`는 허용하되 `FOR UPDATE`만 차단하는 것은 PostgreSQL 표준 동작이나, sonamu 프로젝트에서 특별히 다른 의미를 부여하고 있는지 확인이 필요합니다.
- **declaration merging**: 서버 사이드에서도 동일한 SonamuFile 확장이 필요한 경우, `sonamu` 패키지 쪽에도 별도의 augment 예제가 필요할 수 있습니다. 이 PR은 프론트엔드 설정 문서만 수정하므로, 서버 사이드 문서가 별도로 존재하는 경우 추가 수정이 필요할 수 있습니다.