### PR TITLE
[Nightly 2026-06-18] 문서 코드 예제의 미존재 예외 클래스명 및 잘못된 서브모듈 import 경로 일괄 수정 (ko/en 17파일)

### DIFF
--- a/modules/docs/en/advanced-features/caching/cache-configuration.mdx
+++ b/modules/docs/en/advanced-features/caching/cache-configuration.mdx
@@ -24,7 +24,8 @@ BentoCache is a TypeScript cache library that supports multi-tier caching.
 Add cache configuration to the `server.cache` field in `sonamu.config.ts`:
 
 ```typescript
-import { drivers, store, type SonamuConfig } from "sonamu";
+import { drivers, store } from "sonamu/cache";
+import type { SonamuConfig } from "sonamu";
 
 export const config: SonamuConfig = {
   // ... other settings

--- a/modules/docs/en/api-development/file-upload/saving-files.mdx
+++ b/modules/docs/en/api-development/file-upload/saving-files.mdx
@@ -29,8 +29,6 @@ Learn how to save files to local, S3, GCS, and other storage using Sonamu's Stor
 The `saveToDisk()` method of `UploadedFile` is the simplest way to save files.
 
 ```typescript
-import type { UploadedFile } from "sonamu";
-
 class FileModel extends BaseModelClass {
   @upload()
   async upload(): Promise<{ url: string }> {
@@ -130,7 +128,7 @@ class FileModel extends BaseModelClass {
 
 ```typescript
 // storage.config.ts
-import type { StorageConfig } from "sonamu";
+import type { StorageConfig } from "sonamu/storage";
 
 export const storageConfig: StorageConfig = {
   default: "local", // Default disk

--- a/modules/docs/en/api-development/file-upload/setup.mdx
+++ b/modules/docs/en/api-development/file-upload/setup.mdx
@@ -28,7 +28,6 @@ Sonamu allows you to easily handle file uploads through the `@upload` decorator.
 
 ```typescript
 import { BaseModelClass, api, upload } from "sonamu";
-import type { UploadedFile } from "sonamu";
 import type { FileSubsetKey, FileSubsetMapping } from "../sonamu.generated";
 import { fileLoaderQueries, fileSubsetQueries } from "../sonamu.generated.sso";
 
@@ -155,7 +154,7 @@ Sonamu provides a Storage Manager that manages multiple storages in an integrate
 
 ```typescript
 // storage.config.ts
-import type { StorageConfig } from "sonamu";
+import type { StorageConfig } from "sonamu/storage";
 
 export const storageConfig: StorageConfig = {
   default: "local", // Default disk

--- a/modules/docs/en/api-reference/decorators/api.mdx
+++ b/modules/docs/en/api-reference/decorators/api.mdx
@@ -109,7 +109,7 @@ async downloadFile(fileId: number, ctx: Context) {
     .first();
 
   if (!file) {
-    throw new NotFoundError("File not found");
+    throw new NotFoundException("File not found");
   }
 
   // Read file from storage

--- a/modules/docs/en/faq/testing.mdx
+++ b/modules/docs/en/faq/testing.mdx
@@ -303,7 +303,7 @@ describe("User API", () => {
 <Accordion title="How do I test errors?">
 
 ```typescript
-import { BadRequestError, NotFoundError } from "sonamu";
+import { BadRequestException, NotFoundException, UnauthorizedException } from "sonamu";
 
 describe("User API Errors", () => {
   test("createUser - duplicate email", async () => {
@@ -312,17 +312,17 @@ describe("User API Errors", () => {
         name: "Test",
         email: "john@example.com", // Already exists
       }),
-    ).rejects.toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestException);
   });
 
   test("findById - non-existent ID", async () => {
-    await expect(UserModel.findById(99999)).rejects.toThrow(NotFoundError);
+    await expect(UserModel.findById(99999)).rejects.toThrow(NotFoundException);
   });
 
   test("deleteUser - no permission", async () => {
     await expect(
       UserModel.deleteUser(1), // Permission check fails
-    ).rejects.toThrow(ForbiddenError);
+    ).rejects.toThrow(UnauthorizedException);
   });
 });
 ```

--- a/modules/docs/en/tools-and-cli/hmr/boundaries.mdx
+++ b/modules/docs/en/tools-and-cli/hmr/boundaries.mdx
@@ -325,7 +325,7 @@ export class ProductModel extends BaseModelClass {
 
   async reserveStock(quantity: number) {
     if (!this.hasStock(quantity)) {
-      throw new BadRequestError("Out of stock");
+      throw new BadRequestException("Out of stock");
     }
 
     await this.update({ stock: this.stock - quantity });

--- a/modules/docs/en/tools-and-cli/hmr/how-hmr-works.mdx
+++ b/modules/docs/en/tools-and-cli/hmr/how-hmr-works.mdx
@@ -231,7 +231,7 @@ async create(body: PostForm) {
   const user = await UserModel.findById(body.userId);
 
   if (!user.isActive()) {  // 👈 Use the method just added!
-    throw new BadRequestError("User is not active");
+    throw new BadRequestException("User is not active");
   }
 
   return PostModel.save(body);

--- a/modules/docs/ko/advanced-features/caching/cache-configuration.mdx
+++ b/modules/docs/ko/advanced-features/caching/cache-configuration.mdx
@@ -24,7 +24,8 @@ BentoCache는 Multi-tier 캐싱을 지원하는 TypeScript 캐시 라이브러�
 `sonamu.config.ts`의 `server.cache` 필드에 캐시 설정을 추가합니다:
 
 ```typescript
-import { drivers, store, type SonamuConfig } from "sonamu";
+import { drivers, store } from "sonamu/cache";
+import type { SonamuConfig } from "sonamu";
 
 export const config: SonamuConfig = {
   // ... 기타 설정

--- a/modules/docs/ko/advanced-features/caching/cache-decorator.mdx
+++ b/modules/docs/ko/advanced-features/caching/cache-decorator.mdx
@@ -650,7 +650,7 @@ class DashboardModelClass extends BaseModelClass {
 
     // 권한 체크
     if (context.user?.id !== userId && context.user?.role !== "admin") {
-      throw new ForbiddenError();
+      throw new UnauthorizedException();
     }
 
     // 대시보드 데이터 조회

--- a/modules/docs/ko/api-development/file-upload/saving-files.mdx
+++ b/modules/docs/ko/api-development/file-upload/saving-files.mdx
@@ -128,7 +128,7 @@ class FileModel extends BaseModelClass {
 
 ```typescript
 // storage.config.ts
-import type { StorageConfig } from "sonamu";
+import type { StorageConfig } from "sonamu/storage";
 
 export const storageConfig: StorageConfig = {
   default: "local", // 기본 디스크

--- a/modules/docs/ko/api-development/file-upload/setup.mdx
+++ b/modules/docs/ko/api-development/file-upload/setup.mdx
@@ -28,7 +28,6 @@ Sonamu는 `@upload` 데코레이터를 통해 파일 업로드를 간편하게 �
 
 ```typescript
 import { BaseModelClass, api, upload } from "sonamu";
-import type { UploadedFile } from "sonamu";
 import type { FileSubsetKey, FileSubsetMapping } from "../sonamu.generated";
 import { fileLoaderQueries, fileSubsetQueries } from "../sonamu.generated.sso";
 
@@ -155,7 +154,7 @@ Sonamu는 여러 스토리지를 통합 관리하는 Storage Manager를 제공�
 
 ```typescript
 // storage.config.ts
-import type { StorageConfig } from "sonamu";
+import type { StorageConfig } from "sonamu/storage";
 
 export const storageConfig: StorageConfig = {
   default: "local", // 기본 디스크

--- a/modules/docs/ko/api-reference/decorators/api.mdx
+++ b/modules/docs/ko/api-reference/decorators/api.mdx
@@ -109,7 +109,7 @@ async downloadFile(fileId: number, ctx: Context) {
     .first();
 
   if (!file) {
-    throw new NotFoundError("파일을 찾을 수 없습니다");
+    throw new NotFoundException("파일을 찾을 수 없습니다");
   }
 
   // Storage에서 파일 읽기

--- a/modules/docs/ko/database/subsets/nested-relations.mdx
+++ b/modules/docs/ko/database/subsets/nested-relations.mdx
@@ -857,7 +857,7 @@ class EmployeeModelClass extends BaseModelClass {
   ): EmployeeTreeNode {
     const employee = employeeMap.get(employeeId);
     if (!employee) {
-      throw new NotFoundError(`직원 ${employeeId}를 찾을 수 없습니다`);
+      throw new NotFoundException(`직원 ${employeeId}를 찾을 수 없습니다`);
     }
 
     // 직속 부하 찾기

--- a/modules/docs/ko/database/transactions/best-practices.mdx
+++ b/modules/docs/ko/database/transactions/best-practices.mdx
@@ -695,7 +695,7 @@ class InventoryModelClass extends BaseModelClass {
       const product = await wdb.table("products").where("id", item.productId).first();
 
       if (!product || product.stock < item.quantity) {
-        throw new BadRequestError(`상품 ${item.productId}의 재고가 부족합니다.`);
+        throw new BadRequestException(`상품 ${item.productId}의 재고가 부족합니다.`);
       }
 
       // 재고 차감
@@ -836,11 +836,11 @@ class ProductModelClass extends BaseModelClass {
       .first();
 
     if (!product) {
-      throw new NotFoundError("상품을 찾을 수 없습니다");
+      throw new NotFoundException("상품을 찾을 수 없습니다");
     }
 
     if (product.stock < quantity) {
-      throw new BadRequestError("재고가 부족합니다");
+      throw new BadRequestException("재고가 부족합니다");
     }
 
     // 재고 차감
@@ -947,7 +947,7 @@ class PaymentModelClass extends BaseModelClass {
     // 1. 주문 정보 조회 (읽기 전용)
     const order = await this.findOrderById(orderId);
     if (!order) {
-      throw new NotFoundError("주문을 찾을 수 없습니다");
+      throw new NotFoundException("주문을 찾을 수 없습니다");
     }
 
     // 2. 외부 결제 API 호출 (트랜잭션 밖)

--- a/modules/docs/ko/faq/testing.mdx
+++ b/modules/docs/ko/faq/testing.mdx
@@ -303,7 +303,7 @@ describe("User API", () => {
 <Accordion title="에러를 테스트하려면?">
 
 ```typescript
-import { BadRequestError, NotFoundError } from "sonamu";
+import { BadRequestException, NotFoundException, UnauthorizedException } from "sonamu";
 
 describe("User API Errors", () => {
   test("createUser - 이메일 중복", async () => {
@@ -312,17 +312,17 @@ describe("User API Errors", () => {
         name: "Test",
         email: "john@example.com", // 이미 존재
       }),
-    ).rejects.toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestException);
   });
 
   test("findById - 존재하지 않는 ID", async () => {
-    await expect(UserModel.findById(99999)).rejects.toThrow(NotFoundError);
+    await expect(UserModel.findById(99999)).rejects.toThrow(NotFoundException);
   });
 
   test("deleteUser - 권한 없음", async () => {
     await expect(
       UserModel.deleteUser(1), // 권한 체크 실패
-    ).rejects.toThrow(ForbiddenError);
+    ).rejects.toThrow(UnauthorizedException);
   });
 });
 ```

--- a/modules/docs/ko/tools-and-cli/hmr/boundaries.mdx
+++ b/modules/docs/ko/tools-and-cli/hmr/boundaries.mdx
@@ -325,7 +325,7 @@ export class ProductModel extends BaseModelClass {
 
   async reserveStock(quantity: number) {
     if (!this.hasStock(quantity)) {
-      throw new BadRequestError("Out of stock");
+      throw new BadRequestException("Out of stock");
     }
 
     await this.update({ stock: this.stock - quantity });

--- a/modules/docs/ko/tools-and-cli/hmr/how-hmr-works.mdx
+++ b/modules/docs/ko/tools-and-cli/hmr/how-hmr-works.mdx
@@ -231,7 +231,7 @@ async create(body: PostForm) {
   const user = await UserModel.findById(body.userId);
 
   if (!user.isActive()) {  // 👈 방금 추가한 메서드 바로 사용!
-    throw new BadRequestError("User is not active");
+    throw new BadRequestException("User is not active");
   }
 
   return PostModel.save(body);


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 참조한 Issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (내일 새벽에 AI에게 맡길 일들) — "문서와 주석이 코드와 어긋나는 경우 업데이트"

## 이 PR은 무엇인가

sonamu 문서(.mdx)의 코드 예제에서 **실제로 존재하지 않는 예외 클래스명** 및 **잘못된 import 경로**를 사용하고 있는 부분을 소스코드의 실제 export에 맞춰 일괄 수정합니다.

## 왜 이 작업을 선정했는가

문서의 코드 예제를 그대로 따라하면 컴파일 에러가 발생하는 명백한 불일치가 다수 존재했습니다:

1. **예외 클래스명 불일치 (11파일, 20개소)**:
   - `BadRequestError` → sonamu에 존재하지 않음, 실제는 `BadRequestException`
   - `NotFoundError` → sonamu에 존재하지 않음, 실제는 `NotFoundException`
   - `ForbiddenError` → sonamu에 존재하지 않음, 가장 가까운 것은 `UnauthorizedException`
   - 근거: `modules/sonamu/src/exceptions/so-exceptions.ts`의 export 확인

2. **Import 경로 불일치 (6파일)**:
   - `drivers`, `store`: `"sonamu"` 메인에서 export되지 않음 → `"sonamu/cache"`가 올바른 경로
   - `StorageConfig`: `"sonamu"` 메인에서 export되지 않음 → `"sonamu/storage"`가 올바른 경로
   - `UploadedFile`: `"sonamu"` 메인에서 export되지 않으며, 코드 예제에서 실제 사용되지 않는 dead import → 제거
   - 근거: `modules/sonamu/src/index.ts`, `modules/sonamu/src/cache/index.ts`, `modules/sonamu/src/storage/index.ts`의 export 확인

## 기존 Nightly PR과의 관계

PR #187에서 동일한 예외 클래스명 수정이 시도된 바 있으나, 해당 PR에 함께 포함된 `workflows.destroy()` 이중 호출 수정이 타당하지 않다는 리뷰(Nebu1eto)에 따라 PR 전체가 close되었습니다. 이번 PR에서는 **문서 수정만 분리**하여 제출합니다.

## 어떤 접근 방식을 채택했는가

- 소스코드의 실제 export를 기준으로 1:1 대응하는 올바른 클래스명/경로로 교체
- `ForbiddenError`는 sonamu에 `ForbiddenException`이 존재하지 않으므로, HTTP 401에 해당하는 `UnauthorizedException`으로 교체 (sonamu에서 가장 가까운 의미의 예외)
- 코드에서 사용되지 않는 `UploadedFile` import는 삭제 (코드 예제가 `bufferedFiles`를 사용)
- 소스코드 변경 없이 문서(.mdx) 파일만 수정

## 이렇게 하지 않으면 어떤 점이 안 좋은가

- 사용자가 문서의 코드 예제를 복사하면 즉시 TypeScript 컴파일 에러가 발생
- 올바른 클래스명/import 경로를 찾기 위해 소스코드를 직접 탐색해야 하는 불필요한 비용 발생
- 특히 `BadRequestError`와 `BadRequestException`은 충분히 혼동될 수 있어 디버깅 시간 소요

## 영향 범위

- **문서 전용 변경**: 소스코드 변경 없음, 빌드/런타임 영향 없음
- 한국어 문서 9파일, 영어 문서 8파일 (총 17파일)
- `pnpm check` (oxlint + oxfmt) 통과 확인

## 변경 확인 방법

```bash
# 잘못된 예외 클래스명이 더 이상 없는지 확인
grep -rn "BadRequestError\|NotFoundError\|ForbiddenError" modules/docs/ --include="*.mdx"
# (결과 없음이면 정상)

# 잘못된 import 경로가 더 이상 없는지 확인
grep -rn 'from "sonamu"' modules/docs/ --include="*.mdx" | grep -E "drivers|store[^:]|UploadedFile|StorageConfig"
# (SonamuConfig만 남아 있으면 정상 — SonamuConfig는 sonamu 메인에서 올바르게 export됨)
```

## 사람의 확인이 필요한 부분

- `ForbiddenError` → `UnauthorizedException` 교체: sonamu에 `ForbiddenException`(403)이 없어 `UnauthorizedException`(401)로 대체했습니다. 의미적으로 "권한 없음"이라는 맥락에서 적절하다고 판단했으나, 만약 403 전용 예외가 필요하다면 별도 검토가 필요할 수 있습니다.