### PR TITLE
[Nightly 2026-06-19] 문서 코드 예제의 knex.raw()/getDB() 패턴을 Puri 정적 메서드(count/sum/avg/rawNumber/rawString) 기반으로 교체 (ko/en 10파일)

### DIFF
--- a/modules/docs/en/core-concepts/entity/field-types.mdx
+++ b/modules/docs/en/core-concepts/entity/field-types.mdx
@@ -655,7 +655,7 @@ Virtual fields not stored in the database.
     // Used in {entity}.model.ts subset queries
     const { qb } = this.getSubsetQueries(subset);
     qb.appendSelect({
-      full_name: this.getPuri("r").raw("first_name || ' ' || last_name"),
+      full_name: Puri.rawString("first_name || ' ' || last_name"),
     });
     ```
     

--- a/modules/docs/en/core-concepts/model/basemodel-methods.mdx
+++ b/modules/docs/en/core-concepts/model/basemodel-methods.mdx
@@ -741,16 +741,14 @@ async findMany<T extends UserSubsetKey>(
 
 ```typescript
 async getStatistics(): Promise<UserStatistics> {
-  const rdb = this.getDB("r");
-
-  const [stats] = await rdb("users")
-    .select([
-      rdb.raw("COUNT(*) as total_users"),
-      rdb.raw("COUNT(CASE WHEN is_active THEN 1 END) as active_users"),
-      rdb.raw("COUNT(CASE WHEN role = 'admin' THEN 1 END) as admin_count"),
-      rdb.raw("AVG(age) as average_age"),
-    ])
-    .first();
+  const [stats] = await this.getPuri("r")
+    .table("users")
+    .select({
+      total_users: Puri.count(),
+      active_users: Puri.rawNumber("COUNT(CASE WHEN is_active THEN 1 END)"),
+      admin_count: Puri.rawNumber("COUNT(CASE WHEN role = 'admin' THEN 1 END)"),
+      average_age: Puri.avg("age"),
+    });
 
   return {
     total_users: Number(stats.total_users),

--- a/modules/docs/en/troubleshooting/performance/caching-strategies.mdx
+++ b/modules/docs/en/troubleshooting/performance/caching-strategies.mdx
@@ -118,7 +118,7 @@ class ProductModelClass extends BaseModelClass {
   // Cache for 1 day
   @cache({ ttl: "1d" })
   async getCategoryCounts() {
-    return this.getPuri("r").table("products").select("category", knex.raw("COUNT(*) as count")).groupBy("category");
+    return this.getPuri("r").table("products").select({ category: "category", count: Puri.count() }).groupBy("category");
   }
 
   // Permanent cache (requires manual invalidation)

--- a/modules/docs/en/troubleshooting/performance/n-plus-one-problems.mdx
+++ b/modules/docs/en/troubleshooting/performance/n-plus-one-problems.mdx
@@ -394,12 +394,12 @@ class DashboardService {
   async getDashboardFast() {
     return UserModel.getPuri("r")
       .table("users")
-      .select(
-        "users.id",
-        "users.name",
-        knex.raw("COUNT(orders.id) as order_count"),
-        knex.raw("COALESCE(SUM(orders.total), 0) as total_spent"),
-      )
+      .select({
+        id: "users.id",
+        name: "users.name",
+        order_count: Puri.count("orders.id"),
+        total_spent: Puri.rawNumber("COALESCE(SUM(orders.total), 0)"),
+      })
       .leftJoin("orders", "orders.user_id", "users.id")
       .groupBy("users.id");
   }

--- a/modules/docs/en/troubleshooting/performance/query-optimization.mdx
+++ b/modules/docs/en/troubleshooting/performance/query-optimization.mdx
@@ -173,10 +173,14 @@ const count = result[0].count;
 ```typescript
 // Order statistics
 const orderStats = await OrderModel.getPuri("r").table("orders")
-  .select("user_id", knex.raw("COUNT(*) as order_count"), knex.raw("SUM(total) as total_amount"))
+  .select({
+    user_id: "user_id",
+    order_count: Puri.count(),
+    total_amount: Puri.sum("total"),
+  })
   .where({ status: "completed" })
   .groupBy("user_id")
-  .having(knex.raw("COUNT(*) > ?", [10])); // More than 10 orders
+  .having("order_count", ">", 10); // More than 10 orders
 ```
 
 ## Pagination Optimization
@@ -246,15 +250,19 @@ const usersWithOrders = await UserModel.getPuri("r").table("users")
 
 ```typescript
 // Subquery - avoid
-const users = await UserModel.getPuri("r").table("users").select(
-  "id",
-  "name",
-  knex.raw("(SELECT COUNT(*) FROM orders WHERE orders.user_id = users.id) as order_count"),
-);
+const users = await UserModel.getPuri("r").table("users").select({
+  id: "id",
+  name: "name",
+  order_count: Puri.rawNumber("(SELECT COUNT(*) FROM orders WHERE orders.user_id = users.id)"),
+});
 
 // LEFT JOIN + GROUP BY (faster)
 const users = await UserModel.getPuri("r").table("users")
-  .select("users.id", "users.name", knex.raw("COUNT(orders.id) as order_count"))
+  .select({
+    id: "users.id",
+    name: "users.name",
+    order_count: Puri.count("orders.id"),
+  })
   .leftJoin("orders", "orders.user_id", "users.id")
   .groupBy("users.id");
 ```

--- a/modules/docs/ko/core-concepts/entity/field-types.mdx
+++ b/modules/docs/ko/core-concepts/entity/field-types.mdx
@@ -653,7 +653,7 @@ export type ProductMetadata = {
     // {entity}.model.ts의 subset 쿼리에서 사용
     const { qb } = this.getSubsetQueries(subset);
     qb.appendSelect({
-      full_name: this.getPuri("r").raw("first_name || ' ' || last_name"),
+      full_name: Puri.rawString("first_name || ' ' || last_name"),
     });
     ```
     

--- a/modules/docs/ko/core-concepts/model/basemodel-methods.mdx
+++ b/modules/docs/ko/core-concepts/model/basemodel-methods.mdx
@@ -740,16 +740,14 @@ async findMany<T extends UserSubsetKey>(
 
 ```typescript
 async getStatistics(): Promise<UserStatistics> {
-  const rdb = this.getDB("r");
-
-  const [stats] = await rdb("users")
-    .select([
-      rdb.raw("COUNT(*) as total_users"),
-      rdb.raw("COUNT(CASE WHEN is_active THEN 1 END) as active_users"),
-      rdb.raw("COUNT(CASE WHEN role = 'admin' THEN 1 END) as admin_count"),
-      rdb.raw("AVG(age) as average_age"),
-    ])
-    .first();
+  const [stats] = await this.getPuri("r")
+    .table("users")
+    .select({
+      total_users: Puri.count(),
+      active_users: Puri.rawNumber("COUNT(CASE WHEN is_active THEN 1 END)"),
+      admin_count: Puri.rawNumber("COUNT(CASE WHEN role = 'admin' THEN 1 END)"),
+      average_age: Puri.avg("age"),
+    });
 
   return {
     total_users: Number(stats.total_users),

--- a/modules/docs/ko/troubleshooting/performance/caching-strategies.mdx
+++ b/modules/docs/ko/troubleshooting/performance/caching-strategies.mdx
@@ -118,7 +118,7 @@ class ProductModelClass extends BaseModelClass {
   // 1일 캐싱
   @cache({ ttl: "1d" })
   async getCategoryCounts() {
-    return this.getPuri("r").table("products").select("category", knex.raw("COUNT(*) as count")).groupBy("category");
+    return this.getPuri("r").table("products").select({ category: "category", count: Puri.count() }).groupBy("category");
   }
 
   // 영구 캐싱 (수동 무효화 필요)

--- a/modules/docs/ko/troubleshooting/performance/n-plus-one-problems.mdx
+++ b/modules/docs/ko/troubleshooting/performance/n-plus-one-problems.mdx
@@ -394,12 +394,12 @@ class DashboardService {
   async getDashboardFast() {
     return UserModel.getPuri("r")
       .table("users")
-      .select(
-        "users.id",
-        "users.name",
-        knex.raw("COUNT(orders.id) as order_count"),
-        knex.raw("COALESCE(SUM(orders.total), 0) as total_spent"),
-      )
+      .select({
+        id: "users.id",
+        name: "users.name",
+        order_count: Puri.count("orders.id"),
+        total_spent: Puri.rawNumber("COALESCE(SUM(orders.total), 0)"),
+      })
       .leftJoin("orders", "orders.user_id", "users.id")
       .groupBy("users.id");
   }

--- a/modules/docs/ko/troubleshooting/performance/query-optimization.mdx
+++ b/modules/docs/ko/troubleshooting/performance/query-optimization.mdx
@@ -173,10 +173,14 @@ const count = result[0].count;
 ```typescript
 // 주문 통계
 const orderStats = await OrderModel.getPuri("r").table("orders")
-  .select("user_id", knex.raw("COUNT(*) as order_count"), knex.raw("SUM(total) as total_amount"))
+  .select({
+    user_id: "user_id",
+    order_count: Puri.count(),
+    total_amount: Puri.sum("total"),
+  })
   .where({ status: "completed" })
   .groupBy("user_id")
-  .having(knex.raw("COUNT(*) > ?", [10])); // 주문 10개 이상
+  .having("order_count", ">", 10); // 주문 10개 이상
 ```
 
 ## 페이지네이션 최적화
@@ -246,15 +250,19 @@ const usersWithOrders = await UserModel.getPuri("r").table("users")
 
 ```typescript
 // ❌ 서브쿼리
-const users = await UserModel.getPuri("r").table("users").select(
-  "id",
-  "name",
-  knex.raw("(SELECT COUNT(*) FROM orders WHERE orders.user_id = users.id) as order_count"),
-);
+const users = await UserModel.getPuri("r").table("users").select({
+  id: "id",
+  name: "name",
+  order_count: Puri.rawNumber("(SELECT COUNT(*) FROM orders WHERE orders.user_id = users.id)"),
+});
 
 // ✅ LEFT JOIN + GROUP BY (더 빠름)
 const users = await UserModel.getPuri("r").table("users")
-  .select("users.id", "users.name", knex.raw("COUNT(orders.id) as order_count"))
+  .select({
+    id: "users.id",
+    name: "users.name",
+    order_count: Puri.count("orders.id"),
+  })
   .leftJoin("orders", "orders.user_id", "users.id")
   .groupBy("users.id");
 ```


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위), 서브이슈 #197(Puri/UpsertBuilder 우선 사용)의 지침에 따라 AI에 의해 자동 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 참조한 Issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (작업 범위) — "문서와 주석이 코드와 어긋나는 경우 업데이트", "sonamu-docs 업데이트"
- #197 (서브이슈: Puri/UpsertBuilder 우선 사용) — `.getDb()` 사용을 권장하는 문서들을 `.getPuri()` 사용을 우선시하는 방향으로 수정, `knex.raw()` 사용을 지양하고 Puri 정적 메서드 우선 사용

## 이 PR은 무엇인가

sonamu 문서(.mdx)의 코드 예제에서 `knex.raw()` 및 `getDB()` + `rdb.raw()` 패턴을 사용하고 있는 부분을, Puri가 제공하는 타입 안전한 정적 메서드(`Puri.count()`, `Puri.sum()`, `Puri.avg()`, `Puri.rawNumber()`, `Puri.rawString()`)와 `getPuri()` 기반 패턴으로 교체합니다.

## 왜 이 작업을 선정했는가

1. **서브이슈 #197의 명시적 요청**: `knex.raw()` 사용을 지양하고 Puri의 정적 메서드를 우선 사용하도록 문서를 수정해달라는 요청이 있었습니다.

2. **타입 불일치 수정**: `field-types.mdx`의 `appendSelect()` 예제에서 `this.getPuri("r").raw("...")`를 사용하고 있었는데, `Puri.raw()`는 `Knex.Raw`를 반환하고 `appendSelect()`의 `SelectObject`는 `SqlExpression` 타입을 기대합니다. 이를 `Puri.rawString()`으로 교체하여 타입을 일치시켰습니다.

3. **Puri select() API와의 불일치**: 여러 문서에서 `.select("col1", knex.raw("..."))` 같은 positional 인자 방식을 사용하고 있었는데, Puri의 `select()`는 `SelectObject` (객체 형태)만 받습니다. 이를 `select({ alias: value })` 형태로 정정했습니다.

## 변경 내용 (3개 커밋)

### 커밋 1: appendSelect() 내 Puri.raw() → Puri.rawString() (ko/en 2파일)
- `field-types.mdx`의 virtualType query 예제
- `this.getPuri("r").raw("first_name || ' ' || last_name")` → `Puri.rawString("first_name || ' ' || last_name")`

### 커밋 2: troubleshooting 문서의 knex.raw() → Puri 정적 메서드 (ko/en 6파일)
- `caching-strategies.mdx`: `knex.raw("COUNT(*) as count")` → `Puri.count()`
- `n-plus-one-problems.mdx`: `knex.raw("COUNT(orders.id) as order_count")` → `Puri.count("orders.id")`, `knex.raw("COALESCE(SUM(...))") → Puri.rawNumber(...)`
- `query-optimization.mdx`: GROUP BY 예제, 서브쿼리 예제, JOIN+GROUP BY 예제 전체를 Puri 객체 select 형태로 교체

### 커밋 3: basemodel-methods 커스텀 집계 쿼리 예제 교체 (ko/en 2파일)
- `getDB("r")` + `rdb.raw("COUNT(*)")` 패턴 → `getPuri("r").table("users").select({ total_users: Puri.count(), ... })`
- `getDB()` 레퍼런스 섹션 자체는 유지 (해당 메서드의 API 문서이므로)

## 어떤 접근 방식을 채택했는가

- Puri 소스코드(`puri.ts`)의 실제 정적 메서드 시그니처를 확인하여 1:1 대응하는 올바른 메서드로 교체
- `COUNT(*)` → `Puri.count()`, `COUNT(col)` → `Puri.count("col")`, `SUM(col)` → `Puri.sum("col")`, `AVG(col)` → `Puri.avg("col")`
- Puri에 직접 대응하는 정적 메서드가 없는 복잡한 SQL(`COALESCE(SUM(...))`, `COUNT(CASE WHEN ...)`)은 `Puri.rawNumber()`로 교체
- positional `select()` 인자를 Puri의 `SelectObject` 형태(`{ alias: value }`)로 정정
- 소스코드 변경 없이 문서(.mdx) 파일만 수정

## 이렇게 하지 않으면 어떤 점이 안 좋은가

- 문서가 `knex.raw()`를 기본 패턴으로 안내하여, Puri의 타입 안전한 API를 사용하지 않는 코드가 확산됨
- `appendSelect()` 예제의 타입 불일치로 인해, 문서대로 코딩하면 TypeScript 타입 에러가 발생
- positional `select()` 인자 사용은 Puri의 실제 API 시그니처와 맞지 않아 컴파일 에러 발생 가능

## 영향 범위

- 문서 파일(.mdx)만 수정하므로 런타임 영향 없음
- 영향받는 문서: field-types, basemodel-methods, caching-strategies, n-plus-one-problems, query-optimization (각각 ko/en)

## 변경 확인 방법

- 각 문서의 코드 예제에서 Puri의 실제 API 시그니처와 일치하는지 확인
- `Puri.count()`, `Puri.sum()`, `Puri.avg()`, `Puri.rawNumber()`, `Puri.rawString()` — 모두 `puri.ts`에 정의된 정적 메서드

## 사람의 확인이 필요한 부분

- `basemodel-methods.mdx`의 `getDB()` 레퍼런스 섹션(상단)은 그대로 두었습니다. 이것이 메서드 자체에 대한 API 문서이므로 유지하는 것이 맞다고 판단했으나, `getPuri()` 우선 안내를 더 강조해야 할지는 메인테이너 판단에 맡깁니다.
- `query-optimization.mdx`의 JOIN 조건 최적화 예제(`knex.raw("users ON users.id = ...")`)는 Puri의 `join()` API만으로는 동등하게 표현하기 어려워 이번 수정에서 제외했습니다. Puri의 join이 조건부 ON을 지원하는지 확인이 필요합니다.