### PR TITLE
[Nightly 2026-06-29] deployment FAQ의 미존재 DB 설정 구조 정정 및 query-optimization JOIN 예제의 knex.raw() 제거 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/faq/deployment.mdx
+++ b/modules/docs/en/faq/deployment.mdx
@@ -81,22 +81,22 @@ server {
 <AccordionGroup>
 <Accordion title="How do I set environment variables?">
 
-**Create .env file:**
+Sonamu automatically loads `.env.{environment}` files based on `NODE_ENV`.
+
+**Create `.env.production` file:**
 
 ```bash
 # api/.env.production
-NODE_ENV=production
+
+# Database (use SONAMU_DB_ prefix)
+SONAMU_DB_HOST=prod-db.example.com
+SONAMU_DB_PORT=5432
+SONAMU_DB_NAME=myapp_production
+SONAMU_DB_USER=postgres
+SONAMU_DB_PASSWORD=secure_password
+
+# Server
 PORT=34900
-
-# Database
-DB_HOST=prod-db.example.com
-DB_PORT=5432
-DB_NAME=sonamu_prod
-DB_USER=postgres
-DB_PASSWORD=secure_password
-
-# Session
-SESSION_SECRET=your-super-secret-key
 
 # CORS
 CORS_ORIGIN=https://example.com
@@ -107,30 +107,26 @@ REDIS_PORT=6379
 REDIS_PASSWORD=redis_password
 ```
 
-**Use in sonamu.config.ts:**
+Sonamu reads `SONAMU_DB_*` environment variables to automatically configure DB connections, so you don't need to specify connection details directly in `sonamu.config.ts`. Use `database.defaultOptions` to override defaults:
 
 ```typescript
-export default {
+import { defineConfig } from "sonamu";
+
+export default defineConfig({
+  // ...
+  database: {
+    database: "pg",
+    defaultOptions: {
+      pool: { min: 2, max: 10 },
+    },
+  },
   server: {
     listen: {
       port: Number(process.env.PORT) || 34900,
     },
+    // ...
   },
-  database: {
-    connections: {
-      main: {
-        host: process.env.DB_HOST,
-        port: Number(process.env.DB_PORT),
-        database: process.env.DB_NAME,
-        user: process.env.DB_USER,
-        password: process.env.DB_PASSWORD,
-      },
-    },
-  },
-  session: {
-    secret: process.env.SESSION_SECRET,
-  },
-} satisfies SonamuConfig;
+});
 ```
 
 </Accordion>
@@ -503,11 +499,11 @@ services:
     build: ./api
     environment:
       NODE_ENV: production
-      DB_HOST: postgres
-      DB_PORT: 5432
-      DB_NAME: sonamu_prod
-      DB_USER: postgres
-      DB_PASSWORD: ${DB_PASSWORD}
+      SONAMU_DB_HOST: postgres
+      SONAMU_DB_PORT: 5432
+      SONAMU_DB_NAME: sonamu_production
+      SONAMU_DB_USER: postgres
+      SONAMU_DB_PASSWORD: ${SONAMU_DB_PASSWORD}
       REDIS_HOST: redis
       REDIS_PORT: 6379
     ports:

--- a/modules/docs/en/troubleshooting/performance/query-optimization.mdx
+++ b/modules/docs/en/troubleshooting/performance/query-optimization.mdx
@@ -146,10 +146,12 @@ const result = await OrderModel.getPuri("r").table("orders")
   .join("users", "users.id", "orders.user_id")
   .where({ "users.status": "active" }); // Filtering after join
 
-// Good example - filtering before join
+// Good example - include filter in join condition
 const result = await OrderModel.getPuri("r").table("orders")
   .select("orders.*", "users.name")
-  .join(knex.raw("users ON users.id = orders.user_id AND users.status = ?", ["active"])); // Include in join condition
+  .join("users", (join) => {
+    join.on("users.id", "orders.user_id").andOnVal("users.status", "active");
+  });
 ```
 
 ## Aggregation Query Optimization

--- a/modules/docs/ko/faq/deployment.mdx
+++ b/modules/docs/ko/faq/deployment.mdx
@@ -81,22 +81,22 @@ server {
 <AccordionGroup>
 <Accordion title="환경 변수를 설정하려면?">
 
-**.env 파일 생성:**
+Sonamu는 `NODE_ENV`에 따라 `.env.{environment}` 파일을 자동으로 로드합니다.
+
+**`.env.production` 파일 생성:**
 
 ```bash
 # api/.env.production
-NODE_ENV=production
+
+# Database (SONAMU_DB_ 접두사 사용)
+SONAMU_DB_HOST=prod-db.example.com
+SONAMU_DB_PORT=5432
+SONAMU_DB_NAME=myapp_production
+SONAMU_DB_USER=postgres
+SONAMU_DB_PASSWORD=secure_password
+
+# Server
 PORT=34900
-
-# Database
-DB_HOST=prod-db.example.com
-DB_PORT=5432
-DB_NAME=sonamu_prod
-DB_USER=postgres
-DB_PASSWORD=secure_password
-
-# Session
-SESSION_SECRET=your-super-secret-key
 
 # CORS
 CORS_ORIGIN=https://example.com
@@ -107,30 +107,26 @@ REDIS_PORT=6379
 REDIS_PASSWORD=redis_password
 ```
 
-**sonamu.config.ts에서 사용:**
+Sonamu가 `SONAMU_DB_*` 환경변수를 읽어 DB 연결을 자동으로 구성하므로, `sonamu.config.ts`에서 직접 연결 정보를 지정할 필요가 없습니다. 기본값을 오버라이드하고 싶다면 `database.defaultOptions`를 사용합니다:
 
 ```typescript
-export default {
+import { defineConfig } from "sonamu";
+
+export default defineConfig({
+  // ...
+  database: {
+    database: "pg",
+    defaultOptions: {
+      pool: { min: 2, max: 10 },
+    },
+  },
   server: {
     listen: {
       port: Number(process.env.PORT) || 34900,
     },
+    // ...
   },
-  database: {
-    connections: {
-      main: {
-        host: process.env.DB_HOST,
-        port: Number(process.env.DB_PORT),
-        database: process.env.DB_NAME,
-        user: process.env.DB_USER,
-        password: process.env.DB_PASSWORD,
-      },
-    },
-  },
-  session: {
-    secret: process.env.SESSION_SECRET,
-  },
-} satisfies SonamuConfig;
+});
 ```
 
 </Accordion>
@@ -503,11 +499,11 @@ services:
     build: ./api
     environment:
       NODE_ENV: production
-      DB_HOST: postgres
-      DB_PORT: 5432
-      DB_NAME: sonamu_prod
-      DB_USER: postgres
-      DB_PASSWORD: ${DB_PASSWORD}
+      SONAMU_DB_HOST: postgres
+      SONAMU_DB_PORT: 5432
+      SONAMU_DB_NAME: sonamu_production
+      SONAMU_DB_USER: postgres
+      SONAMU_DB_PASSWORD: ${SONAMU_DB_PASSWORD}
       REDIS_HOST: redis
       REDIS_PORT: 6379
     ports:

--- a/modules/docs/ko/troubleshooting/performance/query-optimization.mdx
+++ b/modules/docs/ko/troubleshooting/performance/query-optimization.mdx
@@ -146,10 +146,12 @@ const result = await OrderModel.getPuri("r").table("orders")
   .join("users", "users.id", "orders.user_id")
   .where({ "users.status": "active" }); // 조인 후 필터링
 
-// ✅ 좋은 예 - 조인 전 필터링
+// ✅ 좋은 예 - 조인 조건에 필터 포함
 const result = await OrderModel.getPuri("r").table("orders")
   .select("orders.*", "users.name")
-  .join(knex.raw("users ON users.id = orders.user_id AND users.status = ?", ["active"])); // 조인 조건에 포함
+  .join("users", (join) => {
+    join.on("users.id", "orders.user_id").andOnVal("users.status", "active");
+  });
 ```
 
 ## 집계 쿼리 최적화


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위), 서브이슈 #197(Puri/UpsertBuilder 우선 사용)의 지침에 따라 AI에 의해 자동 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 참조한 Issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (작업 범위) — "문서와 주석이 코드와 어긋나는 경우 업데이트", "sonamu-docs 업데이트"
- #197 (서브이슈: Puri/UpsertBuilder 우선 사용) — `knex.raw()` 사용을 지양하고 Puri 메서드 우선 사용

## 이 PR은 무엇인가

sonamu 문서 4파일(ko/en)에서 발견된 2가지 문서-코드 불일치를 수정합니다.

## 왜 이 작업을 선정했는가

### 커밋 1: query-optimization JOIN 예제의 knex.raw() 제거

**문제**: `troubleshooting/performance/query-optimization.mdx`의 JOIN 조건 최적화 예제에서 `join(knex.raw("users ON users.id = ... AND users.status = ?", ["active"]))` 패턴을 사용하고 있었습니다. 이 패턴은 마이그레이션 파일이 아닌 일반 쿼리 문맥이므로 서브이슈 #197의 "knex.raw() 사용 지양" 범위에 해당합니다.

**수정**: Puri에 정의된 `andOnVal()` 메서드를 활용하는 Knex join builder 콜백 형태로 교체했습니다:
```typescript
.join("users", (join) => {
  join.on("users.id", "orders.user_id").andOnVal("users.status", "active");
});
```

`andOnVal()`은 `modules/sonamu/src/database/puri.ts:1720-1725`에 정의되어 있으며, 값 비교를 위한 정확한 메서드입니다.

### 커밋 2: deployment FAQ의 미존재 database 설정 구조 및 환경변수명 정정

**문제**: `faq/deployment.mdx`의 "환경 변수를 설정하려면?" 예제에서 다음 3가지 문제가 있었습니다:
1. `database.connections.main.host` — `SonamuConfig.database`에 `connections` 필드가 존재하지 않음 (`modules/sonamu/src/api/config.ts:95-100` 참조)
2. `session.secret` — `SonamuConfig`에 `session` 필드가 존재하지 않음
3. `DB_HOST`, `DB_PORT` 등 접두사 없는 환경변수 — 최근 커밋 `da6561ce`에서 `SONAMU_DB_*` 접두사 기반 환경변수 체계가 도입됨 (`modules/sonamu/src/database/db.ts:83-117`, `modules/sonamu/src/env.ts` 참조)

**수정**:
- `.env.production` 예제를 `SONAMU_DB_HOST`, `SONAMU_DB_PORT` 등 실제 환경변수명으로 교체
- `sonamu.config.ts` 예제를 `defineConfig()` + `database.defaultOptions` 패턴으로 교체 (실제 `examples/miomock/api/src/sonamu.config.ts`와 일관됨)
- Docker Compose 예제의 환경변수도 동일하게 정정
- `NODE_ENV=production`을 .env 파일에서 제거 (Sonamu는 `.env.{environment}` 파일명으로 환경을 구분하므로 .env 파일 내에 `NODE_ENV`를 설정할 필요 없음)

## 이렇게 하지 않으면 어떤 점이 안 좋은가

- 사용자가 문서를 따라 `database.connections.main` 구조를 사용하면 타입 에러 발생
- `DB_HOST` 등 접두사 없는 환경변수를 설정하면 Sonamu가 DB 연결 정보를 읽지 못함
- `knex.raw()` join 패턴을 따르면 Puri의 타입 안전한 join API를 활용하지 못함

## 이 변경이 어떤 기능에 영향을 미치는가

문서(`.mdx`) 변경만이므로 소스코드 동작에는 영향이 없습니다.

## 이 변경의 영향을 확인하는 방법

1. `pnpm check` 통과 확인 (완료)
2. `pnpm --filter sonamu build` 성공 확인 (완료)
3. 문서 사이트에서 해당 페이지 확인:
   - `/faq/deployment` — "환경 변수를 설정하려면?" 섹션
   - `/troubleshooting/performance/query-optimization` — "JOIN 조건 최적화" 섹션

## 추후 사람의 확인이 필요한 부분

- **deployment.mdx의 다른 섹션들**: 같은 파일의 다른 Accordion에서도 `DB_HOST` 등을 사용하는 부분이 남아있을 수 있으나, 그 부분들은 Sonamu 프레임워크 외부의 직접 Knex 설정(workflow, session 등)을 다루는 문맥인지 확인이 필요합니다.
- **다른 문서 파일들**: `api-reference/decorators/workflow.mdx`, `tools-and-cli/hmr/boundaries.mdx`, `api-development/authentication/session-management.mdx` 등에서도 `process.env.DB_HOST` 패턴이 남아있습니다. 이들은 Sonamu DB가 아닌 외부 서비스(세션 스토어, workflow DB 등)의 설정 문맥이라 이번 PR의 범위에서는 제외했으나, 동일한 정정이 필요한지 메인테이너의 확인이 필요합니다.
- **vector search 문서**: `Puri.raw()`에 파라미터를 전달하는 예제(`pgvector-setup.mdx`, `hybrid-search.mdx`)가 있으나, 실제 `PuriWrapper.raw()` 구현은 SQL 문자열만 받습니다. 이는 문서 수정 또는 소스코드 변경이 필요한 별도의 이슈입니다.