### PR TITLE
[Nightly 2026-06-30] business-logic/api-decorator 문서의 미존재 ForbiddenException 정정 및 checksum 스트림 안전성 개선

### DIFF
--- a/modules/docs/en/core-concepts/model/api-decorator.mdx
+++ b/modules/docs/en/core-concepts/model/api-decorator.mdx
@@ -284,7 +284,7 @@ export default {
       throw new UnauthorizedException("Login required");
     }
     if (guard === "admin" && request.user?.role !== "admin") {
-      throw new ForbiddenException("Admin permission required");
+      throw new UnauthorizedException("Admin permission required");
     }
   },
 };

--- a/modules/docs/en/core-concepts/model/business-logic.mdx
+++ b/modules/docs/en/core-concepts/model/business-logic.mdx
@@ -165,7 +165,7 @@ async save(params: UserSaveParams[]): Promise<number[]> {
     if (param.role && param.role !== "normal") {
       const context = Sonamu.getContext();
       if (context.user?.role !== "admin") {
-        throw new ForbiddenException(
+        throw new UnauthorizedException(
           "Only admins can change roles"
         );
       }
@@ -302,7 +302,7 @@ async updateStatus(
   if (newStatus === "cancelled") {
     // Users can only cancel pending orders
     if (order.status !== "pending" && context.user?.role !== "admin") {
-      throw new ForbiddenException(
+      throw new UnauthorizedException(
         "Only admins can cancel confirmed orders"
       );
     }
@@ -311,7 +311,7 @@ async updateStatus(
   if (newStatus === "delivered") {
     // Only delivery staff can mark as delivered
     if (context.user?.role !== "delivery") {
-      throw new ForbiddenException(
+      throw new UnauthorizedException(
         "Only delivery staff can mark as delivered"
       );
     }
@@ -500,7 +500,7 @@ async login(params: LoginParams): Promise<{ user: User }> {
   }
 
   if (!user.is_verified) {
-    throw new ForbiddenException(
+    throw new UnauthorizedException(
       "Email verification not complete. Please check your verification email."
     );
   }

--- a/modules/docs/ko/core-concepts/model/api-decorator.mdx
+++ b/modules/docs/ko/core-concepts/model/api-decorator.mdx
@@ -284,7 +284,7 @@ export default {
       throw new UnauthorizedException("로그인이 필요합니다");
     }
     if (guard === "admin" && request.user?.role !== "admin") {
-      throw new ForbiddenException("관리자 권한이 필요합니다");
+      throw new UnauthorizedException("관리자 권한이 필요합니다");
     }
   },
 };

--- a/modules/docs/ko/core-concepts/model/business-logic.mdx
+++ b/modules/docs/ko/core-concepts/model/business-logic.mdx
@@ -165,7 +165,7 @@ async save(params: UserSaveParams[]): Promise<number[]> {
     if (param.role && param.role !== "normal") {
       const context = Sonamu.getContext();
       if (context.user?.role !== "admin") {
-        throw new ForbiddenException(
+        throw new UnauthorizedException(
           "관리자만 역할을 변경할 수 있습니다"
         );
       }
@@ -302,7 +302,7 @@ async updateStatus(
   if (newStatus === "cancelled") {
     // 사용자는 pending만 취소 가능
     if (order.status !== "pending" && context.user?.role !== "admin") {
-      throw new ForbiddenException(
+      throw new UnauthorizedException(
         "관리자만 확정된 주문을 취소할 수 있습니다"
       );
     }
@@ -311,7 +311,7 @@ async updateStatus(
   if (newStatus === "delivered") {
     // 배송 완료는 배송 담당자만 가능
     if (context.user?.role !== "delivery") {
-      throw new ForbiddenException(
+      throw new UnauthorizedException(
         "배송 담당자만 배송 완료 처리할 수 있습니다"
       );
     }
@@ -500,7 +500,7 @@ async login(params: LoginParams): Promise<{ user: User }> {
   }
 
   if (!user.is_verified) {
-    throw new ForbiddenException(
+    throw new UnauthorizedException(
       "이메일 인증이 완료되지 않았습니다. 인증 메일을 확인해주세요."
     );
   }

--- a/modules/sonamu/src/syncer/checksum.ts
+++ b/modules/sonamu/src/syncer/checksum.ts
@@ -1,4 +1,4 @@
-import crypto, { type BinaryLike } from "crypto";
+import crypto from "crypto";
 import { createReadStream, type PathLike } from "fs";
 import { readFile, writeFile } from "fs/promises";
 import path from "path";
@@ -114,15 +114,10 @@ async function saveChecksums(checksums: PathAndChecksum[]): Promise<void> {
 }
 
 async function getChecksumOfFile(filePath: PathLike): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const hash = crypto.createHash("sha1");
-    const input = createReadStream(filePath);
-    input.on("error", reject);
-    input.on("data", (chunk: BinaryLike) => {
-      hash.update(chunk);
-    });
-    input.on("close", () => {
-      resolve(hash.digest("hex"));
-    });
-  });
+  const hash = crypto.createHash("sha1");
+  const input = createReadStream(filePath);
+  for await (const chunk of input) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
 }


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 참조한 Issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (작업 범위) — "코드에 예상치 못한 동작이나 버그 등 잠재적으로 위험한 포인트", "문서와 주석이 코드와 어긋나는 경우 업데이트"

## 이 PR은 무엇인가

2가지 개선을 포함합니다:
1. **문서 코드 예제의 미존재 `ForbiddenException` 정정** (ko/en 4파일, 10개소)
2. **`getChecksumOfFile` 함수의 스트림 처리 안전성 개선** (소스 1파일)

## 왜 이 작업을 선정했는가

### 커밋 1: ForbiddenException → UnauthorizedException (ko/en 4파일)

**문제**: `business-logic.mdx`(ko/en)와 `api-decorator.mdx`(ko/en)에서 `ForbiddenException`을 import나 커스텀 정의 없이 사용하고 있었습니다. `ForbiddenException`은 Sonamu에 내장된 예외가 아닙니다(`modules/sonamu/src/exceptions/so-exceptions.ts`에 정의되지 않음).

PR #196에서 `ForbiddenError` → `UnauthorizedException` 교체가 수행되었으나, 이름이 다른 `ForbiddenException`(Error가 아닌 Exception)은 누락되었습니다.

**근거**: `unauthorized-error.mdx`에서 명시하듯, "Sonamu에서는 `UnauthorizedException` 하나로 [401/403] 둘 다 처리하지만, 필요하다면 커스텀 `ForbiddenException`을 만들 수 있습니다." `custom-errors.mdx`에서도 `ForbiddenException`은 커스텀 예외 정의 예시로만 소개됩니다.

**수정**: 별도 정의 없이 사용된 `ForbiddenException` 10개소를 `UnauthorizedException`으로 교체했습니다. 커스텀 예외 가이드 문서(`unauthorized-error.mdx`, `custom-errors.mdx`)의 `ForbiddenException` 정의/사용 예시는 그대로 보존했습니다.

### 커밋 2: getChecksumOfFile 스트림 안전성 개선 (소스 1파일)

**문제**: `modules/sonamu/src/syncer/checksum.ts`의 `getChecksumOfFile` 함수가 `createReadStream`의 `error`/`close` 이벤트를 수동 등록하여 Promise를 settle하는 패턴을 사용하고 있었습니다. 이 패턴에서:
- `error` 이벤트 발생 → `reject()` 호출
- 이후 `close` 이벤트 발생 → `hash.digest()` 호출(불완전한 데이터에 대해)
- Promise 특성상 두 번째 settle은 무시되지만, 에러 경로에서 불필요한 `hash.digest()` 연산이 발생합니다.

**수정**: `for await...of` 패턴으로 교체했습니다. Node.js의 ReadableStream AsyncIterator 프로토콜이 에러 전파와 스트림 정리를 자동으로 처리하므로 더 안전하고 간결합니다. 기능적으로 동일한 SHA-1 해시를 생성합니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가

1. 사용자가 `business-logic.mdx`의 권한 검증 예제를 따라하면 `ForbiddenException is not defined` 컴파일 에러가 발생합니다.
2. `checksum.ts`의 수동 이벤트 리스너 패턴은 동작하지만, 에러 경로에서 불필요한 연산이 발생하며 코드가 불필요하게 장황합니다.

## 영향 범위

- **문서 변경**: `business-logic.mdx` (ko/en), `api-decorator.mdx` (ko/en) — 소스 코드 영향 없음
- **소스 변경**: `modules/sonamu/src/syncer/checksum.ts` — 파일 체크섬 계산 로직. syncer가 변경 감지 시 사용하는 함수이며, 동일한 해시 결과를 생성합니다.

## 변경 확인 방법

```bash
# 문서에서 ForbiddenException이 커스텀 정의 없이 사용되는 곳이 없는지 확인
grep -rn 'ForbiddenException' modules/docs/ko/core-concepts/ modules/docs/en/core-concepts/
# (결과 없음이면 정상)

# checksum 관련 타입 체크
pnpm --filter sonamu test:type

# 린트/포맷
pnpm check
```

## 사람의 확인이 필요한 부분

- `ForbiddenException` → `UnauthorizedException` 교체가 문서의 맥락(권한 부족 시나리오)에서 적절한지 확인 부탁드립니다. 만약 403 응답을 명시적으로 구분해야 하는 문서 의도가 있었다면, 커스텀 `ForbiddenException` 정의를 코드 예제 상단에 추가하는 방향도 가능합니다.
- `for await...of` 패턴이 프로젝트의 Node.js 최소 지원 버전에서 문제없는지 확인 부탁드립니다.