### PR TITLE
[Nightly 2026-07-01] HMR boundaries 문서의 미존재 Sonamu.config.database.* 필드 및 worker-setup/entity-and-model 문서의 getDB() 인자 누락 정정 (ko/en 6파일)

### DIFF
--- a/modules/docs/en/advanced-features/workflows/worker-setup.mdx
+++ b/modules/docs/en/advanced-features/workflows/worker-setup.mdx
@@ -223,7 +223,7 @@ CREATE TABLE workflow_steps (
 // Direct DB query
 import { DB } from "sonamu";
 
-const knex = DB.getDB();
+const knex = DB.getDB("r");
 const runs = await knex("workflow_runs").where("status", "running").select("*");
 ```
 

--- a/modules/docs/en/faq/entity-and-model.mdx
+++ b/modules/docs/en/faq/entity-and-model.mdx
@@ -371,7 +371,7 @@ export const UtilFrame = new UtilFrameClass();
 **Frame characteristics:**
 
 - Extends `BaseFrameClass`
-- Provides `getDB()`, `getUpsertBuilder()` methods
+- Provides `getDB(preset)`, `getUpsertBuilder()` methods
 - No Entity, Subset, Model methods
 - Filename: `{name}.frame.ts`
 

--- a/modules/docs/en/tools-and-cli/hmr/boundaries.mdx
+++ b/modules/docs/en/tools-and-cli/hmr/boundaries.mdx
@@ -491,14 +491,12 @@ import.meta.hot?.decline();
 
 ```typescript
 // database.config.ts
-import { Sonamu } from "@sonamu-kit/sonamu";
-
 export const dbPool = new Pool({
-  host: Sonamu.config.database.host,
-  port: Sonamu.config.database.port,
-  user: Sonamu.config.database.user,
-  password: Sonamu.config.database.password,
-  database: Sonamu.config.database.database,
+  host: process.env.SONAMU_DB_HOST,
+  port: parseInt(process.env.SONAMU_DB_PORT ?? "5432"),
+  user: process.env.SONAMU_DB_USER,
+  password: process.env.SONAMU_DB_PASSWORD,
+  database: process.env.SONAMU_DB_NAME,
 });
 
 // DB connection config changes require restart

--- a/modules/docs/ko/advanced-features/workflows/worker-setup.mdx
+++ b/modules/docs/ko/advanced-features/workflows/worker-setup.mdx
@@ -223,7 +223,7 @@ CREATE TABLE workflow_steps (
 // DB 직접 조회
 import { DB } from "sonamu";
 
-const knex = DB.getDB();
+const knex = DB.getDB("r");
 const runs = await knex("workflow_runs").where("status", "running").select("*");
 ```
 

--- a/modules/docs/ko/faq/entity-and-model.mdx
+++ b/modules/docs/ko/faq/entity-and-model.mdx
@@ -371,7 +371,7 @@ export const UtilFrame = new UtilFrameClass();
 **Frame 특징:**
 
 - `BaseFrameClass` 상속
-- `getDB()`, `getUpsertBuilder()` 메서드 제공
+- `getDB(preset)`, `getUpsertBuilder()` 메서드 제공
 - Entity, Subset, Model 메서드 없음
 - 파일명: `{name}.frame.ts`
 

--- a/modules/docs/ko/tools-and-cli/hmr/boundaries.mdx
+++ b/modules/docs/ko/tools-and-cli/hmr/boundaries.mdx
@@ -491,14 +491,12 @@ import.meta.hot?.decline();
 
 ```typescript
 // database.config.ts
-import { Sonamu } from "@sonamu-kit/sonamu";
-
 export const dbPool = new Pool({
-  host: Sonamu.config.database.host,
-  port: Sonamu.config.database.port,
-  user: Sonamu.config.database.user,
-  password: Sonamu.config.database.password,
-  database: Sonamu.config.database.database,
+  host: process.env.SONAMU_DB_HOST,
+  port: parseInt(process.env.SONAMU_DB_PORT ?? "5432"),
+  user: process.env.SONAMU_DB_USER,
+  password: process.env.SONAMU_DB_PASSWORD,
+  database: process.env.SONAMU_DB_NAME,
 });
 
 // DB 연결 설정 변경은 재시작 필요


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 참조한 Issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (작업 범위) — "문서와 주석이 코드와 어긋나는 경우 업데이트", "코드에 예상치 못한 동작이나 버그 등 잠재적으로 위험한 포인트"

## 이 PR은 무엇인가

2가지 개선을 포함합니다:
1. **boundaries.mdx의 미존재 `Sonamu.config.database.*` 필드 정정** (ko/en 2파일)
2. **worker-setup.mdx/entity-and-model.mdx의 `getDB()` 인자 누락 정정** (ko/en 4파일)

## 왜 이 작업을 선정했는가

### 커밋 1: Sonamu.config.database.* → process.env.SONAMU_DB_* (ko/en 2파일)

**문제**: `boundaries.mdx`(ko/en)의 decline() 사용 예시에서 `Sonamu.config.database.host/port/user/password`를 참조하고 있었습니다. 그러나 `SonamuConfig.database`에는 `database` (pg/pgnative)와 `defaultOptions` 두 필드만 존재하며, `host/port/user/password` 필드는 없습니다.

**근거**: `modules/sonamu/src/api/config.ts:95-100`의 `SonamuConfig.database` 타입 정의를 보면:
```typescript
database: {
  database?: "pg" | "pgnative";
  defaultOptions?: DatabaseConfig;
};
```
DB 연결정보는 `modules/sonamu/src/database/db.ts:83-117`의 `connectionFromEnv()` 함수에서 `SONAMU_DB_HOST`, `SONAMU_DB_PORT`, `SONAMU_DB_USER`, `SONAMU_DB_PASSWORD`, `SONAMU_DB_NAME` 환경변수로 관리합니다.

**수정**: decline() 예시의 Pool 생성 코드를 `process.env.SONAMU_DB_*` 환경변수 기반으로 교체했습니다. 미사용된 `import { Sonamu }` 구문도 제거했습니다.

### 커밋 2: getDB() → getDB("r") / getDB(preset) (ko/en 4파일)

**문제**: `worker-setup.mdx`(ko/en)의 모니터링 예제에서 `DB.getDB()`를 인자 없이 호출하고 있었습니다. 또한 `entity-and-model.mdx`(ko/en)에서 Frame 특징을 설명할 때 `getDB()`로 인자 없이 표기하고 있었습니다.

**근거**: 
- `modules/sonamu/src/database/db.ts:178`: `getDB(which: DBPreset): Knex` — `which` 매개변수는 필수
- `modules/sonamu/src/api/base-frame.ts:18`: `getDB(which: DBPreset): Knex` — 동일하게 필수
- `DBPreset = "w" | "r" | SonamuDBPreset`으로 정의됨

**수정**: worker-setup.mdx의 `DB.getDB()`를 읽기 전용 조회이므로 `DB.getDB("r")`로, entity-and-model.mdx의 `getDB()`를 `getDB(preset)`으로 수정했습니다.

## 이렇게 하지 않으면 어떤 점이 안 좋은가

1. 사용자가 boundaries.mdx의 예제를 참고하여 `Sonamu.config.database.host` 등으로 DB 연결 정보에 접근하려 하면, 해당 필드가 존재하지 않아 `undefined` 값으로 Pool이 생성되어 DB 연결이 실패합니다.
2. 사용자가 worker-setup.mdx의 예제를 참고하여 `DB.getDB()`를 인자 없이 호출하면, TypeScript 컴파일 에러가 발생합니다.

## 이 변경이 어떤 기능에 영향을 미치는가

문서 전용 변경이므로 소스 코드의 기능에는 영향이 없습니다.

## 이 변경이 미치는 영향을 바로 확인하는 구체적인 방법

- boundaries.mdx: 변경된 코드 예시의 `process.env.SONAMU_DB_*` 환경변수가 `modules/sonamu/src/database/db.ts`의 `connectionFromEnv()` 함수에서 사용하는 것과 동일한지 확인
- worker-setup.mdx: `DB.getDB("r")`이 `modules/sonamu/src/database/db.ts:178`의 시그니처 `getDB(which: DBPreset)`에 부합하는지 확인
- entity-and-model.mdx: `getDB(preset)`이 `modules/sonamu/src/api/base-frame.ts:18`의 시그니처에 부합하는지 확인

## 추후 사람의 확인이 필요한 부분

- boundaries.mdx의 decline() 예시는 커스텀 Pool 생성이라는 시나리오를 보여주는데, 실제 Sonamu 사용에서는 DB 연결을 프레임워크가 자동 관리하므로 이런 패턴이 필요한 경우가 드뭅니다. 예시 자체의 적절성은 메인테이너의 판단이 필요합니다.
- worker-setup.mdx의 모니터링 예제에서 `workflow_runs` 테이블을 직접 조회하는 패턴이 현재 Sonamu의 workflow 기능에서 실제로 지원되는 패턴인지도 확인이 필요할 수 있습니다.