### PR TITLE
[Nightly 2026-07-06] BentoCache API 시그니처 오류, MySQL DATE_FORMAT→PostgreSQL to_char, 미존재 getPuri() 호출 수정 (ko/en 14파일)

### DIFF
--- a/modules/docs/en/api-development/context/custom-context.mdx
+++ b/modules/docs/en/api-development/context/custom-context.mdx
@@ -82,7 +82,7 @@ declare module "sonamu" {
 // middleware/auth.middleware.ts
 import { FastifyRequest, FastifyReply } from "fastify";
 import jwt from "jsonwebtoken";
-import { Sonamu } from "sonamu";
+import { Sonamu, DB } from "sonamu";
 
 export async function authMiddleware(request: FastifyRequest, reply: FastifyReply) {
   // Extract token from Authorization header
@@ -105,8 +105,8 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
     };
 
     // Get user info from DB
-    const rdb = Sonamu.getPuri("r");
-    const user = await rdb.table("users").where("id", payload.userId).first();
+    const rdb = DB.getDB("r");
+    const user = await rdb("users").where("id", payload.userId).first();
 
     if (!user) {
       reply.status(401);
@@ -141,7 +141,7 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
 ```typescript
 // middleware/tenant.middleware.ts
 import { FastifyRequest } from "fastify";
-import { Sonamu } from "sonamu";
+import { Sonamu, DB } from "sonamu";
 
 export async function tenantMiddleware(request: FastifyRequest) {
   const context = Sonamu.getContext();
@@ -154,11 +154,10 @@ export async function tenantMiddleware(request: FastifyRequest) {
     return; // No tenant info
   }
 
-  const rdb = Sonamu.getPuri("r");
+  const rdb = DB.getDB("r");
 
   // Get tenant
-  const tenant = await rdb
-    .table("tenants")
+  const tenant = await rdb("tenants")
     .where((qb) => {
       if (subdomain) {
         qb.where("subdomain", subdomain);

--- a/modules/docs/en/api-development/context/getting-context.mdx
+++ b/modules/docs/en/api-development/context/getting-context.mdx
@@ -411,9 +411,9 @@ class AnalyticsFrame extends BaseFrameClass {
   async track(params: TrackParams): Promise<void> {
     const context = Sonamu.getContext();
 
-    const wdb = this.getPuri("w");
+    const wdb = this.getDB("w");
 
-    await wdb.table("analytics").insert({
+    await wdb("analytics").insert({
       event_type: params.eventType,
       event_data: JSON.stringify(params.data),
       user_id: context.user?.id,

--- a/modules/docs/en/api-reference/base-model/get-puri.mdx
+++ b/modules/docs/en/api-reference/base-model/get-puri.mdx
@@ -375,7 +375,7 @@ class UserModelClass extends BaseModelClass {
         const [result] = await rdb.raw(`
           WITH monthly_sales AS (
             SELECT
-              DATE_FORMAT(created_at, '%Y-%m') as month,
+              to_char(created_at, 'YYYY-MM') as month,
               COUNT(*) as order_count,
               SUM(total_amount) as total
             FROM orders

--- a/modules/docs/en/api-reference/decorators/api.mdx
+++ b/modules/docs/en/api-reference/decorators/api.mdx
@@ -592,7 +592,7 @@ Logs are recorded through LogTape, with categories in `[model:user]` or `[frame:
         const result = await this.upsert(wdb, { id, ...data });
 
         // Invalidate cache
-        await Sonamu.cache.deleteByTags(["products"]);
+        await Sonamu.cache.deleteByTag({ tags: ["products"] });
 
         return result;
       }

--- a/modules/docs/en/api-reference/decorators/cache.mdx
+++ b/modules/docs/en/api-reference/decorators/cache.mdx
@@ -190,7 +190,7 @@ async findById(id: number) {
 }
 
 // Invalidate cache
-await Sonamu.cache.deleteByTags(["products"]);
+await Sonamu.cache.deleteByTag({ tags: ["products"] });
 ```
 
 ### grace
@@ -262,7 +262,7 @@ class ProductModelClass extends BaseModelClass {
     const result = await this.insert(wdb, data);
 
     // Invalidate all caches with "products" tag
-    await Sonamu.cache.deleteByTags(["products"]);
+    await Sonamu.cache.deleteByTag({ tags: ["products"] });
 
     return result;
   }
@@ -273,10 +273,10 @@ class ProductModelClass extends BaseModelClass {
 
 ```typescript
 // Delete specific key
-await Sonamu.cache.delete("Product.findById:123");
+await Sonamu.cache.delete({ key: "Product.findById:123" });
 
-// Delete with pattern matching
-await Sonamu.cache.deleteMany("Product.findById:*");
+// Delete multiple keys
+await Sonamu.cache.deleteMany({ keys: ["Product.findById:123", "Product.findById:456"] });
 ```
 
 ### Clear All
@@ -509,7 +509,7 @@ export default defineConfig({
         const result = await this.insert(wdb, data);
 
         // Invalidate cache
-        await Sonamu.cache.deleteByTags(["products"]);
+        await Sonamu.cache.deleteByTag({ tags: ["products"] });
 
         return result;
       }
@@ -549,7 +549,7 @@ export default defineConfig({
         await this.upsert(wdb, { id, ...data });
 
         // Invalidate only this user's cache
-        await Sonamu.cache.delete(`user:profile:${id}`);
+        await Sonamu.cache.delete({ key: `user:profile:${id}` });
 
         return this.getProfile(id);
       }
@@ -640,7 +640,7 @@ export default defineConfig({
       @api({ httpMethod: "DELETE" })
       async clearSearchCache() {
         // Invalidate all search caches
-        await Sonamu.cache.deleteByTags(["search"]);
+        await Sonamu.cache.deleteByTag({ tags: ["search"] });
         return { success: true };
       }
     }

--- a/modules/docs/en/api-reference/decorators/transactional.mdx
+++ b/modules/docs/en/api-reference/decorators/transactional.mdx
@@ -597,18 +597,18 @@ async save() {
 
         // 1. Aggregate sales
         const sales = await rdb.table("orders")
-          .whereRaw("DATE_FORMAT(created_at, '%Y-%m') = ?", [month])
+          .whereRaw("to_char(created_at, 'YYYY-MM') = ?", [month])
           .sum("total_amount as total");
 
         // 2. New members
         const newUsers = await rdb.table("users")
-          .whereRaw("DATE_FORMAT(created_at, '%Y-%m') = ?", [month])
+          .whereRaw("to_char(created_at, 'YYYY-MM') = ?", [month])
           .count("* as count");
 
         // 3. Sales by product
         const productSales = await rdb.table("order_items")
           .join("orders", "orders.id", "order_items.order_id")
-          .whereRaw("DATE_FORMAT(orders.created_at, '%Y-%m') = ?", [month])
+          .whereRaw("to_char(orders.created_at, 'YYYY-MM') = ?", [month])
           .groupBy("order_items.product_id")
           .select(
             "order_items.product_id",

--- a/modules/docs/en/troubleshooting/performance/caching-strategies.mdx
+++ b/modules/docs/en/troubleshooting/performance/caching-strategies.mdx
@@ -237,8 +237,8 @@ class UserModelClass extends BaseModelClass {
     const user = await this.save(params);
 
     // Invalidate related caches
-    await Sonamu.cache.delete("users:active:count");
-    await Sonamu.cache.delete("users:stats");
+    await Sonamu.cache.delete({ key: "users:active:count" });
+    await Sonamu.cache.delete({ key: "users:stats" });
 
     return user;
   }
@@ -459,7 +459,7 @@ class AuthService {
 
   // Logout
   async logout(token: string) {
-    await Sonamu.cache.delete(`session:${token}`);
+    await Sonamu.cache.delete({ key: `session:${token}` });
   }
 }
 ```
@@ -492,8 +492,8 @@ class ProductModelClass extends BaseModelClass {
 
   private async invalidateProductCaches() {
     // Delete individually
-    await Sonamu.cache.delete("featured:products");
-    await Sonamu.cache.delete("stats:products");
+    await Sonamu.cache.delete({ key: "featured:products" });
+    await Sonamu.cache.delete({ key: "stats:products" });
   }
 }
 ```

--- a/modules/docs/ko/api-development/context/custom-context.mdx
+++ b/modules/docs/ko/api-development/context/custom-context.mdx
@@ -82,7 +82,7 @@ declare module "sonamu" {
 // middleware/auth.middleware.ts
 import { FastifyRequest, FastifyReply } from "fastify";
 import jwt from "jsonwebtoken";
-import { Sonamu } from "sonamu";
+import { Sonamu, DB } from "sonamu";
 
 export async function authMiddleware(request: FastifyRequest, reply: FastifyReply) {
   // Authorization 헤더에서 토큰 추출
@@ -105,8 +105,8 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
     };
 
     // DB에서 사용자 정보 조회
-    const rdb = Sonamu.getPuri("r");
-    const user = await rdb.table("users").where("id", payload.userId).first();
+    const rdb = DB.getDB("r");
+    const user = await rdb("users").where("id", payload.userId).first();
 
     if (!user) {
       reply.status(401);
@@ -141,7 +141,7 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
 ```typescript
 // middleware/tenant.middleware.ts
 import { FastifyRequest } from "fastify";
-import { Sonamu } from "sonamu";
+import { Sonamu, DB } from "sonamu";
 
 export async function tenantMiddleware(request: FastifyRequest) {
   const context = Sonamu.getContext();
@@ -154,11 +154,10 @@ export async function tenantMiddleware(request: FastifyRequest) {
     return; // 테넌트 정보 없음
   }
 
-  const rdb = Sonamu.getPuri("r");
+  const rdb = DB.getDB("r");
 
   // 테넌트 조회
-  const tenant = await rdb
-    .table("tenants")
+  const tenant = await rdb("tenants")
     .where((qb) => {
       if (subdomain) {
         qb.where("subdomain", subdomain);

--- a/modules/docs/ko/api-development/context/getting-context.mdx
+++ b/modules/docs/ko/api-development/context/getting-context.mdx
@@ -411,9 +411,9 @@ class AnalyticsFrame extends BaseFrameClass {
   async track(params: TrackParams): Promise<void> {
     const context = Sonamu.getContext();
 
-    const wdb = this.getPuri("w");
+    const wdb = this.getDB("w");
 
-    await wdb.table("analytics").insert({
+    await wdb("analytics").insert({
       event_type: params.eventType,
       event_data: JSON.stringify(params.data),
       user_id: context.user?.id,

--- a/modules/docs/ko/api-reference/base-model/get-puri.mdx
+++ b/modules/docs/ko/api-reference/base-model/get-puri.mdx
@@ -374,7 +374,7 @@ class UserModelClass extends BaseModelClass {
         const [result] = await rdb.raw(`
           WITH monthly_sales AS (
             SELECT
-              DATE_FORMAT(created_at, '%Y-%m') as month,
+              to_char(created_at, 'YYYY-MM') as month,
               COUNT(*) as order_count,
               SUM(total_amount) as total
             FROM orders

--- a/modules/docs/ko/api-reference/decorators/api.mdx
+++ b/modules/docs/ko/api-reference/decorators/api.mdx
@@ -592,7 +592,7 @@ async findById(id: number) {
         const result = await this.upsert(wdb, { id, ...data });
 
         // 캐시 무효화
-        await Sonamu.cache.deleteByTags(["products"]);
+        await Sonamu.cache.deleteByTag({ tags: ["products"] });
 
         return result;
       }

--- a/modules/docs/ko/api-reference/decorators/cache.mdx
+++ b/modules/docs/ko/api-reference/decorators/cache.mdx
@@ -190,7 +190,7 @@ async findById(id: number) {
 }
 
 // 캐시 무효화
-await Sonamu.cache.deleteByTags(["products"]);
+await Sonamu.cache.deleteByTag({ tags: ["products"] });
 ```
 
 ### grace
@@ -262,7 +262,7 @@ class ProductModelClass extends BaseModelClass {
     const result = await this.insert(wdb, data);
 
     // "products" 태그의 모든 캐시 무효화
-    await Sonamu.cache.deleteByTags(["products"]);
+    await Sonamu.cache.deleteByTag({ tags: ["products"] });
 
     return result;
   }
@@ -273,10 +273,10 @@ class ProductModelClass extends BaseModelClass {
 
 ```typescript
 // 특정 키 삭제
-await Sonamu.cache.delete("Product.findById:123");
+await Sonamu.cache.delete({ key: "Product.findById:123" });
 
-// 패턴 매칭으로 삭제
-await Sonamu.cache.deleteMany("Product.findById:*");
+// 여러 키 삭제
+await Sonamu.cache.deleteMany({ keys: ["Product.findById:123", "Product.findById:456"] });
 ```
 
 ### 전체 무효화
@@ -507,7 +507,7 @@ export default defineConfig({
         const result = await this.insert(wdb, data);
 
         // 캐시 무효화
-        await Sonamu.cache.deleteByTags(["products"]);
+        await Sonamu.cache.deleteByTag({ tags: ["products"] });
 
         return result;
       }
@@ -547,7 +547,7 @@ export default defineConfig({
         await this.upsert(wdb, { id, ...data });
 
         // 해당 사용자 캐시만 무효화
-        await Sonamu.cache.delete(`user:profile:${id}`);
+        await Sonamu.cache.delete({ key: `user:profile:${id}` });
 
         return this.getProfile(id);
       }
@@ -638,7 +638,7 @@ export default defineConfig({
       @api({ httpMethod: "DELETE" })
       async clearSearchCache() {
         // 검색 캐시 전체 무효화
-        await Sonamu.cache.deleteByTags(["search"]);
+        await Sonamu.cache.deleteByTag({ tags: ["search"] });
         return { success: true };
       }
     }

--- a/modules/docs/ko/api-reference/decorators/transactional.mdx
+++ b/modules/docs/ko/api-reference/decorators/transactional.mdx
@@ -594,18 +594,18 @@ async save() {
 
         // 1. 매출 집계
         const sales = await rdb.table("orders")
-          .whereRaw("DATE_FORMAT(created_at, '%Y-%m') = ?", [month])
+          .whereRaw("to_char(created_at, 'YYYY-MM') = ?", [month])
           .sum("total_amount as total");
 
         // 2. 신규 회원 수
         const newUsers = await rdb.table("users")
-          .whereRaw("DATE_FORMAT(created_at, '%Y-%m') = ?", [month])
+          .whereRaw("to_char(created_at, 'YYYY-MM') = ?", [month])
           .count("* as count");
 
         // 3. 상품별 판매량
         const productSales = await rdb.table("order_items")
           .join("orders", "orders.id", "order_items.order_id")
-          .whereRaw("DATE_FORMAT(orders.created_at, '%Y-%m') = ?", [month])
+          .whereRaw("to_char(orders.created_at, 'YYYY-MM') = ?", [month])
           .groupBy("order_items.product_id")
           .select(
             "order_items.product_id",

--- a/modules/docs/ko/troubleshooting/performance/caching-strategies.mdx
+++ b/modules/docs/ko/troubleshooting/performance/caching-strategies.mdx
@@ -237,8 +237,8 @@ class UserModelClass extends BaseModelClass {
     const user = await this.save(params);
 
     // 관련 캐시 무효화
-    await Sonamu.cache.delete("users:active:count");
-    await Sonamu.cache.delete("users:stats");
+    await Sonamu.cache.delete({ key: "users:active:count" });
+    await Sonamu.cache.delete({ key: "users:stats" });
 
     return user;
   }
@@ -459,7 +459,7 @@ class AuthService {
 
   // 로그아웃
   async logout(token: string) {
-    await Sonamu.cache.delete(`session:${token}`);
+    await Sonamu.cache.delete({ key: `session:${token}` });
   }
 }
 ```
@@ -492,8 +492,8 @@ class ProductModelClass extends BaseModelClass {
 
   private async invalidateProductCaches() {
     // 개별 삭제
-    await Sonamu.cache.delete("featured:products");
-    await Sonamu.cache.delete("stats:products");
+    await Sonamu.cache.delete({ key: "featured:products" });
+    await Sonamu.cache.delete({ key: "stats:products" });
   }
 }
 ```


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 참조한 Issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (작업 범위) — "문서와 주석이 코드와 어긋나는 경우 업데이트"

## 이 PR은 무엇인가

문서 코드 예제의 API 호출 오류 3건을 수정하여 **실제 소스코드 및 타입 정의와 일치하도록** 정정합니다. 총 14개 파일(ko 7, en 7) 변경, 소스코드 변경 없음.

## 왜 이 작업을 선정했는가

이슈 #44의 "문서와 주석이 코드와 어긋나는 경우 업데이트" 지침에 따라, 문서의 코드 예제가 실제 API와 다른 경우를 탐색하였습니다. 발견한 3건 모두 **문서대로 코드를 작성하면 런타임 에러가 발생**하는 실질적 문제입니다.

기존 Nightly PR들(#180~#202)과 중복되지 않으며, PR #187(close), #202의 피드백을 반영하였습니다.

---

### 커밋 1: BentoCache API 호출 시그니처 수정 (ko/en 6파일)

**문제**: `Sonamu.cache`가 래핑하는 BentoCache의 `delete`/`deleteMany`/`deleteByTag` 메서드 호출이 실제 타입 정의와 다릅니다.

| 문서의 호출 | 실제 API (bentocache `DeleteOptions` 등) |
|---|---|
| `Sonamu.cache.deleteByTags(["products"])` | `Sonamu.cache.deleteByTag({ tags: ["products"] })` |
| `Sonamu.cache.delete("key")` | `Sonamu.cache.delete({ key: "key" })` |
| `Sonamu.cache.deleteMany("glob*")` | `Sonamu.cache.deleteMany({ keys: [...] })` (glob 미지원) |

**근거**: `bentocache@1.5.1`의 `build/src/types/main.d.ts`에서 `DeleteOptions = { key: string }`, `DeleteManyOptions = { keys: string[] }`, `DeleteByTagOptions = { tags: string[] }` 타입이 정의되어 있습니다.

**수정 범위**: `cache.mdx` (ko/en), `api.mdx` (ko/en), `caching-strategies.mdx` (ko/en) — 총 6파일

**이렇게 하지 않으면**: 문서를 참고하여 `Sonamu.cache.delete("key")`로 코드를 작성하면, BentoCache 내부에서 `rawOptions.key`가 `undefined`가 되어 의도한 캐시가 삭제되지 않습니다.

### 커밋 2: MySQL DATE_FORMAT을 PostgreSQL to_char로 교체 (ko/en 4파일)

**문제**: Sonamu는 PostgreSQL 전용 프레임워크인데, `transactional.mdx`와 `get-puri.mdx`의 "복잡한 보고서" 예제에서 MySQL 전용 함수인 `DATE_FORMAT(created_at, '%Y-%m')`을 사용하고 있습니다.

**근거**: `modules/sonamu/src/database/db.ts:302`에서 client가 `"postgresql"` 또는 `"pgnative"`로 고정됩니다. PostgreSQL에서 `DATE_FORMAT`은 존재하지 않는 함수입니다.

**수정**: `DATE_FORMAT(created_at, '%Y-%m')` → `to_char(created_at, 'YYYY-MM')` (PostgreSQL 표준)

**이렇게 하지 않으면**: 예제를 그대로 실행하면 `ERROR: function date_format(timestamp, text) does not exist`가 발생합니다.

### 커밋 3: Frame/미들웨어 예제에서 미존재 getPuri() 호출 수정 (ko/en 4파일)

**문제 A**: `getting-context.mdx`의 `AnalyticsFrame` 예제에서 `this.getPuri("w")`를 호출하지만, `BaseFrameClass`(`base-frame.ts`)는 `getDB()`만 제공합니다.

**문제 B**: `custom-context.mdx`의 auth/tenant 미들웨어 예제에서 `Sonamu.getPuri("r")`를 호출하지만, `SonamuClass`(`sonamu.ts`)에는 `getPuri()` 메서드가 존재하지 않습니다.

**근거**:
- `BaseFrameClass`는 `getDB(which: DBPreset): Knex`와 `getUpsertBuilder()`만 노출 (`base-frame.ts:18-24`)
- `SonamuClass`에 `getPuri` 메서드 없음 (`sonamu.ts` 전체 검색)
- PR #202에서 Frame 문서의 getPuri 사용을 수정했으나 이 2개 파일은 누락됨

**수정**:
- Frame 예제: `this.getPuri("w")` → `this.getDB("w")`, `.table("analytics")` → `("analytics")`
- 미들웨어 예제: `Sonamu.getPuri("r")` → `DB.getDB("r")`, import에 `DB` 추가

**이렇게 하지 않으면**: `TypeError: this.getPuri is not a function` 또는 `TypeError: Sonamu.getPuri is not a function`이 런타임에 발생합니다.

## 영향 범위

문서 전용 변경이므로 기능에 영향 없음. 변경된 14파일 모두 `.mdx` 문서 파일이며, ko/en이 대칭적으로 수정됨.

## 확인 방법

1. 수정된 코드 예제의 메서드명/시그니처를 실제 소스 타입 정의와 대조
2. `pnpm check` (oxlint + oxfmt) 통과 확인됨

## 사람의 확인이 필요한 부분

- `custom-context.mdx`에서 `Sonamu.getPuri("r")`를 `DB.getDB("r")`로 교체하면서, `.table("users")` knex 문법을 `("users")` 단축 호출로 변경하였습니다. 기존 예제의 스타일 선호도에 따라 `.from("users")` 등으로 조정이 필요할 수 있습니다.
- `transactional.mdx`의 "복잡한 보고서" 예제에서 `rdb.raw("SUM(...)")` 패턴이 아직 남아 있습니다. PR #198에서 Puri 정적 메서드 패턴을 권장하는 방향으로 정정한 바 있으나, 이 예제는 `@transactional` 데코레이터의 raw SQL 사용 시나리오를 보여주는 목적이므로 이번에는 변경하지 않았습니다.