### PR TITLE
[Nightly 2026-07-07] query-optimization HAVING절의 PostgreSQL 미지원 alias 수정 및 deployment Docker Compose DB 환경변수 불일치 정정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/faq/deployment.mdx
+++ b/modules/docs/en/faq/deployment.mdx
@@ -482,9 +482,9 @@ services:
   postgres:
     image: postgres:15-alpine
     environment:
-      POSTGRES_DB: sonamu_prod
+      POSTGRES_DB: sonamu_production
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_PASSWORD: ${SONAMU_DB_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:

--- a/modules/docs/en/troubleshooting/performance/query-optimization.mdx
+++ b/modules/docs/en/troubleshooting/performance/query-optimization.mdx
@@ -182,7 +182,7 @@ const orderStats = await OrderModel.getPuri("r").table("orders")
   })
   .where({ status: "completed" })
   .groupBy("user_id")
-  .having("order_count", ">", 10); // More than 10 orders
+  .having("COUNT(*)", ">", 10); // More than 10 orders
 ```
 
 ## Pagination Optimization

--- a/modules/docs/ko/faq/deployment.mdx
+++ b/modules/docs/ko/faq/deployment.mdx
@@ -482,9 +482,9 @@ services:
   postgres:
     image: postgres:15-alpine
     environment:
-      POSTGRES_DB: sonamu_prod
+      POSTGRES_DB: sonamu_production
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_PASSWORD: ${SONAMU_DB_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:

--- a/modules/docs/ko/troubleshooting/performance/query-optimization.mdx
+++ b/modules/docs/ko/troubleshooting/performance/query-optimization.mdx
@@ -182,7 +182,7 @@ const orderStats = await OrderModel.getPuri("r").table("orders")
   })
   .where({ status: "completed" })
   .groupBy("user_id")
-  .having("order_count", ">", 10); // 주문 10개 이상
+  .having("COUNT(*)", ">", 10); // 주문 10개 이상
 ```
 
 ## 페이지네이션 최적화


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 참조한 Issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (작업 범위) — "문서와 주석이 코드와 어긋나는 경우 업데이트", "잠재적으로 위험한 포인트 식별"

## 이 PR은 무엇인가

문서 코드 예제의 실행 불가능한 오류 2건을 수정하여 **실제 PostgreSQL 동작 및 Docker Compose 설정 규칙과 일치하도록** 정정합니다. 총 4개 파일(ko 2, en 2) 변경, 소스코드 변경 없음.

## 왜 이 작업을 선정했는가

이슈 #44의 "문서와 주석이 코드와 어긋나는 경우 업데이트" 및 "잠재적으로 위험한 포인트 식별" 지침에 따라, 문서를 복사하면 런타임 에러가 발생하거나 서비스 연결이 실패하는 사례를 탐색하였습니다.

기존 Nightly PR들(#180~#203)과 중복되지 않으며, PR #202(noasouth의 puri 패턴 정정)과 PR #187(close, 소스코드 변경 기각)의 피드백을 반영하여 **문서 수정에만 집중**하였습니다.

---

### 커밋 1: HAVING절에서 PostgreSQL 미지원 SELECT alias를 집계 표현식으로 교체 (ko/en 2파일)

**문제**: `query-optimization.mdx`의 GROUP BY 최적화 예제에서 `.having("order_count", ">", 10)`을 사용하고 있으나, `order_count`는 SELECT절에서 `Puri.count()`에 부여한 alias입니다. **PostgreSQL은 HAVING절에서 SELECT alias를 참조할 수 없습니다.**

**근거**: Puri의 `having()` 구현(`puri.ts:1100-1115`)은 3-인자 호출 시 첫 번째 인자를 `this.knex.raw(conditions[0])`으로 감싸서 SQL에 그대로 전달합니다. 따라서 `"order_count"` 문자열이 SQL의 HAVING절에 컬럼명으로 들어가는데, PostgreSQL에서 이 alias는 사용 불가하여 `column "order_count" does not exist` 런타임 에러가 발생합니다.

**수정**: `.having("order_count", ">", 10)` → `.having("COUNT(*)", ">", 10)`

**이렇게 하지 않으면**: 문서를 참고하여 GROUP BY + HAVING 패턴을 작성한 사용자가 런타임 에러를 만납니다.

**영향 확인 방법**: PostgreSQL 환경에서 수정 전/후 코드를 실행하여 에러 발생 여부를 비교할 수 있습니다.

### 커밋 2: Docker Compose 예제의 postgres 서비스와 API 서비스 간 DB 이름·비밀번호 변수 불일치 수정 (ko/en 2파일)

**문제**: `deployment.mdx`의 Docker Compose 예제에서 두 가지 불일치가 있습니다:

| 항목 | postgres 서비스 (수정 전) | api 서비스 | 불일치 |
|------|--------------------------|-----------|--------|
| DB 이름 | `POSTGRES_DB: sonamu_prod` | `SONAMU_DB_NAME: sonamu_production` | 이름 다름 |
| 비밀번호 | `POSTGRES_PASSWORD: ${DB_PASSWORD}` | `SONAMU_DB_PASSWORD: ${SONAMU_DB_PASSWORD}` | 변수명 다름 |

**근거**: `connectionFromEnv()`(`db.ts:115`)에서 `SONAMU_DB_NAME` 미설정 시 기본값이 `${baseName}_production`이므로, postgres 서비스도 `sonamu_production`으로 통일하는 것이 Sonamu 컨벤션에 부합합니다. 비밀번호 변수도 `${SONAMU_DB_PASSWORD}`로 통일하여 `.env` 파일에서 하나의 변수로 양쪽 서비스가 동일한 자격증명을 참조하도록 합니다.

**수정**:
- `POSTGRES_DB: sonamu_prod` → `POSTGRES_DB: sonamu_production`
- `POSTGRES_PASSWORD: ${DB_PASSWORD}` → `POSTGRES_PASSWORD: ${SONAMU_DB_PASSWORD}`

**이렇게 하지 않으면**: Docker Compose를 그대로 복사하면 postgres가 `sonamu_prod` 데이터베이스를 생성하는데 API가 `sonamu_production`에 연결하려 하여 연결 실패가 발생합니다. 비밀번호도 `.env`에서 양쪽 변수를 모두 설정하지 않으면 인증 실패합니다.

**영향 확인 방법**: Docker Compose 예제를 로컬에서 `docker compose up`으로 실행하여 API 컨테이너가 postgres에 정상 연결되는지 확인할 수 있습니다.

---

## 추가 참고 사항

코드베이스 분석 과정에서 소스코드(`code-generation.ts:888`)에 `typeof` 오용 버그(`typeof column.defaultTo.startsWith('"')`가 항상 truthy)를 발견하였으나, PR #187에서 소스코드 로직 변경이 기각된 전례를 고려하여 이번 PR에서는 제외하였습니다. 필요 시 별도 이슈로 논의를 제안드립니다.