### PR TITLE
[Nightly 2026-07-08] deployment FAQ·pgvector-setup 문서의 미존재/제거된 SonamuConfig API 사용 코드 예제를 현재 API로 일괄 정정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/advanced-features/vector-search/pgvector-setup.mdx
+++ b/modules/docs/en/advanced-features/vector-search/pgvector-setup.mdx
@@ -41,10 +41,7 @@ To implement vector search, you need a database that can store and search vector
 // sonamu.config.ts
 export default defineConfig({
   database: {
-    client: "pg",
-    connection: {
-      /* ... */
-    },
+    database: "pg",
   },
 });
 ```
@@ -215,23 +212,15 @@ OPENAI_API_KEY=sk-...
 import { defineConfig } from "sonamu";
 
 export default defineConfig({
+  projectName: "myapp",
   database: {
-    name: "myapp",
-    defaultOptions: {
-      client: "pg",
-      connection: {
-        host: "localhost",
-        port: 5432,
-        user: "postgres",
-        password: "postgres",
-        database: "myapp",
-      },
-    },
+    database: "pg",
   },
 });
 ```
 
-Sonamu already uses PostgreSQL. No additional configuration needed.
+Sonamu already uses PostgreSQL. DB connection details are automatically loaded from
+`SONAMU_DB_*` environment variables, so no additional configuration is needed.
 
 ### 3. Create Table with Knex Migration
 

--- a/modules/docs/en/faq/deployment.mdx
+++ b/modules/docs/en/faq/deployment.mdx
@@ -233,29 +233,26 @@ gunzip < backup.sql.gz | psql -h prod-db.example.com -U postgres -d sonamu_prod
 <AccordionGroup>
 <Accordion title="How do I set up logging?">
 
-**Using Winston:**
+Sonamu provides structured logging based on [LogTape](https://github.com/dahlia/logtape).
+Configure it via the `logging` option in `sonamu.config.ts`:
 
 ```typescript
 // sonamu.config.ts
-import winston from "winston";
+import { defineConfig } from "sonamu";
 
-export default {
-  server: {
-    logger: winston.createLogger({
-      level: process.env.LOG_LEVEL || "info",
-      format: winston.format.json(),
-      transports: [
-        new winston.transports.File({
-          filename: "logs/error.log",
-          level: "error",
-        }),
-        new winston.transports.File({
-          filename: "logs/combined.log",
-        }),
-      ],
-    }),
+export default defineConfig({
+  // ...
+  logging: {
+    sinks: {
+      console: { type: "console" },
+      file: { type: "file", path: "logs/app.log" },
+    },
+    filters: {
+      all: { sinkId: "console", level: "info" },
+      fileAll: { sinkId: "file", level: "warning" },
+    },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 **Using the logger:**
@@ -277,6 +274,8 @@ class UserModelClass extends BaseModelClass {
   }
 }
 ```
+
+See [LogTape Setup](/en/configuration/logging/logtape-setup) for detailed configuration.
 
 </Accordion>
 
@@ -323,6 +322,7 @@ export const HealthFrame = new HealthFrameClass();
 ```typescript
 // sonamu.config.ts
 import * as Sentry from "@sentry/node";
+import { defineConfig } from "sonamu";
 
 if (process.env.NODE_ENV === "production") {
   Sentry.init({
@@ -332,8 +332,10 @@ if (process.env.NODE_ENV === "production") {
   });
 }
 
-export default {
+export default defineConfig({
+  // ...
   server: {
+    // ...
     lifecycle: {
       async onStart() {
         console.log("Server started");
@@ -345,7 +347,7 @@ export default {
       },
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 </Accordion>
@@ -361,61 +363,63 @@ export default {
 **1. Connection Pool settings:**
 
 ```typescript
-export default {
+import { defineConfig } from "sonamu";
+
+export default defineConfig({
+  // ...
   database: {
-    connections: {
-      main: {
-        pool: {
-          min: 2,
-          max: 10,
-          acquireTimeoutMillis: 30000,
-          idleTimeoutMillis: 30000,
-        },
+    database: "pg",
+    defaultOptions: {
+      pool: {
+        min: 2,
+        max: 10,
       },
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 **2. Enable caching:**
 
 ```typescript
-import { bentostore } from "bentocache";
-import { redisDriver } from "bentocache/drivers/redis";
+import { defineConfig } from "sonamu";
+import { drivers, store } from "sonamu/cache";
 
-export default {
+export default defineConfig({
+  // ...
   server: {
+    // ...
     cache: {
       default: "redis",
       stores: {
-        redis: bentostore().useL1Layer(
-          redisDriver({
+        redis: store().useL1Layer(
+          drivers.redis({
             connection: {
               host: process.env.REDIS_HOST,
-              port: 6379,
+              port: Number(process.env.REDIS_PORT) || 6379,
             },
           }),
         ),
       },
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 **3. Enable compression:**
 
 ```typescript
-import compress from "@fastify/compress";
+import { defineConfig } from "sonamu";
 
-export default {
+export default defineConfig({
+  // ...
   server: {
-    lifecycle: {
-      async onStart(fastify) {
-        await fastify.register(compress);
-      },
+    // ...
+    plugins: {
+      compress: true,
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 </Accordion>
@@ -639,15 +643,21 @@ server {
 
 ```typescript
 // sonamu.config.ts
-export default {
+import { defineConfig } from "sonamu";
+
+export default defineConfig({
+  // ...
   server: {
-    cors: {
-      origin: process.env.CORS_ORIGIN || "http://localhost:5173",
-      credentials: true,
-      methods: ["GET", "POST", "PUT", "DELETE", "PATCH"],
+    // ...
+    plugins: {
+      cors: {
+        origin: process.env.CORS_ORIGIN || "http://localhost:5173",
+        credentials: true,
+        methods: ["GET", "POST", "PUT", "DELETE", "PATCH"],
+      },
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 </Accordion>
@@ -656,19 +666,22 @@ export default {
 
 ```typescript
 import rateLimit from "@fastify/rate-limit";
+import { defineConfig } from "sonamu";
 
-export default {
+export default defineConfig({
+  // ...
   server: {
-    lifecycle: {
-      async onStart(fastify) {
-        await fastify.register(rateLimit, {
-          max: 100, // 100 requests
+    // ...
+    plugins: {
+      custom: async (server) => {
+        await server.register(rateLimit, {
+          max: 100,
           timeWindow: "1 minute",
         });
       },
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 </Accordion>
@@ -702,7 +715,7 @@ export default {
 
 - [ ] Health check endpoint
 - [ ] Error monitoring (Sentry)
-- [ ] Log collection (Winston)
+- [ ] Log collection (LogTape)
 - [ ] DB backup automation
 
 **Deployment:**

--- a/modules/docs/ko/advanced-features/vector-search/pgvector-setup.mdx
+++ b/modules/docs/ko/advanced-features/vector-search/pgvector-setup.mdx
@@ -41,10 +41,7 @@ Sonamu로 웹 앱을 만들다 보면 이런 기능을 구현하게 됩니다:
 // sonamu.config.ts
 export default defineConfig({
   database: {
-    client: "pg",
-    connection: {
-      /* ... */
-    },
+    database: "pg",
   },
 });
 ```
@@ -179,23 +176,15 @@ OPENAI_API_KEY=sk-...
 import { defineConfig } from "sonamu";
 
 export default defineConfig({
+  projectName: "myapp",
   database: {
-    name: "myapp",
-    defaultOptions: {
-      client: "pg",
-      connection: {
-        host: "localhost",
-        port: 5432,
-        user: "postgres",
-        password: "postgres",
-        database: "myapp",
-      },
-    },
+    database: "pg",
   },
 });
 ```
 
-Sonamu는 이미 PostgreSQL을 쓰고 있습니다. 추가 설정 불필요합니다.
+Sonamu는 이미 PostgreSQL을 쓰고 있습니다. DB 연결 정보는 `SONAMU_DB_*` 환경변수에서 자동으로
+로드되므로 추가 설정이 불필요합니다.
 
 ### 3. Knex Migration으로 테이블 생성
 

--- a/modules/docs/ko/faq/deployment.mdx
+++ b/modules/docs/ko/faq/deployment.mdx
@@ -233,29 +233,26 @@ gunzip < backup.sql.gz | psql -h prod-db.example.com -U postgres -d sonamu_prod
 <AccordionGroup>
 <Accordion title="로그를 설정하려면?">
 
-**Winston 사용:**
+Sonamu는 [LogTape](https://github.com/dahlia/logtape) 기반의 구조화된 로깅을 제공합니다.
+`sonamu.config.ts`의 `logging` 옵션으로 설정합니다:
 
 ```typescript
 // sonamu.config.ts
-import winston from "winston";
+import { defineConfig } from "sonamu";
 
-export default {
-  server: {
-    logger: winston.createLogger({
-      level: process.env.LOG_LEVEL || "info",
-      format: winston.format.json(),
-      transports: [
-        new winston.transports.File({
-          filename: "logs/error.log",
-          level: "error",
-        }),
-        new winston.transports.File({
-          filename: "logs/combined.log",
-        }),
-      ],
-    }),
+export default defineConfig({
+  // ...
+  logging: {
+    sinks: {
+      console: { type: "console" },
+      file: { type: "file", path: "logs/app.log" },
+    },
+    filters: {
+      all: { sinkId: "console", level: "info" },
+      fileAll: { sinkId: "file", level: "warning" },
+    },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 **로그 사용:**
@@ -277,6 +274,8 @@ class UserModelClass extends BaseModelClass {
   }
 }
 ```
+
+자세한 설정은 [LogTape 설정](/ko/configuration/logging/logtape-setup)을 참고하세요.
 
 </Accordion>
 
@@ -323,6 +322,7 @@ export const HealthFrame = new HealthFrameClass();
 ```typescript
 // sonamu.config.ts
 import * as Sentry from "@sentry/node";
+import { defineConfig } from "sonamu";
 
 if (process.env.NODE_ENV === "production") {
   Sentry.init({
@@ -332,8 +332,10 @@ if (process.env.NODE_ENV === "production") {
   });
 }
 
-export default {
+export default defineConfig({
+  // ...
   server: {
+    // ...
     lifecycle: {
       async onStart() {
         console.log("Server started");
@@ -345,7 +347,7 @@ export default {
       },
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 </Accordion>
@@ -361,61 +363,63 @@ export default {
 **1. Connection Pool 설정:**
 
 ```typescript
-export default {
+import { defineConfig } from "sonamu";
+
+export default defineConfig({
+  // ...
   database: {
-    connections: {
-      main: {
-        pool: {
-          min: 2,
-          max: 10,
-          acquireTimeoutMillis: 30000,
-          idleTimeoutMillis: 30000,
-        },
+    database: "pg",
+    defaultOptions: {
+      pool: {
+        min: 2,
+        max: 10,
       },
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 **2. 캐싱 활성화:**
 
 ```typescript
-import { bentostore } from "bentocache";
-import { redisDriver } from "bentocache/drivers/redis";
+import { defineConfig } from "sonamu";
+import { drivers, store } from "sonamu/cache";
 
-export default {
+export default defineConfig({
+  // ...
   server: {
+    // ...
     cache: {
       default: "redis",
       stores: {
-        redis: bentostore().useL1Layer(
-          redisDriver({
+        redis: store().useL1Layer(
+          drivers.redis({
             connection: {
               host: process.env.REDIS_HOST,
-              port: 6379,
+              port: Number(process.env.REDIS_PORT) || 6379,
             },
           }),
         ),
       },
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 **3. 압축 활성화:**
 
 ```typescript
-import compress from "@fastify/compress";
+import { defineConfig } from "sonamu";
 
-export default {
+export default defineConfig({
+  // ...
   server: {
-    lifecycle: {
-      async onStart(fastify) {
-        await fastify.register(compress);
-      },
+    // ...
+    plugins: {
+      compress: true,
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 </Accordion>
@@ -639,15 +643,21 @@ server {
 
 ```typescript
 // sonamu.config.ts
-export default {
+import { defineConfig } from "sonamu";
+
+export default defineConfig({
+  // ...
   server: {
-    cors: {
-      origin: process.env.CORS_ORIGIN || "http://localhost:5173",
-      credentials: true,
-      methods: ["GET", "POST", "PUT", "DELETE", "PATCH"],
+    // ...
+    plugins: {
+      cors: {
+        origin: process.env.CORS_ORIGIN || "http://localhost:5173",
+        credentials: true,
+        methods: ["GET", "POST", "PUT", "DELETE", "PATCH"],
+      },
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 </Accordion>
@@ -656,19 +666,22 @@ export default {
 
 ```typescript
 import rateLimit from "@fastify/rate-limit";
+import { defineConfig } from "sonamu";
 
-export default {
+export default defineConfig({
+  // ...
   server: {
-    lifecycle: {
-      async onStart(fastify) {
-        await fastify.register(rateLimit, {
-          max: 100, // 100 requests
+    // ...
+    plugins: {
+      custom: async (server) => {
+        await server.register(rateLimit, {
+          max: 100,
           timeWindow: "1 minute",
         });
       },
     },
   },
-} satisfies SonamuConfig;
+});
 ```
 
 </Accordion>
@@ -702,7 +715,7 @@ export default {
 
 - [ ] 헬스체크 엔드포인트
 - [ ] 에러 모니터링 (Sentry)
-- [ ] 로그 수집 (Winston)
+- [ ] 로그 수집 (LogTape)
 - [ ] DB 백업 자동화
 
 **배포:**


### PR DESCRIPTION
> 이 PR은 issue #43(Nightly PR Directions)과 issue #44(작업 범위)의 지침에 따라 AI에 의해 자동 생성되었습니다.
> 코드베이스에 대한 ownership은 전적으로 메인테이너에게 있으며, 이 PR은 검토를 위한 제안입니다.

## 참조한 Issue

- #43 (Nightly PR Directions) — 작업 절차 및 PR 형식 지침
- #44 (작업 범위) — "문서와 주석이 코드와 어긋나는 경우 업데이트"

## 이 PR은 무엇인가

`deployment.mdx`(FAQ)와 `pgvector-setup.mdx`의 코드 예제에서, 현재 `SonamuConfig` 타입에 존재하지 않거나 명시적으로 제거된 API 필드들을 현재 API에 맞게 정정합니다. 총 4개 파일(ko 2, en 2) 변경, 소스코드 변경 없음.

## 왜 이 작업을 선정했는가

이슈 #44의 "문서와 주석이 코드와 어긋나는 경우 업데이트" 지침에 따라, 문서 코드 예제가 현재 `SonamuConfig` 타입과 일치하는지 검증했습니다. `deployment.mdx`에서 7곳, `pgvector-setup.mdx`에서 2곳의 불일치를 발견했습니다.

기존 Nightly PR들(#170~#204)과 중복되지 않으며, PR #202(noasouth의 Frame getPuri 정정)과 PR #187(close, workflows.destroy 소스코드 변경 기각)의 피드백을 반영하여 **문서 수정에만 집중**했습니다.

---

### 커밋 1: deployment FAQ의 미존재 SonamuConfig API 사용 코드 예제 수정 (ko/en 2파일)

**문제**: `deployment.mdx`의 성능 최적화·로깅·캐싱·CORS·압축·Rate Limiting 예제들이 현재 `SonamuConfig` 타입에 존재하지 않는 필드를 사용하고 있습니다.

| 예제 | 사용한 필드 | 현재 올바른 필드 |
|------|------------|-----------------|
| 로깅 설정 | `server.logger` (Winston) | `logging` (LogTape 기반) |
| Connection Pool | `database.connections.main.pool` | `database.defaultOptions.pool` |
| 캐싱 | `import { bentostore } from "bentocache"` | `import { store } from "sonamu/cache"` |
| 압축 | `lifecycle.onStart`에서 수동 `register(compress)` | `server.plugins.compress: true` |
| CORS | `server.cors` | `server.plugins.cors` |
| Rate Limiting | `lifecycle.onStart`에서 수동 `register` | `server.plugins.custom`에서 등록 |
| 전체 | `} satisfies SonamuConfig` | `defineConfig(...)` 패턴 |

**근거**: `SonamuConfig` 타입 정의(`config.ts`)에 `server.logger`, `database.connections`, `server.cors` 필드가 없음. `SonamuServerOptions.plugins`에 `compress`, `cors` 옵션이 이미 존재함. Sonamu는 LogTape 기반 로깅을 사용하며 `logging` 최상위 옵션으로 설정됨. 캐시 드라이버는 `sonamu/cache` 모듈을 통해 re-export됨.

**이렇게 하지 않으면**: 문서를 참고하여 설정을 작성한 사용자가 TypeScript 타입 에러를 만나거나, 런타임에서 설정이 무시됩니다.

**영향 확인 방법**: 수정된 코드 예제를 `sonamu.config.ts`에 작성하고 TypeScript 타입 체크(`pnpm build` 또는 에디터 타입 검사)를 실행하여 에러가 없는지 확인할 수 있습니다.

### 커밋 2: pgvector-setup 문서의 제거된 database.name 및 미존재 client/connection 직접 설정 교체 (ko/en 2파일)

**문제**: `pgvector-setup.mdx`의 Sonamu Config 예제에서 제거된 `database.name` 필드와 미존재 `database.client`, `database.connection` 직접 설정을 사용하고 있습니다.

| 사용한 필드 | 현재 올바른 필드 |
|------------|-----------------|
| `database.name: "myapp"` | `projectName: "myapp"` (최상위) |
| `database.client: "pg"` | `database.database: "pg"` |
| `database.defaultOptions.connection: { host, port, ... }` | `SONAMU_DB_*` 환경변수에서 자동 로드 |

**근거**: `da6561ce` 커밋에서 `database.name`과 `database.environments` 필드가 제거되었고, `assertNoLegacyDatabaseConfig()` 함수가 이를 감지하여 런타임 에러를 발생시킴(`db.ts:136-147`). DB 연결 정보는 이제 `SONAMU_DB_*` 환경변수에서 자동으로 로드됨.

**이렇게 하지 않으면**: 문서를 참고하여 `database.name`을 사용한 사용자가 서버 시작 시 `"Sonamu database.name and database.environments were removed"` 런타임 에러를 만납니다.

**영향 확인 방법**: 수정 전 코드를 `sonamu.config.ts`에 작성하면 `assertNoLegacyDatabaseConfig()` 에러가 발생하는 것을 확인할 수 있습니다.

## 사람의 확인이 필요한 부분

- `deployment.mdx`의 로깅 예제를 LogTape 기반으로 교체했습니다. `logging.sinks`, `logging.filters`의 정확한 스키마가 `SonamuLoggingOptions` 제네릭으로 정의되어 있어, 예제의 sink/filter 이름이 실제 프로젝트 설정과 일치하는지 확인이 필요합니다.
- `deployment.mdx`의 Rate Limiting 예제에서 `lifecycle.onStart` 대신 `plugins.custom`을 사용하도록 변경했습니다. `plugins.custom` 콜백의 시그니처가 `(server: FastifyInstance) => void`인 반면, 예제에서 `async` 함수를 사용하고 있습니다. 소스코드에서 `custom` 호출부(`await options.lifecycle?.onStart?.(server)` 패턴)가 await를 지원하는지 확인이 필요합니다.