### PR TITLE
[Nightly 2026-07-10] @transactional 데코레이터 문서의 getDB("w") 호출을 getPuri("w")로 일괄 교체하여 트랜잭션 컨텍스트 누락 문제 정정 (ko/en 2파일)

### DIFF
--- a/modules/docs/en/api-reference/decorators/transactional.mdx
+++ b/modules/docs/en/api-reference/decorators/transactional.mdx
@@ -14,24 +14,24 @@ class UserModelClass extends BaseModelClass<UserSubsetKey, UserSubsetMapping, Us
   @api({ httpMethod: "POST" })
   @transactional()
   async create(data: UserCreateParams) {
-    const wdb = this.getDB("w");
+    const wdb = this.getPuri("w");
 
     // All operations executed within transaction
-    const user = await this.insert(wdb, data);
-    await this.createProfile(user.id);
-    await this.sendWelcomeEmail(user.id);
+    const user = await wdb.table("users").insert(data).returning("*");
+    await this.createProfile(user[0].id);
+    await this.sendWelcomeEmail(user[0].id);
 
     // Commits if all succeed, rolls back if any fails
-    return user;
+    return user[0];
   }
 
   @api({ httpMethod: "PUT" })
   @transactional()
   async update(id: number, data: UserUpdateParams) {
-    const wdb = this.getDB("w");
+    const wdb = this.getPuri("w");
 
     // Transaction guaranteed
-    await this.upsert(wdb, { id, ...data });
+    await wdb.table("users").where("id", id).update(data);
     await this.updateRelatedData(id);
 
     return this.findById(id);
@@ -131,8 +131,8 @@ Specifies the database preset to use.
 @transactional({ dbPreset: "w" })
 async saveData(data: SaveParams) {
   // Uses write DB (default)
-  const wdb = this.getDB("w");
-  return this.insert(wdb, data);
+  const wdb = this.getPuri("w");
+  return wdb.table("items").insert(data).returning("id");
 }
 
 @transactional({ dbPreset: "r", readOnly: true })
@@ -164,7 +164,7 @@ async criticalOperation(data: OperationParams) {
 ```typescript
 @transactional()
 async transfer(fromId: number, toId: number, amount: number) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   // 1. Withdraw
   await wdb.table("accounts")
@@ -194,19 +194,19 @@ Transactions with the same dbPreset are **reused**:
 class UserModelClass extends BaseModelClass {
   @transactional()
   async createUser(data: UserCreateParams) {
-    const wdb = this.getDB("w");
-    const user = await this.insert(wdb, data);
+    const wdb = this.getPuri("w");
+    const user = await wdb.table("users").insert(data).returning("*");
 
     // This method also has @transactional
     // but reuses the same transaction
-    await this.createProfile(user.id);
+    await this.createProfile(user[0].id);
 
-    return user;
+    return user[0];
   }
 
   @transactional()
   async createProfile(userId: number) {
-    const wdb = this.getDB("w");
+    const wdb = this.getPuri("w");
     // Reuses createUser's transaction
     return wdb.table("profiles").insert({ user_id: userId });
   }
@@ -230,7 +230,7 @@ Different dbPresets create **separate transactions**:
 ```typescript
 @transactional({ dbPreset: "w" })
 async saveData(data: SaveParams) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
   await wdb.table("logs").insert(data);
 
   // Different preset creates separate transaction
@@ -284,7 +284,7 @@ async findWithRelations(id: number) {
 async uploadAvatar() {
   const { files } = Sonamu.getContext();
   const file = files?.[0]; // Use first file
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   // File save + DB update in transaction
   const url = await this.saveFile(file);
@@ -336,7 +336,7 @@ async child() {
 ```typescript
 @transactional()
 async processOrder(orderId: number) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   try {
     await wdb.table("orders")
@@ -360,9 +360,9 @@ Throw an error when explicit rollback is needed:
 ```typescript
 @transactional()
 async validateAndSave(data: SaveParams) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
-  const result = await this.insert(wdb, data);
+  const result = await wdb.table("items").insert(data).returning("*");
 
   // Rollback on validation failure
   if (!this.validate(result)) {
@@ -398,7 +398,7 @@ class UserModelClass extends BaseModelClass {
 // ❌ Bad: Long-running operation
 @transactional()
 async processLargeData() {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   // 10-minute operation
   for (let i = 0; i < 1000000; i++) {
@@ -418,9 +418,11 @@ async processLargeData() {
 
 @transactional()
 async processBatch(batch: Item[]) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
   // Execute transaction in small units
-  return this.insertBatch(wdb, batch);
+  for (const item of batch) {
+    await wdb.table("items").insert(item);
+  }
 }
 ```
 
@@ -430,15 +432,15 @@ async processBatch(batch: Item[]) {
 // ❌ Bad: External API in transaction
 @transactional()
 async createOrder(data: OrderCreateParams) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
-  const order = await this.insert(wdb, data);
+  const order = await wdb.table("orders").insert(data).returning("*");
 
   // External payment API call (slow)
-  await this.paymentService.charge(order.amount);
+  await this.paymentService.charge(order[0].amount);
   // Transaction open too long
 
-  return order;
+  return order[0];
 }
 
 // ✅ Good: Handle outside transaction
@@ -457,13 +459,13 @@ async createOrder(data: OrderCreateParams) {
 
 @transactional()
 async saveOrder(data: OrderCreateParams) {
-  const wdb = this.getDB("w");
-  return this.insert(wdb, data);
+  const wdb = this.getPuri("w");
+  return (await wdb.table("orders").insert(data).returning("*"))[0];
 }
 
 @transactional()
 async updateOrderStatus(id: number, status: string) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
   return wdb.table("orders").where("id", id).update({ status });
 }
 ```
@@ -495,7 +497,7 @@ async save() {
         toAccountId: number,
         amount: number
       ) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
 
         // 1. Check sender balance
         const fromAccount = await wdb.table("accounts")
@@ -538,14 +540,14 @@ async save() {
       @api({ httpMethod: "POST" })
       @transactional()
       async createOrder(data: OrderCreateParams) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
 
         // 1. Create order
-        const order = await this.insert(wdb, {
+        const [order] = await wdb.table("orders").insert({
           user_id: data.userId,
           total_amount: data.totalAmount,
           status: "pending"
-        });
+        }).returning("*");
 
         // 2. Save order items
         await wdb.table("order_items").insert(
@@ -652,13 +654,13 @@ async save() {
       // Per-batch transaction
       @transactional()
       async processBatch(batch: Item[]) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
 
         // Transaction per batch
         const processed = [];
         for (const item of batch) {
-          const result = await this.processItem(wdb, item);
-          processed.push(result);
+          const result = await wdb.table("items").insert(item).returning("*");
+          processed.push(result[0]);
         }
 
         return processed;

--- a/modules/docs/ko/api-reference/decorators/transactional.mdx
+++ b/modules/docs/ko/api-reference/decorators/transactional.mdx
@@ -14,24 +14,24 @@ class UserModelClass extends BaseModelClass<UserSubsetKey, UserSubsetMapping, Us
   @api({ httpMethod: "POST" })
   @transactional()
   async create(data: UserCreateParams) {
-    const wdb = this.getDB("w");
+    const wdb = this.getPuri("w");
 
     // 모든 작업이 트랜잭션 내에서 실행됨
-    const user = await this.insert(wdb, data);
-    await this.createProfile(user.id);
-    await this.sendWelcomeEmail(user.id);
+    const user = await wdb.table("users").insert(data).returning("*");
+    await this.createProfile(user[0].id);
+    await this.sendWelcomeEmail(user[0].id);
 
     // 모두 성공하면 commit, 하나라도 실패하면 rollback
-    return user;
+    return user[0];
   }
 
   @api({ httpMethod: "PUT" })
   @transactional()
   async update(id: number, data: UserUpdateParams) {
-    const wdb = this.getDB("w");
+    const wdb = this.getPuri("w");
 
     // 트랜잭션 보장
-    await this.upsert(wdb, { id, ...data });
+    await wdb.table("users").where("id", id).update(data);
     await this.updateRelatedData(id);
 
     return this.findById(id);
@@ -128,8 +128,8 @@ async generateReport(startDate: Date, endDate: Date) {
 @transactional({ dbPreset: "w" })
 async saveData(data: SaveParams) {
   // 쓰기용 DB 사용 (기본값)
-  const wdb = this.getDB("w");
-  return this.insert(wdb, data);
+  const wdb = this.getPuri("w");
+  return wdb.table("items").insert(data).returning("id");
 }
 
 @transactional({ dbPreset: "r", readOnly: true })
@@ -161,7 +161,7 @@ async criticalOperation(data: OperationParams) {
 ```typescript
 @transactional()
 async transfer(fromId: number, toId: number, amount: number) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   // 1. 출금
   await wdb.table("accounts")
@@ -191,19 +191,19 @@ async transfer(fromId: number, toId: number, amount: number) {
 class UserModelClass extends BaseModelClass {
   @transactional()
   async createUser(data: UserCreateParams) {
-    const wdb = this.getDB("w");
-    const user = await this.insert(wdb, data);
+    const wdb = this.getPuri("w");
+    const user = await wdb.table("users").insert(data).returning("*");
 
     // 이 메서드도 @transactional이지만
     // 같은 트랜잭션을 재사용함
-    await this.createProfile(user.id);
+    await this.createProfile(user[0].id);
 
-    return user;
+    return user[0];
   }
 
   @transactional()
   async createProfile(userId: number) {
-    const wdb = this.getDB("w");
+    const wdb = this.getPuri("w");
     // createUser의 트랜잭션 재사용
     return wdb.table("profiles").insert({ user_id: userId });
   }
@@ -227,7 +227,7 @@ class UserModelClass extends BaseModelClass {
 ```typescript
 @transactional({ dbPreset: "w" })
 async saveData(data: SaveParams) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
   await wdb.table("logs").insert(data);
 
   // 다른 preset은 별도 트랜잭션
@@ -281,7 +281,7 @@ async findWithRelations(id: number) {
 async uploadAvatar() {
   const { files } = Sonamu.getContext();
   const file = files?.[0]; // 첫 번째 파일 사용
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   // 파일 저장 + DB 업데이트를 트랜잭션으로
   const url = await this.saveFile(file);
@@ -333,7 +333,7 @@ async child() {
 ```typescript
 @transactional()
 async processOrder(orderId: number) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   try {
     await wdb.table("orders")
@@ -357,9 +357,9 @@ async processOrder(orderId: number) {
 ```typescript
 @transactional()
 async validateAndSave(data: SaveParams) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
-  const result = await this.insert(wdb, data);
+  const result = await wdb.table("items").insert(data).returning("*");
 
   // 검증 실패 시 롤백
   if (!this.validate(result)) {
@@ -395,7 +395,7 @@ class UserModelClass extends BaseModelClass {
 // ❌ 나쁜 예: 오래 걸리는 작업
 @transactional()
 async processLargeData() {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   // 10분 걸리는 작업
   for (let i = 0; i < 1000000; i++) {
@@ -415,9 +415,11 @@ async processLargeData() {
 
 @transactional()
 async processBatch(batch: Item[]) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
   // 작은 단위로 트랜잭션 실행
-  return this.insertBatch(wdb, batch);
+  for (const item of batch) {
+    await wdb.table("items").insert(item);
+  }
 }
 ```
 
@@ -427,15 +429,15 @@ async processBatch(batch: Item[]) {
 // ❌ 나쁜 예: 트랜잭션 중 외부 API
 @transactional()
 async createOrder(data: OrderCreateParams) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
-  const order = await this.insert(wdb, data);
+  const order = await wdb.table("orders").insert(data).returning("*");
 
   // 외부 결제 API 호출 (느림)
-  await this.paymentService.charge(order.amount);
+  await this.paymentService.charge(order[0].amount);
   // 트랜잭션이 오래 열려있음
 
-  return order;
+  return order[0];
 }
 
 // ✅ 좋은 예: 트랜잭션 밖에서 처리
@@ -454,13 +456,13 @@ async createOrder(data: OrderCreateParams) {
 
 @transactional()
 async saveOrder(data: OrderCreateParams) {
-  const wdb = this.getDB("w");
-  return this.insert(wdb, data);
+  const wdb = this.getPuri("w");
+  return (await wdb.table("orders").insert(data).returning("*"))[0];
 }
 
 @transactional()
 async updateOrderStatus(id: number, status: string) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
   return wdb.table("orders").where("id", id).update({ status });
 }
 ```
@@ -492,7 +494,7 @@ async save() {
         toAccountId: number,
         amount: number
       ) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
 
         // 1. 출금 계좌 잔액 확인
         const fromAccount = await wdb.table("accounts")
@@ -535,14 +537,14 @@ async save() {
       @api({ httpMethod: "POST" })
       @transactional()
       async createOrder(data: OrderCreateParams) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
 
         // 1. 주문 생성
-        const order = await this.insert(wdb, {
+        const [order] = await wdb.table("orders").insert({
           user_id: data.userId,
           total_amount: data.totalAmount,
           status: "pending"
-        });
+        }).returning("*");
 
         // 2. 주문 상품 저장
         await wdb.table("order_items").insert(
@@ -649,13 +651,13 @@ async save() {
       // 배치별 트랜잭션
       @transactional()
       async processBatch(batch: Item[]) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
 
         // 배치 단위로 트랜잭션
         const processed = [];
         for (const item of batch) {
-          const result = await this.processItem(wdb, item);
-          processed.push(result);
+          const result = await wdb.table("items").insert(item).returning("*");
+          processed.push(result[0]);
         }
 
         return processed;


### PR DESCRIPTION
> 이 PR은 [#43 Nightly PR Directions](https://github.com/cartanova-ai/sonamu/issues/43)과 [#44](https://github.com/cartanova-ai/sonamu/issues/44), [#197](https://github.com/cartanova-ai/sonamu/issues/197)을 참조하여 AI(Claude)에 의해 자동으로 생성되었습니다. 코드베이스 ownership은 전적으로 메인테이너에게 있으며, 모든 변경은 리뷰 후 판단하시기 바랍니다.

## 요약

`@transactional` 데코레이터 레퍼런스 문서(ko/en)의 모든 코드 예제에서 `this.getDB("w")`를 `this.getPuri("w")`로 교체하고, 함께 사용된 미존재 헬퍼 호출(`this.insert(wdb, data)`, `this.upsert(wdb, ...)`)을 Puri 표준 쿼리 패턴으로 정정했습니다.

## 왜 이 작업을 선정했나

### 근본 원인: `getDB`는 트랜잭션 컨텍스트를 무시함

소스 코드(`base-model.ts:54-68`)를 확인하면:

- **`getDB(which)`**: 단순히 `DB.getDB(which)`를 반환합니다. AsyncLocalStorage의 트랜잭션 컨텍스트를 전혀 확인하지 않습니다.
- **`getPuri(which)`**: 먼저 `DB.getTransactionContext().getTransaction(which)`를 확인하여, 활성 트랜잭션이 있으면 해당 `PuriTransactionWrapper`를 반환합니다. 트랜잭션이 없으면 새 `PuriWrapper`를 생성합니다.

따라서 `@transactional()` 데코레이터 내에서 `this.getDB("w")`를 사용하면, **데코레이터가 시작한 트랜잭션과 무관한 별도의 DB 커넥션에서 쿼리가 실행됩니다.** 이는 다음 문제를 야기합니다:

1. 트랜잭션 내의 쓰기가 실제로는 트랜잭션 밖에서 실행되어, 에러 시 롤백되지 않음
2. 트랜잭션 중첩(재사용) 패턴이 의도대로 동작하지 않음

문서에서 이 패턴을 기본 예제로 안내하면, 사용자가 트랜잭션이 작동한다고 믿고 사용하지만 실제로는 데이터 무결성이 보장되지 않는 코드를 작성하게 됩니다.

### 서브이슈 #197과의 부합

서브이슈 #197은 sonamu-docs와 sonamu-skills 공통으로 `getPuri` 사용을 우선시하도록 문서를 수정하라고 지시하고 있습니다. 이번 변경은 이 지시의 핵심 대상인 트랜잭션 문서를 정정합니다.

### 일관성 문제

동일 문서 내에서도 읽기 전용 예제(`readOnly: true`)에서는 이미 `this.getPuri("r")`를 사용하고 있었으나, 쓰기 예제에서만 `this.getDB("w")`를 사용하여 일관성이 없었습니다.

## 접근 방식

1. **`this.getDB("w")` → `this.getPuri("w")`**: 트랜잭션 컨텍스트를 올바르게 참조하도록 교체
2. **`this.insert(wdb, data)` → `wdb.table("...").insert(data).returning("*")`**: 미존재 헬퍼 메서드 대신 Puri가 실제로 지원하는 표준 쿼리 패턴으로 교체
3. **`this.upsert(wdb, ...)` → `wdb.table("...").where(...).update(...)`**: 동일 이유로 교체
4. **`returning("*")` 결과의 배열 접근**: PostgreSQL `RETURNING` 절은 배열을 반환하므로, `user[0]` 패턴으로 정정

## 이렇게 하지 않으면

- 사용자가 `@transactional` 문서를 따라 코드를 작성하면, 트랜잭션이 작동하지 않는 코드가 됩니다.
- 에러 발생 시 롤백되지 않아 데이터 무결성이 깨질 수 있습니다.
- 트랜잭션 중첩 예제가 실제로는 중첩되지 않으므로, 사용자가 예기치 않은 동작을 경험합니다.

## 영향 범위

- 기능에 영향 없음. 문서의 코드 예제만 변경됨.
- 변경 대상: `modules/docs/ko/api-reference/decorators/transactional.mdx`, `modules/docs/en/api-reference/decorators/transactional.mdx`

## 확인 방법

1. 변경된 `.mdx` 파일에서 `getDB` 문자열이 더 이상 존재하지 않는지 확인: `grep -c "getDB" modules/docs/ko/api-reference/decorators/transactional.mdx` → 0
2. 소스 코드의 `base-model.ts:54-68`에서 `getDB`와 `getPuri`의 동작 차이를 직접 확인
3. `pnpm check` (oxlint + oxfmt) 통과 확인됨

## 사람의 확인이 필요한 부분

- 일부 예제에서 `this.insert(wdb, data)` 같은 커스텀 헬퍼를 `wdb.table("...").insert(data).returning("*")` 형태로 교체했습니다. 이것이 문서에서 보여주고자 하는 패턴과 부합하는지 검토가 필요합니다.
- `returning("*")` 후 `[0]` 배열 접근은 PostgreSQL 표준이지만, 문서의 가독성 측면에서 더 간결한 표현이 선호될 수 있습니다.