### PR TITLE
[Nightly 2026-07-13] @api·@upload 데코레이터 문서의 @transactional 내 getDB("w") 호출을 getPuri("w")로 일괄 교체하여 트랜잭션 컨텍스트 누락 문제 정정 (ko/en 4파일)

### DIFF
--- a/modules/docs/en/api-reference/decorators/api.mdx
+++ b/modules/docs/en/api-reference/decorators/api.mdx
@@ -19,8 +19,9 @@ class UserModelClass extends BaseModelClass<UserSubsetKey, UserSubsetMapping, Us
 
   @api({ httpMethod: "POST" })
   async save(data: UserSaveParams) {
-    const wdb = this.getDB("w");
-    return this.upsert(wdb, data);
+    const wdb = this.getPuri("w");
+    wdb.ubRegister("users", data);
+    return wdb.ubUpsert("users");
   }
 }
 
@@ -363,9 +364,10 @@ class AuthFrameClass extends BaseFrameClass {
 @api({ httpMethod: "POST" })
 @transactional()
 async save(data: UserSaveParams) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
   // Executed within transaction
-  return this.upsert(wdb, data);
+  wdb.ubRegister("users", data);
+  return wdb.ubUpsert("users");
 }
 ```
 
@@ -540,22 +542,27 @@ Logs are recorded through LogTape, with categories in `[model:user]` or `[frame:
       @api({ httpMethod: "POST" })
       @transactional()
       async create(data: UserCreateParams) {
-        const wdb = this.getDB("w");
-        return this.insert(wdb, data);
+        const wdb = this.getPuri("w");
+        const [user] = await wdb.table("users")
+          .insert(data)
+          .returning("*");
+        return user;
       }
 
       @api({ httpMethod: "PUT" })
       @transactional()
       async update(id: number, data: UserUpdateParams) {
-        const wdb = this.getDB("w");
-        return this.upsert(wdb, { id, ...data });
+        const wdb = this.getPuri("w");
+        await wdb.table("users")
+          .where("id", id)
+          .update(data);
       }
 
       @api({ httpMethod: "DELETE" })
       @transactional()
       async delete(id: number) {
-        const wdb = this.getDB("w");
-        return wdb.table("users")
+        const wdb = this.getPuri("w");
+        await wdb.table("users")
           .where("id", id)
           .update({ deleted_at: new Date() });
       }
@@ -588,13 +595,13 @@ Logs are recorded through LogTape, with categories in `[model:user]` or `[frame:
       @api({ httpMethod: "POST" })
       @transactional()
       async update(id: number, data: ProductUpdateParams) {
-        const wdb = this.getDB("w");
-        const result = await this.upsert(wdb, { id, ...data });
+        const wdb = this.getPuri("w");
+        await wdb.table("products")
+          .where("id", id)
+          .update(data);
 
         // Invalidate cache
         await Sonamu.cache.deleteByTag({ tags: ["products"] });
-
-        return result;
       }
     }
     ```
@@ -627,7 +634,7 @@ Logs are recorded through LogTape, with categories in `[model:user]` or `[frame:
       @transactional()
       async banUser(userId: number) {
         // Admin only
-        const wdb = UserModel.getDB("w");
+        const wdb = UserModel.getPuri("w");
         return wdb.table("users")
           .where("id", userId)
           .update({ banned_at: new Date() });

--- a/modules/docs/en/api-reference/decorators/upload.mdx
+++ b/modules/docs/en/api-reference/decorators/upload.mdx
@@ -425,7 +425,7 @@ async uploadAndSave() {
     throw new Error("No file");
   }
 
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   // File save + DB update in transaction
   const md5 = await file.md5();
@@ -731,7 +731,7 @@ async uploadFile() {
         const url = await Sonamu.storage.use("s3").getUrl(key);
 
         // Update DB
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         await wdb.table("users")
           .where("id", user.id)
           .update({ avatar_url: url });
@@ -756,7 +756,7 @@ async uploadFile() {
           throw new Error("No files uploaded");
         }
 
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         const results = [];
 
         for (const file of bufferedFiles) {
@@ -828,7 +828,7 @@ async uploadFile() {
         }
 
         // Validate and save data
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         const results = [];
 
         for (const row of parsed.data) {

--- a/modules/docs/ko/api-reference/decorators/api.mdx
+++ b/modules/docs/ko/api-reference/decorators/api.mdx
@@ -19,8 +19,9 @@ class UserModelClass extends BaseModelClass<UserSubsetKey, UserSubsetMapping, Us
 
   @api({ httpMethod: "POST" })
   async save(data: UserSaveParams) {
-    const wdb = this.getDB("w");
-    return this.upsert(wdb, data);
+    const wdb = this.getPuri("w");
+    wdb.ubRegister("users", data);
+    return wdb.ubUpsert("users");
   }
 }
 
@@ -363,9 +364,10 @@ class AuthFrameClass extends BaseFrameClass {
 @api({ httpMethod: "POST" })
 @transactional()
 async save(data: UserSaveParams) {
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
   // 트랜잭션 내에서 실행
-  return this.upsert(wdb, data);
+  wdb.ubRegister("users", data);
+  return wdb.ubUpsert("users");
 }
 ```
 
@@ -540,22 +542,27 @@ async findById(id: number) {
       @api({ httpMethod: "POST" })
       @transactional()
       async create(data: UserCreateParams) {
-        const wdb = this.getDB("w");
-        return this.insert(wdb, data);
+        const wdb = this.getPuri("w");
+        const [user] = await wdb.table("users")
+          .insert(data)
+          .returning("*");
+        return user;
       }
 
       @api({ httpMethod: "PUT" })
       @transactional()
       async update(id: number, data: UserUpdateParams) {
-        const wdb = this.getDB("w");
-        return this.upsert(wdb, { id, ...data });
+        const wdb = this.getPuri("w");
+        await wdb.table("users")
+          .where("id", id)
+          .update(data);
       }
 
       @api({ httpMethod: "DELETE" })
       @transactional()
       async delete(id: number) {
-        const wdb = this.getDB("w");
-        return wdb.table("users")
+        const wdb = this.getPuri("w");
+        await wdb.table("users")
           .where("id", id)
           .update({ deleted_at: new Date() });
       }
@@ -588,13 +595,13 @@ async findById(id: number) {
       @api({ httpMethod: "POST" })
       @transactional()
       async update(id: number, data: ProductUpdateParams) {
-        const wdb = this.getDB("w");
-        const result = await this.upsert(wdb, { id, ...data });
+        const wdb = this.getPuri("w");
+        await wdb.table("products")
+          .where("id", id)
+          .update(data);
 
         // 캐시 무효화
         await Sonamu.cache.deleteByTag({ tags: ["products"] });
-
-        return result;
       }
     }
     ```
@@ -627,7 +634,7 @@ async findById(id: number) {
       @transactional()
       async banUser(userId: number) {
         // 관리자만 실행 가능
-        const wdb = UserModel.getDB("w");
+        const wdb = UserModel.getPuri("w");
         return wdb.table("users")
           .where("id", userId)
           .update({ banned_at: new Date() });

--- a/modules/docs/ko/api-reference/decorators/upload.mdx
+++ b/modules/docs/ko/api-reference/decorators/upload.mdx
@@ -426,7 +426,7 @@ async uploadAndSave() {
     throw new Error("No file");
   }
 
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   // 파일 저장 + DB 업데이트를 트랜잭션으로
   const md5 = await file.md5();
@@ -732,7 +732,7 @@ async uploadFile() {
         const url = await Sonamu.storage.use("s3").getUrl(key);
 
         // DB 업데이트
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         await wdb.table("users")
           .where("id", user.id)
           .update({ avatar_url: url });
@@ -757,7 +757,7 @@ async uploadFile() {
           throw new Error("No files uploaded");
         }
 
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         const results = [];
 
         for (const file of bufferedFiles) {
@@ -829,7 +829,7 @@ async uploadFile() {
         }
 
         // 데이터 검증 및 저장
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         const results = [];
 
         for (const row of parsed.data) {


### PR DESCRIPTION
> 이 PR은 [#43 Nightly PR Directions](https://github.com/cartanova-ai/sonamu/issues/43)과 [#44](https://github.com/cartanova-ai/sonamu/issues/44), [#197](https://github.com/cartanova-ai/sonamu/issues/197)을 참조하여 AI(Claude)에 의해 자동으로 생성되었습니다. 코드베이스 ownership은 전적으로 메인테이너에게 있으며, 모든 변경은 리뷰 후 판단하시기 바랍니다.

## 요약

`@api` 데코레이터 레퍼런스 문서와 `@upload` 데코레이터 레퍼런스 문서(ko/en 4파일)의 모든 `@transactional()` 데코레이터 내부 코드 예제에서 `this.getDB("w")`를 `this.getPuri("w")`로 교체하고, 함께 사용된 미존재 헬퍼 메서드(`this.insert(wdb, data)`, `this.upsert(wdb, ...)`)를 Puri 표준 쿼리 패턴으로 정정했습니다.

## 왜 이 작업을 선정했나

### 근본 원인: `getDB`는 트랜잭션 컨텍스트를 무시함

소스 코드(`base-model.ts:54-68`)를 확인하면:

- **`getDB(which)`**: 단순히 `DB.getDB(which)`를 반환합니다. AsyncLocalStorage의 트랜잭션 컨텍스트를 전혀 확인하지 않습니다.
- **`getPuri(which)`**: 먼저 `DB.getTransactionContext().getTransaction(which)`를 확인하여, 활성 트랜잭션이 있으면 해당 `PuriTransactionWrapper`를 반환합니다. 트랜잭션이 없으면 새 `PuriWrapper`를 생성합니다.

따라서 `@transactional()` 데코레이터 내에서 `this.getDB("w")`를 사용하면, **데코레이터가 시작한 트랜잭션과 무관한 별도의 DB 커넥션에서 쿼리가 실행됩니다.** 이는 다음 문제를 야기합니다:

1. 트랜잭션 내의 쓰기가 실제로는 트랜잭션 밖에서 실행되어, 에러 시 롤백되지 않음
2. 트랜잭션 중첩(재사용) 패턴이 의도대로 동작하지 않음

### PR #207과의 관계

PR #207은 `@transactional` 데코레이터 레퍼런스 문서(`transactional.mdx`)에서 동일한 문제를 정정한 바 있습니다. 이번 PR은 같은 문제가 `@api` 데코레이터 문서와 `@upload` 데코레이터 문서에도 존재하는 것을 확인하고 정정합니다.

### 서브이슈 #197과의 부합

서브이슈 #197은 sonamu-docs에서 `getPuri` 사용을 우선시하도록 문서를 수정하라고 지시하고 있습니다.

### 미존재 메서드 사용 문제

`api.mdx`의 일부 코드 예제에서 `this.insert(wdb, data)`와 `this.upsert(wdb, {...})` 같은 메서드를 사용하고 있었으나, 이들은 `BaseModelClass`에 실제로 존재하지 않는 메서드입니다. 이를 Puri가 실제로 지원하는 표준 패턴(`wdb.table(...).insert(...)`, `wdb.ubRegister()/ubUpsert()`)으로 교체했습니다.

## 접근 방식

### api.mdx (7곳)

1. **첫 번째 save 예제** (비트랜잭션): `this.getDB("w")` + `this.upsert(wdb, data)` → `this.getPuri("w")` + `wdb.ubRegister()` / `wdb.ubUpsert()` 패턴으로 교체
2. **@transactional 조합 예제**: 동일 패턴 적용
3. **CRUD 패턴 탭 (create/update/delete)**: `this.getDB("w")` + 미존재 헬퍼 → `this.getPuri("w")` + Puri 표준 쿼리 패턴
4. **캐싱 탭 (ProductModel.update)**: 동일 패턴 적용
5. **권한 제어 탭 (AdminFrame.banUser)**: `UserModel.getDB("w")` → `UserModel.getPuri("w")`

### upload.mdx (4곳)

1. **uploadAndSave**: `this.getDB("w")` → `this.getPuri("w")`
2. **아바타 업로드**: 동일 교체
3. **여러 파일 업로드**: 동일 교체
4. **CSV 파일 처리**: 동일 교체

`upload.mdx`의 코드 예제들은 `wdb.table(...).insert(...)`, `wdb.table(...).where(...).update(...)` 같은 Puri가 지원하는 표준 쿼리 체인을 이미 사용하고 있었으므로 `getDB` → `getPuri` 교체만으로 충분합니다.

## 이렇게 하지 않으면

- 사용자가 `@transactional()` 데코레이터 내에서 `getDB("w")`를 사용하는 패턴을 따라할 경우, 트랜잭션이 실제로 작동하지 않아 에러 발생 시 데이터가 롤백되지 않음
- 파일 업로드 시나리오에서 파일 저장은 성공했으나 DB 기록은 실패하는 경우, 불일치 데이터가 남을 수 있음
- 미존재 메서드(`this.insert`, `this.upsert`)를 따라 코드를 작성하면 런타임 에러 발생

## 영향 범위

- `modules/docs/ko/api-reference/decorators/api.mdx` — 코드 예제 7곳 수정
- `modules/docs/en/api-reference/decorators/api.mdx` — 동일 수정 (영문)
- `modules/docs/ko/api-reference/decorators/upload.mdx` — 코드 예제 4곳 수정
- `modules/docs/en/api-reference/decorators/upload.mdx` — 동일 수정 (영문)

문서 변경만이므로 런타임 기능에는 영향이 없습니다.

## 변경 확인 방법

1. `pnpm --filter sonamu-docs dev`로 문서 서버를 실행하여 각 페이지의 코드 예제가 올바르게 렌더링되는지 확인
2. 변경된 코드 예제의 `getPuri("w")` 호출이 `base-model.ts:58`의 실제 메서드 시그니처와 일치하는지 대조
3. `ubRegister`/`ubUpsert` 패턴이 `puri-wrapper.ts`의 UpsertBuilder API와 일치하는지 대조

## 사람의 확인이 필요한 부분

- **`api.mdx`의 첫 번째 save 예제와 @transactional 조합 예제**: `@transactional()` 데코레이터 없이 `ubRegister`/`ubUpsert`를 사용하는 패턴이 의도에 맞는지 확인이 필요합니다. `PuriWrapper.ubUpsert`는 내부적으로 트랜잭션을 사용할 수 있으므로 별도 `@transactional` 없이도 안전할 수 있지만, 문서의 맥락상 트랜잭션 예제와 함께 사용되는 것이 적절한지 원작자의 판단이 필요합니다.
- **update/delete 메서드의 반환값 변경**: 기존 `return this.upsert(wdb, {...})`에서 `await wdb.table(...).update(...)`로 변경하면서 일부 메서드가 값을 반환하지 않게 되었습니다. 이것이 의도된 문서 패턴인지 확인이 필요합니다.