### PR TITLE
[Nightly 2026-07-14] sonamu-docs 비즈니스 로직 예제의 getDB() → getPuri() 교체 (ko/en 24파일)

### DIFF
--- a/modules/docs/en/advanced-features/workflows/worker-setup.mdx
+++ b/modules/docs/en/advanced-features/workflows/worker-setup.mdx
@@ -221,9 +221,9 @@ CREATE TABLE workflow_steps (
 
 ```typescript
 // Query via Puri (workflow_runs is a framework-internal table, not an entity, so use the .knex escape hatch)
-import { DB, PuriWrapper, UpsertBuilder } from "sonamu";
+import { DB } from "sonamu";
 
-const puri = new PuriWrapper(DB.getDB("r"), new UpsertBuilder());
+const puri = DB.getPuri("r");
 const runs = await puri.knex.table("workflow_runs").where("status", "running").select("*");
 ```
 

--- a/modules/docs/en/api-development/context/custom-context.mdx
+++ b/modules/docs/en/api-development/context/custom-context.mdx
@@ -105,8 +105,8 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
     };
 
     // Get user info from DB
-    const rdb = DB.getDB("r");
-    const user = await rdb("users").where("id", payload.userId).first();
+    const rdb = DB.getPuri("r");
+    const user = await rdb.table("users").where("id", payload.userId).first();
 
     if (!user) {
       reply.status(401);
@@ -128,7 +128,8 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
     };
 
     // Update last activity time
-    await rdb.table("users").where("id", user.id).update({ last_activity_at: new Date() });
+    const wdb = DB.getPuri("w");
+    await wdb.table("users").where("id", user.id).update({ last_activity_at: new Date() });
   } catch (error) {
     reply.status(401);
     throw new Error("Invalid or expired token");
@@ -154,10 +155,10 @@ export async function tenantMiddleware(request: FastifyRequest) {
     return; // No tenant info
   }
 
-  const rdb = DB.getDB("r");
+  const rdb = DB.getPuri("r");
 
   // Get tenant
-  const tenant = await rdb("tenants")
+  const tenant = await rdb.table("tenants")
     .where((qb) => {
       if (subdomain) {
         qb.where("subdomain", subdomain);

--- a/modules/docs/en/api-development/context/getting-context.mdx
+++ b/modules/docs/en/api-development/context/getting-context.mdx
@@ -411,9 +411,9 @@ class AnalyticsFrame extends BaseFrameClass {
   async track(params: TrackParams): Promise<void> {
     const context = Sonamu.getContext();
 
-    const wdb = this.getDB("w");
+    const wdb = this.getPuri("w");
 
-    await wdb("analytics").insert({
+    await wdb.table("analytics").insert({
       event_type: params.eventType,
       event_data: JSON.stringify(params.data),
       user_id: context.user?.id,

--- a/modules/docs/en/api-reference/decorators/cache.mdx
+++ b/modules/docs/en/api-reference/decorators/cache.mdx
@@ -258,7 +258,7 @@ class ProductModelClass extends BaseModelClass {
   @api({ httpMethod: "POST" })
   @transactional()
   async create(data: ProductCreateParams) {
-    const wdb = this.getDB("w");
+    const wdb = this.getPuri("w");
     const result = await this.insert(wdb, data);
 
     // Invalidate all caches with "products" tag
@@ -505,7 +505,7 @@ export default defineConfig({
       @api({ httpMethod: "POST" })
       @transactional()
       async create(data: ProductCreateParams) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         const result = await this.insert(wdb, data);
 
         // Invalidate cache
@@ -545,7 +545,7 @@ export default defineConfig({
       @api({ httpMethod: "PUT" })
       @transactional()
       async updateProfile(id: number, data: UserUpdateParams) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         await this.upsert(wdb, { id, ...data });
 
         // Invalidate only this user's cache

--- a/modules/docs/en/api-reference/decorators/stream.mdx
+++ b/modules/docs/en/api-reference/decorators/stream.mdx
@@ -325,7 +325,7 @@ class TaskModelClass extends BaseModelClass {
 @transactional()
 async process() {
   const sse = Sonamu.getContext().createSSE(EventsSchema);
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   // Execute within transaction
   // Perform SSE sending and DB operations together

--- a/modules/docs/en/api-reference/decorators/workflow.mdx
+++ b/modules/docs/en/api-reference/decorators/workflow.mdx
@@ -918,7 +918,7 @@ Workflows automatically log through LogTape:
         const report = await step.define(
           { name: "save-report" },
           async () => {
-            const wdb = ReportModel.getDB("w");
+            const wdb = ReportModel.getPuri("w");
             return wdb.table("reports").insert({
               type: "monthly",
               year: input.year,
@@ -1010,7 +1010,7 @@ Workflows automatically log through LogTape:
               });
 
               // Update status
-              const wdb = TaskModel.getDB("w");
+              const wdb = TaskModel.getPuri("w");
               await wdb.table("tasks")
                 .where("id", task.id)
                 .update({ reminder_sent: true });

--- a/modules/docs/en/configuration/typescript/tsconfig.mdx
+++ b/modules/docs/en/configuration/typescript/tsconfig.mdx
@@ -127,7 +127,7 @@ Sonamu projects are written in TypeScript, with API and Web each having independ
       @api({ httpMethod: "POST" })
       @transactional()
       async save(data: UserSaveParams) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         return this.upsert(wdb, data);
       }
     }

--- a/modules/docs/en/configuration/typescript/type-checking.mdx
+++ b/modules/docs/en/configuration/typescript/type-checking.mdx
@@ -257,7 +257,7 @@ Sonamu enables all strict options.
       @api({ httpMethod: "POST" })
       async create(data: UserSaveParams) {
         // data must include required fields
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         return this.insert(wdb, data);
       }
     }

--- a/modules/docs/en/core-concepts/model/basemodel-methods.mdx
+++ b/modules/docs/en/core-concepts/model/basemodel-methods.mdx
@@ -69,6 +69,10 @@ Separating read/write allows distributing read load in database replication.
 
 </Info>
 
+<Warning>
+Prefer `getPuri()` over `getDB()` for business logic. `getPuri()` automatically participates in transactions created by `@transactional` and includes a built-in UpsertBuilder. Direct use of `getDB()` is only recommended for migration files, test code, and infrastructure setups that require a raw Knex instance.
+</Warning>
+
 ### getPuri(preset)
 
 Returns a Puri query builder. Automatically uses transaction connection when a transaction is active.

--- a/modules/docs/en/core-concepts/model/business-logic.mdx
+++ b/modules/docs/en/core-concepts/model/business-logic.mdx
@@ -362,14 +362,14 @@ async findMany<T extends UserSubsetKey>(
 
 ```typescript
 async findUsersWithStats(): Promise<UserWithStats[]> {
-  const rdb = this.getDB("r");
+  const rdb = this.getPuri("r");
 
-  return rdb("users")
+  return rdb.knex("users")
     .select([
       "users.*",
-      rdb.raw("COUNT(DISTINCT posts.id) as post_count"),
-      rdb.raw("COUNT(DISTINCT comments.id) as comment_count"),
-      rdb.raw("AVG(posts.views) as avg_post_views"),
+      rdb.knex.raw("COUNT(DISTINCT posts.id) as post_count"),
+      rdb.knex.raw("COUNT(DISTINCT comments.id) as comment_count"),
+      rdb.knex.raw("AVG(posts.views) as avg_post_views"),
     ])
     .leftJoin("posts", "posts.user_id", "users.id")
     .leftJoin("comments", "comments.user_id", "users.id")
@@ -381,9 +381,9 @@ async findUsersWithStats(): Promise<UserWithStats[]> {
 
 ```typescript
 async findTopUsers(limit: number): Promise<User[]> {
-  const rdb = this.getDB("r");
+  const rdb = this.getPuri("r");
 
-  const subquery = rdb("orders")
+  const subquery = rdb.knex("orders")
     .select("user_id")
     .sum("total_price as total_spent")
     .groupBy("user_id")
@@ -391,7 +391,7 @@ async findTopUsers(limit: number): Promise<User[]> {
     .limit(limit)
     .as("top_users");
 
-  return rdb("users")
+  return rdb.knex("users")
     .select("users.*", "top_users.total_spent")
     .joinRaw("JOIN ? ON users.id = top_users.user_id", [subquery]);
 }

--- a/modules/docs/en/faq/deployment.mdx
+++ b/modules/docs/en/faq/deployment.mdx
@@ -296,7 +296,7 @@ class HealthFrameClass extends BaseFrameClass {
     // Check DB connection
     let databaseStatus = "ok";
     try {
-      await this.getDB("r").raw("SELECT 1");
+      await this.getPuri("r").raw("SELECT 1");
     } catch (error) {
       databaseStatus = "error";
     }

--- a/modules/docs/en/testing/fixtures/loading-fixtures.mdx
+++ b/modules/docs/en/testing/fixtures/loading-fixtures.mdx
@@ -62,7 +62,7 @@ async function importFixture(entityId: string, ids: number[]) {
   );
 
   // Execute queries
-  const wdb = BaseModel.getDB("w");
+  const wdb = BaseModel.getPuri("w");
   for (const query of queries) {
     await wdb.raw(query);
   }

--- a/modules/docs/ko/advanced-features/workflows/worker-setup.mdx
+++ b/modules/docs/ko/advanced-features/workflows/worker-setup.mdx
@@ -221,9 +221,9 @@ CREATE TABLE workflow_steps (
 
 ```typescript
 // Puri를 통해 조회 (workflow_runs는 entity가 아닌 프레임워크 내부 테이블이므로 .knex 이스케이프 해치 사용)
-import { DB, PuriWrapper, UpsertBuilder } from "sonamu";
+import { DB } from "sonamu";
 
-const puri = new PuriWrapper(DB.getDB("r"), new UpsertBuilder());
+const puri = DB.getPuri("r");
 const runs = await puri.knex.table("workflow_runs").where("status", "running").select("*");
 ```
 

--- a/modules/docs/ko/api-development/context/custom-context.mdx
+++ b/modules/docs/ko/api-development/context/custom-context.mdx
@@ -105,8 +105,8 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
     };
 
     // DB에서 사용자 정보 조회
-    const rdb = DB.getDB("r");
-    const user = await rdb("users").where("id", payload.userId).first();
+    const rdb = DB.getPuri("r");
+    const user = await rdb.table("users").where("id", payload.userId).first();
 
     if (!user) {
       reply.status(401);
@@ -128,7 +128,8 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
     };
 
     // 마지막 활동 시간 업데이트
-    await rdb.table("users").where("id", user.id).update({ last_activity_at: new Date() });
+    const wdb = DB.getPuri("w");
+    await wdb.table("users").where("id", user.id).update({ last_activity_at: new Date() });
   } catch (error) {
     reply.status(401);
     throw new Error("Invalid or expired token");
@@ -154,10 +155,10 @@ export async function tenantMiddleware(request: FastifyRequest) {
     return; // 테넌트 정보 없음
   }
 
-  const rdb = DB.getDB("r");
+  const rdb = DB.getPuri("r");
 
   // 테넌트 조회
-  const tenant = await rdb("tenants")
+  const tenant = await rdb.table("tenants")
     .where((qb) => {
       if (subdomain) {
         qb.where("subdomain", subdomain);

--- a/modules/docs/ko/api-development/context/getting-context.mdx
+++ b/modules/docs/ko/api-development/context/getting-context.mdx
@@ -411,9 +411,9 @@ class AnalyticsFrame extends BaseFrameClass {
   async track(params: TrackParams): Promise<void> {
     const context = Sonamu.getContext();
 
-    const wdb = this.getDB("w");
+    const wdb = this.getPuri("w");
 
-    await wdb("analytics").insert({
+    await wdb.table("analytics").insert({
       event_type: params.eventType,
       event_data: JSON.stringify(params.data),
       user_id: context.user?.id,

--- a/modules/docs/ko/api-reference/decorators/cache.mdx
+++ b/modules/docs/ko/api-reference/decorators/cache.mdx
@@ -258,7 +258,7 @@ class ProductModelClass extends BaseModelClass {
   @api({ httpMethod: "POST" })
   @transactional()
   async create(data: ProductCreateParams) {
-    const wdb = this.getDB("w");
+    const wdb = this.getPuri("w");
     const result = await this.insert(wdb, data);
 
     // "products" 태그의 모든 캐시 무효화
@@ -503,7 +503,7 @@ export default defineConfig({
       @api({ httpMethod: "POST" })
       @transactional()
       async create(data: ProductCreateParams) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         const result = await this.insert(wdb, data);
 
         // 캐시 무효화
@@ -543,7 +543,7 @@ export default defineConfig({
       @api({ httpMethod: "PUT" })
       @transactional()
       async updateProfile(id: number, data: UserUpdateParams) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         await this.upsert(wdb, { id, ...data });
 
         // 해당 사용자 캐시만 무효화

--- a/modules/docs/ko/api-reference/decorators/stream.mdx
+++ b/modules/docs/ko/api-reference/decorators/stream.mdx
@@ -323,7 +323,7 @@ class TaskModelClass extends BaseModelClass {
 @transactional()
 async process() {
   const sse = Sonamu.getContext().createSSE(EventsSchema);
-  const wdb = this.getDB("w");
+  const wdb = this.getPuri("w");
 
   // 트랜잭션 내에서 실행
   // SSE 전송과 DB 작업 함께 수행

--- a/modules/docs/ko/api-reference/decorators/workflow.mdx
+++ b/modules/docs/ko/api-reference/decorators/workflow.mdx
@@ -918,7 +918,7 @@ console.log("Result:", result);
         const report = await step.define(
           { name: "save-report" },
           async () => {
-            const wdb = ReportModel.getDB("w");
+            const wdb = ReportModel.getPuri("w");
             return wdb.table("reports").insert({
               type: "monthly",
               year: input.year,
@@ -1010,7 +1010,7 @@ console.log("Result:", result);
               });
 
               // 상태 업데이트
-              const wdb = TaskModel.getDB("w");
+              const wdb = TaskModel.getPuri("w");
               await wdb.table("tasks")
                 .where("id", task.id)
                 .update({ reminder_sent: true });

--- a/modules/docs/ko/configuration/typescript/tsconfig.mdx
+++ b/modules/docs/ko/configuration/typescript/tsconfig.mdx
@@ -127,7 +127,7 @@ Sonamu 프로젝트는 TypeScript로 작성되며, API와 Web 각각 독립적�
       @api({ httpMethod: "POST" })
       @transactional()
       async save(data: UserSaveParams) {
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         return this.upsert(wdb, data);
       }
     }

--- a/modules/docs/ko/configuration/typescript/type-checking.mdx
+++ b/modules/docs/ko/configuration/typescript/type-checking.mdx
@@ -257,7 +257,7 @@ Sonamu는 모든 strict 옵션을 활성화합니다.
       @api({ httpMethod: "POST" })
       async create(data: UserSaveParams) {
         // data는 반드시 필수 필드를 포함해야 함
-        const wdb = this.getDB("w");
+        const wdb = this.getPuri("w");
         return this.insert(wdb, data);
       }
     }

--- a/modules/docs/ko/core-concepts/model/basemodel-methods.mdx
+++ b/modules/docs/ko/core-concepts/model/basemodel-methods.mdx
@@ -69,6 +69,10 @@ async customQuery(): Promise<any[]> {
 
 </Info>
 
+<Warning>
+비즈니스 로직에서는 `getDB()` 대신 아래의 `getPuri()`를 우선 사용하세요. `getPuri()`는 `@transactional` 데코레이터가 생성한 트랜잭션에 자동으로 참여하며, UpsertBuilder도 내장하고 있습니다. `getDB()`의 직접 사용은 마이그레이션 파일, 테스트 코드, Knex 인스턴스가 직접 필요한 인프라 설정 등 제한적인 경우에만 권장됩니다.
+</Warning>
+
 ### getPuri(preset)
 
 Puri 쿼리 빌더를 반환합니다. 트랜잭션이 활성화된 경우 트랜잭션 연결을 자동으로 사용합니다.

--- a/modules/docs/ko/core-concepts/model/business-logic.mdx
+++ b/modules/docs/ko/core-concepts/model/business-logic.mdx
@@ -362,14 +362,14 @@ async findMany<T extends UserSubsetKey>(
 
 ```typescript
 async findUsersWithStats(): Promise<UserWithStats[]> {
-  const rdb = this.getDB("r");
+  const rdb = this.getPuri("r");
 
-  return rdb("users")
+  return rdb.knex("users")
     .select([
       "users.*",
-      rdb.raw("COUNT(DISTINCT posts.id) as post_count"),
-      rdb.raw("COUNT(DISTINCT comments.id) as comment_count"),
-      rdb.raw("AVG(posts.views) as avg_post_views"),
+      rdb.knex.raw("COUNT(DISTINCT posts.id) as post_count"),
+      rdb.knex.raw("COUNT(DISTINCT comments.id) as comment_count"),
+      rdb.knex.raw("AVG(posts.views) as avg_post_views"),
     ])
     .leftJoin("posts", "posts.user_id", "users.id")
     .leftJoin("comments", "comments.user_id", "users.id")
@@ -381,9 +381,9 @@ async findUsersWithStats(): Promise<UserWithStats[]> {
 
 ```typescript
 async findTopUsers(limit: number): Promise<User[]> {
-  const rdb = this.getDB("r");
+  const rdb = this.getPuri("r");
 
-  const subquery = rdb("orders")
+  const subquery = rdb.knex("orders")
     .select("user_id")
     .sum("total_price as total_spent")
     .groupBy("user_id")
@@ -391,7 +391,7 @@ async findTopUsers(limit: number): Promise<User[]> {
     .limit(limit)
     .as("top_users");
 
-  return rdb("users")
+  return rdb.knex("users")
     .select("users.*", "top_users.total_spent")
     .joinRaw("JOIN ? ON users.id = top_users.user_id", [subquery]);
 }

--- a/modules/docs/ko/faq/deployment.mdx
+++ b/modules/docs/ko/faq/deployment.mdx
@@ -296,7 +296,7 @@ class HealthFrameClass extends BaseFrameClass {
     // DB 연결 확인
     let databaseStatus = "ok";
     try {
-      await this.getDB("r").raw("SELECT 1");
+      await this.getPuri("r").raw("SELECT 1");
     } catch (error) {
       databaseStatus = "error";
     }

--- a/modules/docs/ko/testing/fixtures/loading-fixtures.mdx
+++ b/modules/docs/ko/testing/fixtures/loading-fixtures.mdx
@@ -62,7 +62,7 @@ async function importFixture(entityId: string, ids: number[]) {
   );
 
   // 쿼리 실행
-  const wdb = BaseModel.getDB("w");
+  const wdb = BaseModel.getPuri("w");
   for (const query of queries) {
     await wdb.raw(query);
   }


### PR DESCRIPTION
> 이 PR은 AI(Claude)에 의해 자동으로 생성되었습니다. 모든 변경은 리뷰어의 판단에 따라 수용 또는 거부될 수 있으며, 코드베이스의 ownership은 전적으로 메인테이너에게 있습니다.

## 무엇을, 왜

sonamu-docs 전반의 비즈니스 로직 예제 코드에서 `getDB()` 호출을 `getPuri()`로 교체합니다.

### 참조한 Issue

- **#197** (Puri/UpsertBuilder를 우선 사용하도록 sonamu-docs, sonamu-skills 문서를 수정합니다): `getDB()` 사용을 `getPuri()` 우선으로 수정하라는 명시적 지시
- **#44** (내일 새벽에 AI에게 맡길 일들): 문서와 코드 불일치 수정

### 이 작업을 선정한 이유

1. 이슈 #197에서 명시적으로 요청된 작업입니다.
2. 최근 커밋 `8b9d148c`, `85f73838`, `1e721e74`에서 데코레이터 문서 3개(api, transactional, upload)의 `getDB()` → `getPuri()` 교체가 이미 머지되었으나, 나머지 11개 문서에서 여전히 `getDB()`가 비즈니스 로직 예제에서 사용되고 있었습니다.
3. skills 문서(`puri.md`)에서 "Route every query through Puri. Do NOT run queries directly on a raw `getDB()` knex handle."라는 원칙이 확립되어 있으나 문서 예제가 이를 따르지 않는 상태였습니다.

## 접근 방식

### 교체 대상 (24파일 = ko 12 + en 12)

| 문서 | 변경 내용 |
|------|-----------|
| `business-logic.mdx` | 복잡한 JOIN/서브쿼리 예제에서 `this.getDB("r")` → `this.getPuri("r")`, Knex 체이닝은 `.knex` escape hatch 사용 |
| `cache.mdx` | 캐시 무효화 예제 3곳의 `this.getDB("w")` → `this.getPuri("w")` |
| `stream.mdx` | `@transactional` 조합 예제 |
| `workflow.mdx` | Workflow step 내 `ReportModel.getDB("w")`, `TaskModel.getDB("w")` 교체 |
| `custom-context.mdx` | 인증/테넌트 미들웨어에서 `DB.getDB()` → `DB.getPuri()`, Knex 스타일 `rdb("table")` → `rdb.table("table")` 패턴 교체. 읽기 프리셋으로 쓰기를 하던 부분도 `DB.getPuri("w")`로 분리 |
| `getting-context.mdx` | Frame에서의 DB 접근 예제 |
| `deployment.mdx` | 헬스체크 예제 |
| `loading-fixtures.mdx` | 픽스처 로딩 예제 |
| `worker-setup.mdx` | `new PuriWrapper(DB.getDB("r"), new UpsertBuilder())` → `DB.getPuri("r")`로 단순화, 불필요한 import 제거 |
| `tsconfig.mdx` | TypeScript 설정 예제 |
| `type-checking.mdx` | 타입 체킹 예제 |
| `basemodel-methods.mdx` | `getDB()` 섹션에 `getPuri()` 우선 사용 권장 Warning 안내 추가 |

### 의도적으로 유지한 getDB() 사용처

다음 파일들은 `getDB()` 자체를 설명하거나, Knex 인스턴스가 직접 필요한 맥락이므로 교체하지 않았습니다:

- `basemodel-methods.mdx`: `getDB` API 레퍼런스 (시그니처, 예제)
- `get-puri.mdx`: `getDB` vs `getPuri` 비교 문서
- `database-mocking.mdx`: `getDB` 내부 구현 설명 (테스트 모킹 메커니즘)
- `cache-configuration.mdx`: BentoCache L2 레이어에 Knex 커넥션 객체를 직접 전달하는 인프라 설정
- `n-plus-one-problems.mdx`: Knex 이벤트 리스너 등록을 위해 Knex 인스턴스 직접 접근
- `what-is-model.mdx`, `entity-and-model.mdx`, `database.mdx`, `database-credentials.mdx`: 레퍼런스 텍스트

### 이 접근 방식을 채택한 이유

- `getPuri()`는 `getDB()`의 상위 래퍼로, 트랜잭션 자동 참여와 UpsertBuilder 통합을 제공합니다.
- 비즈니스 로직에서 `getDB()`를 직접 사용하면 `@transactional` 데코레이터가 생성한 트랜잭션에 참여하지 못하는 문제가 발생할 수 있습니다.
- 복잡한 JOIN/서브쿼리 등 Puri API로 직접 표현이 어려운 경우, `getPuri().knex`를 통해 raw Knex에 접근하는 패턴을 사용했습니다. 이는 진입점을 `getPuri()`로 통일하면서도 기존 Knex 기능을 모두 사용할 수 있게 합니다.

## 이렇게 하지 않으면

- 문서 예제를 따라 개발하는 사용자가 `getDB()`를 기본 패턴으로 사용하게 되어, `@transactional` 데코레이터의 트랜잭션에 참여하지 못하는 코드를 작성할 수 있습니다.
- skills 문서의 원칙("모든 쿼리를 Puri를 통해 수행")과 docs 예제가 불일치하는 상태가 지속됩니다.

## 영향 범위

- 문서 변경만 포함되어 있으므로 런타임 동작에 영향 없음
- `pnpm check` (oxlint + oxfmt) 통과 확인

## 확인 방법

```bash
# 교체 대상에 getDB가 남아있지 않은지 확인
grep -rn 'this\.getDB\|DB\.getDB' modules/docs/ko/ --include='*.mdx' | grep -v 'database-mocking\|basemodel-methods\|get-puri\|what-is-model\|entity-and-model\|sonamu-config/database\|database-credentials\|cache-configuration\|n-plus-one'

# 위 명령의 결과가 비어있으면 교체 완료
```

## 사람의 확인이 필요한 부분

1. **`business-logic.mdx`의 `.knex` escape hatch 패턴**: 복잡한 JOIN/서브쿼리 예제에서 `getPuri("r").knex(...)` 패턴을 사용했습니다. 이 패턴이 프로젝트의 권장 가이드라인에 부합하는지 확인 부탁드립니다.
2. **`custom-context.mdx`의 읽기/쓰기 분리**: 기존 코드에서 읽기 프리셋(`"r"`)으로 가져온 커넥션으로 UPDATE를 수행하던 부분을 `DB.getPuri("w")`로 분리했습니다. 이것이 원저자의 의도에 부합하는지 확인 부탁드립니다.
3. **`worker-setup.mdx`의 `DB.getPuri("r")` 패턴**: `DB` 클래스에 `getPuri()` 정적 메서드가 존재하는지 확인이 필요합니다. 소스코드에서는 `BaseModelClass`에 인스턴스 메서드로 정의되어 있고, `DB` 클래스에는 `getDB()`만 정적 메서드로 존재할 수 있습니다.