### PR TITLE
fix(build): web 빌드 타입검사 게이트 복구 (tsc -b) [SON-508]

### DIFF
--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/bin/build-config.ts
+++ b/modules/sonamu/src/bin/build-config.ts
@@ -32,7 +32,8 @@ export const WEB_ARTIFACTS: BuildArtifact[] = [
     description: "Web 프로젝트 클라이언트 빌드 산출물",
     projectPath: "web",
     preBuildCommand: () => "rm -rf dist/client",
-    buildCommand: () => "tsc --noEmit && vite build --config vite.config.ts --outDir dist/client",
+    buildCommand: () =>
+      "tsc -b --noEmit && vite build --config vite.config.ts --outDir dist/client",
   },
   {
     name: "Web Server",
@@ -40,7 +41,7 @@ export const WEB_ARTIFACTS: BuildArtifact[] = [
     projectPath: "web",
     preBuildCommand: () => "rm -rf dist/server",
     buildCommand: () =>
-      "tsc --noEmit && vite build --config vite.config.ts --ssr src/entry-server.generated.tsx --outDir dist/server",
+      "tsc -b --noEmit && vite build --config vite.config.ts --ssr src/entry-server.generated.tsx --outDir dist/server",
     postBuildCommand: () =>
       "rm -rf ../api/web-dist && mkdir -p ../api/web-dist && cp -r dist/* ../api/web-dist",
   },


### PR DESCRIPTION
## 요약

`sonamu build`의 web 빌드가 옵션 없는 `tsc --noEmit`을 실행했는데, web `tsconfig.json`이 `files:[]`짜리 솔루션(references) config라 **검사 대상이 0개**였다. 그 결과 앱 소스에 타입 에러가 있어도 빌드/CI가 조용히 통과 → 게이트가 사실상 무력화 (SON-508).

`WEB_ARTIFACTS`의 tsc를 **`tsc -b --noEmit`**으로 변경해 references(app+node)를 따라가 실제 앱 소스를 검사하도록 복구한다.

## 변경

- `modules/sonamu/src/bin/build-config.ts`: web Client/Server 두 artifact의 `tsc --noEmit` → `tsc -b --noEmit`. API는 단일 정상 tsconfig라 유지.
- `modules/sonamu/package.json`: `0.10.1` → `0.10.2` (patch)

## 검증

- ✅ 게이트 정상 동작: 타입에러 주입 시 `error TS2322` 탐지 (기존 명령은 exit 0으로 못 잡음)
- ✅ miomock/web 잠복 에러 0건 → 빌드 안 깨짐
- ✅ 실제 `sonamu build`(miomock) end-to-end 통과
- ✅ `pnpm check`(oxlint + oxfmt) 통과
- ✅ `*.tsbuildinfo`는 템플릿 gitignore에 이미 포함

Closes SON-508

🤖 Generated with [Claude Code](https://claude.com/claude-code)