### PR TITLE
[Nightly 2026-07-15] workflow·select·where 문서의 MySQL YEAR()/MONTH() 함수를 PostgreSQL EXTRACT()로 교체 (ko/en 6파일)

### DIFF
--- a/modules/docs/en/api-reference/decorators/workflow.mdx
+++ b/modules/docs/en/api-reference/decorators/workflow.mdx
@@ -870,8 +870,8 @@ Workflows automatically log through LogTape:
           async () => {
             const rdb = OrderModel.getPuri("r");
             return rdb.table("orders")
-              .whereRaw("YEAR(created_at) = ?", [input.year])
-              .whereRaw("MONTH(created_at) = ?", [input.month])
+              .whereRaw("EXTRACT(YEAR FROM created_at) = ?", [input.year])
+              .whereRaw("EXTRACT(MONTH FROM created_at) = ?", [input.month])
               .select(
                 rdb.raw("COUNT(*) as total_orders"),
                 rdb.raw("SUM(total_amount) as total_revenue"),
@@ -887,8 +887,8 @@ Workflows automatically log through LogTape:
           async () => {
             const rdb = UserModel.getPuri("r");
             return rdb.table("users")
-              .whereRaw("YEAR(created_at) = ?", [input.year])
-              .whereRaw("MONTH(created_at) = ?", [input.month])
+              .whereRaw("EXTRACT(YEAR FROM created_at) = ?", [input.year])
+              .whereRaw("EXTRACT(MONTH FROM created_at) = ?", [input.month])
               .count("* as new_users")
               .first();
           }
@@ -901,8 +901,8 @@ Workflows automatically log through LogTape:
             const rdb = OrderModel.getPuri("r");
             return rdb.table("order_items")
               .join("orders", "orders.id", "order_items.order_id")
-              .whereRaw("YEAR(orders.created_at) = ?", [input.year])
-              .whereRaw("MONTH(orders.created_at) = ?", [input.month])
+              .whereRaw("EXTRACT(YEAR FROM orders.created_at) = ?", [input.year])
+              .whereRaw("EXTRACT(MONTH FROM orders.created_at) = ?", [input.month])
               .groupBy("order_items.product_id")
               .select(
                 "order_items.product_id",

--- a/modules/docs/en/api-reference/puri-methods/select.mdx
+++ b/modules/docs/en/api-reference/puri-methods/select.mdx
@@ -105,10 +105,10 @@ const result = await puri.table("users").select({
   display_name: Puri.rawString("CONCAT(users.first_name, ' ', users.last_name)"),
 
   // Return number
-  age: Puri.rawNumber("YEAR(CURRENT_DATE) - YEAR(users.birth_date)"),
+  age: Puri.rawNumber("EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM users.birth_date)"),
 
   // Return boolean
-  is_adult: Puri.rawBoolean("YEAR(CURRENT_DATE) - YEAR(users.birth_date) >= 18"),
+  is_adult: Puri.rawBoolean("EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM users.birth_date) >= 18"),
 
   // Return date
   signup_date: Puri.rawDate("DATE(users.created_at)"),
@@ -508,7 +508,7 @@ puri.table("users").select({
 // Specify return type when using raw SQL
 const result = await puri.table("users").select({
   // ✅ Type specified
-  age: Puri.rawNumber("YEAR(CURRENT_DATE) - YEAR(birth_date)"),
+  age: Puri.rawNumber("EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM birth_date)"),
 
   // ❌ No type (any)
   unknown: puri.raw("SOME_COMPLEX_SQL"),

--- a/modules/docs/en/api-reference/puri-methods/where.mdx
+++ b/modules/docs/en/api-reference/puri-methods/where.mdx
@@ -320,7 +320,7 @@ You can write complex SQL conditions directly.
 
 ```typescript
 // No parameters
-await puri.table("users").whereRaw("YEAR(users.created_at) = YEAR(CURRENT_DATE)");
+await puri.table("users").whereRaw("EXTRACT(YEAR FROM users.created_at) = EXTRACT(YEAR FROM CURRENT_DATE)");
 
 // Parameter binding
 await puri.table("users").whereRaw("users.age BETWEEN ? AND ?", [18, 65]);

--- a/modules/docs/ko/api-reference/decorators/workflow.mdx
+++ b/modules/docs/ko/api-reference/decorators/workflow.mdx
@@ -870,8 +870,8 @@ console.log("Result:", result);
           async () => {
             const rdb = OrderModel.getPuri("r");
             return rdb.table("orders")
-              .whereRaw("YEAR(created_at) = ?", [input.year])
-              .whereRaw("MONTH(created_at) = ?", [input.month])
+              .whereRaw("EXTRACT(YEAR FROM created_at) = ?", [input.year])
+              .whereRaw("EXTRACT(MONTH FROM created_at) = ?", [input.month])
               .select(
                 rdb.raw("COUNT(*) as total_orders"),
                 rdb.raw("SUM(total_amount) as total_revenue"),
@@ -887,8 +887,8 @@ console.log("Result:", result);
           async () => {
             const rdb = UserModel.getPuri("r");
             return rdb.table("users")
-              .whereRaw("YEAR(created_at) = ?", [input.year])
-              .whereRaw("MONTH(created_at) = ?", [input.month])
+              .whereRaw("EXTRACT(YEAR FROM created_at) = ?", [input.year])
+              .whereRaw("EXTRACT(MONTH FROM created_at) = ?", [input.month])
               .count("* as new_users")
               .first();
           }
@@ -901,8 +901,8 @@ console.log("Result:", result);
             const rdb = OrderModel.getPuri("r");
             return rdb.table("order_items")
               .join("orders", "orders.id", "order_items.order_id")
-              .whereRaw("YEAR(orders.created_at) = ?", [input.year])
-              .whereRaw("MONTH(orders.created_at) = ?", [input.month])
+              .whereRaw("EXTRACT(YEAR FROM orders.created_at) = ?", [input.year])
+              .whereRaw("EXTRACT(MONTH FROM orders.created_at) = ?", [input.month])
               .groupBy("order_items.product_id")
               .select(
                 "order_items.product_id",

--- a/modules/docs/ko/api-reference/puri-methods/select.mdx
+++ b/modules/docs/ko/api-reference/puri-methods/select.mdx
@@ -105,10 +105,10 @@ const result = await puri.table("users").select({
   display_name: Puri.rawString("CONCAT(users.first_name, ' ', users.last_name)"),
 
   // 숫자 반환
-  age: Puri.rawNumber("YEAR(CURRENT_DATE) - YEAR(users.birth_date)"),
+  age: Puri.rawNumber("EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM users.birth_date)"),
 
   // 불리언 반환
-  is_adult: Puri.rawBoolean("YEAR(CURRENT_DATE) - YEAR(users.birth_date) >= 18"),
+  is_adult: Puri.rawBoolean("EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM users.birth_date) >= 18"),
 
   // 날짜 반환
   signup_date: Puri.rawDate("DATE(users.created_at)"),
@@ -505,7 +505,7 @@ puri.table("users").select({
 // Raw SQL 사용 시 반환 타입 명시
 const result = await puri.table("users").select({
   // ✅ 타입 명시
-  age: Puri.rawNumber("YEAR(CURRENT_DATE) - YEAR(birth_date)"),
+  age: Puri.rawNumber("EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM birth_date)"),
 
   // ❌ 타입 없음 (any)
   unknown: puri.raw("SOME_COMPLEX_SQL"),

--- a/modules/docs/ko/api-reference/puri-methods/where.mdx
+++ b/modules/docs/ko/api-reference/puri-methods/where.mdx
@@ -320,7 +320,7 @@ await puri.table("items").whereFuzzy("items.search_text", "typscript", { operato
 
 ```typescript
 // 파라미터 없음
-await puri.table("users").whereRaw("YEAR(users.created_at) = YEAR(CURRENT_DATE)");
+await puri.table("users").whereRaw("EXTRACT(YEAR FROM users.created_at) = EXTRACT(YEAR FROM CURRENT_DATE)");
 
 // 파라미터 바인딩
 await puri.table("users").whereRaw("users.age BETWEEN ? AND ?", [18, 65]);


### PR DESCRIPTION
> 이 PR은 AI(Claude)에 의해 자동으로 생성되었습니다. 모든 변경은 리뷰어의 판단에 따라 수용 또는 거부될 수 있으며, 코드베이스의 ownership은 전적으로 메인테이너에게 있습니다.

## 무엇을, 왜

sonamu-docs의 Puri 메서드 예제 코드에서 MySQL 전용 함수인 `YEAR()`와 `MONTH()`를 PostgreSQL 표준 구문인 `EXTRACT(YEAR FROM ...)`과 `EXTRACT(MONTH FROM ...)`으로 교체합니다.

### 참조한 Issue

- **#44** (내일 새벽에 AI에게 맡길 일들): "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다"
- **#197** (Puri/UpsertBuilder를 우선 사용하도록 sonamu-docs, sonamu-skills 문서를 수정합니다)

### 이 작업을 선정한 이유

1. Sonamu는 PostgreSQL 전용입니다 (`SonamuConfig.database.database`는 `"pg" | "pgnative"`만 허용, Knex 클라이언트는 `"postgresql"`로 고정). `YEAR()`와 `MONTH()`는 MySQL 전용 함수로 PostgreSQL에서는 **실행 시 에러가 발생**합니다.
2. PR #206에서 `DATE_FORMAT` → `to_char` 등 유사한 MySQL→PostgreSQL 수정이 이미 머지된 선례가 있으며, 이번에 발견된 `YEAR()`/`MONTH()` 사용처는 당시 수정 범위에서 빠져 있었습니다.
3. 문서의 예제 코드를 그대로 복사하여 사용하는 사용자가 런타임 에러를 겪을 수 있습니다.

## 접근 방식

### 교체 대상 (6파일 = ko 3 + en 3)

| 문서 | 변경 내용 |
|------|-----------|
| `workflow.mdx` | 월간 리포트 워크플로우 예제의 `YEAR(created_at)` → `EXTRACT(YEAR FROM created_at)`, `MONTH(created_at)` → `EXTRACT(MONTH FROM created_at)` (6곳) |
| `select.mdx` | `Puri.rawNumber("YEAR(CURRENT_DATE) - YEAR(users.birth_date)")` → `EXTRACT()` 구문으로 교체, `rawBoolean` 예제도 동일 교체 (3곳) |
| `where.mdx` | `whereRaw("YEAR(users.created_at) = YEAR(CURRENT_DATE)")` → `EXTRACT()` 구문으로 교체 (1곳) |

### 이렇게 하지 않으면

- 문서의 예제 코드를 그대로 사용하면 PostgreSQL에서 `function year(timestamp without time zone) does not exist` 에러가 발생합니다.
- Sonamu가 PostgreSQL 전용이라는 사실과 문서 예제가 모순되어 사용자에게 혼란을 줍니다.

### 영향 범위

- 문서 예제 코드만 변경합니다. 소스 코드나 런타임 동작에는 영향이 없습니다.
- SQL의 의미(연도/월 추출)는 동일하며, PostgreSQL에서 올바르게 실행됩니다.

### 확인 방법

- `modules/docs/ko/api-reference/decorators/workflow.mdx`의 873~905행을 확인하면 `EXTRACT()` 구문으로 교체된 것을 볼 수 있습니다.
- PostgreSQL에서 `SELECT EXTRACT(YEAR FROM CURRENT_DATE)` 실행으로 구문이 유효함을 확인할 수 있습니다.

### 추후 사람의 확인이 필요한 부분

- `CONCAT()` 사용도 일부 문서에 있으나, PostgreSQL 9.1+에서 지원하므로 이번에는 교체하지 않았습니다. 만약 `||` 연산자를 선호하신다면 별도로 알려주세요.
- 문서 내 깨진 내부 링크가 약 29개 발견되었으나, 이번 PR의 범위를 초과하여 별도 작업으로 남겨두었습니다.