### PR TITLE
[Nightly 2026-07-16] auth·server·boundaries·using-services 문서의 미존재 UnauthorizedError를 실제 클래스 UnauthorizedException으로 일괄 교체 (ko/en 8파일)

### DIFF
--- a/modules/docs/en/configuration/sonamu-config/auth.mdx
+++ b/modules/docs/en/configuration/sonamu-config/auth.mdx
@@ -264,7 +264,7 @@ export class MyModel {
     const session = ctx.session; // Session | null
 
     if (!user) {
-      throw new UnauthorizedError("Login required");
+      throw new UnauthorizedException("Login required");
     }
 
     return { userId: user.id, userName: user.name };
@@ -330,17 +330,17 @@ export default defineConfig({
         const { user } = Sonamu.getContext();
 
         if (guard === "auth" && !user) {
-          throw new UnauthorizedError("Login required");
+          throw new UnauthorizedException("Login required");
         }
 
         if (guard === "admin") {
           if (!user) {
-            throw new UnauthorizedError("Login required");
+            throw new UnauthorizedException("Login required");
           }
           // Assuming User entity has a role field
           const fullUser = await UserModel.findById("A", user.id);
           if (fullUser.role !== "admin") {
-            throw new UnauthorizedError("Admin access required");
+            throw new UnauthorizedException("Admin access required");
           }
         }
       },
@@ -776,7 +776,7 @@ export default defineConfig({
         const { user } = Sonamu.getContext();
 
         if (guard === "auth" && !user) {
-          throw new UnauthorizedError("Login required");
+          throw new UnauthorizedException("Login required");
         }
       },
     },

--- a/modules/docs/en/configuration/sonamu-config/server.mdx
+++ b/modules/docs/en/configuration/sonamu-config/server.mdx
@@ -485,7 +485,7 @@ export default defineConfig({
       guardHandler: (guard, request, api) => {
         // Permission check logic
         if (guard === "admin" && !request.session.isAdmin) {
-          throw new UnauthorizedError("Admin only");
+          throw new UnauthorizedException("Admin only");
         }
       },
     },
@@ -712,7 +712,7 @@ export default defineConfig({
 
       guardHandler: (guard, request) => {
         if (guard === "admin" && !request.session.isAdmin) {
-          throw new UnauthorizedError("Admin access required");
+          throw new UnauthorizedException("Admin access required");
         }
       },
     },

--- a/modules/docs/en/frontend-integration/generated-services/using-services.mdx
+++ b/modules/docs/en/frontend-integration/generated-services/using-services.mdx
@@ -407,7 +407,7 @@ class UserModelClass extends BaseModelClass {
 
     // Authorization checks possible
     if (!context.user) {
-      throw new UnauthorizedError();
+      throw new UnauthorizedException();
     }
 
     return this.findById(id, [subset]);

--- a/modules/docs/en/tools-and-cli/hmr/boundaries.mdx
+++ b/modules/docs/en/tools-and-cli/hmr/boundaries.mdx
@@ -248,7 +248,7 @@ async create(body: PostForm) {
   const user = await UserModel.findById(body.userId);
 
   if (!user.canCreatePost()) {  // 👈 Use the method just added!
-    throw new UnauthorizedError("You don't have permission to create posts");
+    throw new UnauthorizedException("You don't have permission to create posts");
   }
 
   return PostModel.save(body);

--- a/modules/docs/ko/configuration/sonamu-config/auth.mdx
+++ b/modules/docs/ko/configuration/sonamu-config/auth.mdx
@@ -261,7 +261,7 @@ export class MyModel {
     const session = ctx.session; // Session | null
 
     if (!user) {
-      throw new UnauthorizedError("로그인이 필요합니다");
+      throw new UnauthorizedException("로그인이 필요합니다");
     }
 
     return { userId: user.id, userName: user.name };
@@ -327,17 +327,17 @@ export default defineConfig({
         const { user } = Sonamu.getContext();
 
         if (guard === "auth" && !user) {
-          throw new UnauthorizedError("로그인이 필요합니다");
+          throw new UnauthorizedException("로그인이 필요합니다");
         }
 
         if (guard === "admin") {
           if (!user) {
-            throw new UnauthorizedError("로그인이 필요합니다");
+            throw new UnauthorizedException("로그인이 필요합니다");
           }
           // User 엔티티에 role 필드가 있다고 가정
           const fullUser = await UserModel.findById("A", user.id);
           if (fullUser.role !== "admin") {
-            throw new UnauthorizedError("관리자 권한이 필요합니다");
+            throw new UnauthorizedException("관리자 권한이 필요합니다");
           }
         }
       },
@@ -773,7 +773,7 @@ export default defineConfig({
         const { user } = Sonamu.getContext();
 
         if (guard === "auth" && !user) {
-          throw new UnauthorizedError("로그인이 필요합니다");
+          throw new UnauthorizedException("로그인이 필요합니다");
         }
       },
     },

--- a/modules/docs/ko/configuration/sonamu-config/server.mdx
+++ b/modules/docs/ko/configuration/sonamu-config/server.mdx
@@ -483,7 +483,7 @@ export default defineConfig({
       guardHandler: (guard, request, api) => {
         // 권한 검사 로직
         if (guard === "admin" && !request.session.isAdmin) {
-          throw new UnauthorizedError("Admin only");
+          throw new UnauthorizedException("Admin only");
         }
       },
     },
@@ -710,7 +710,7 @@ export default defineConfig({
 
       guardHandler: (guard, request) => {
         if (guard === "admin" && !request.session.isAdmin) {
-          throw new UnauthorizedError("Admin access required");
+          throw new UnauthorizedException("Admin access required");
         }
       },
     },

--- a/modules/docs/ko/frontend-integration/generated-services/using-services.mdx
+++ b/modules/docs/ko/frontend-integration/generated-services/using-services.mdx
@@ -519,7 +519,7 @@ class UserModelClass extends BaseModelClass {
 
     // 권한 체크 등 가능
     if (!context.user) {
-      throw new UnauthorizedError();
+      throw new UnauthorizedException();
     }
 
     return this.findById(id, [subset]);

--- a/modules/docs/ko/tools-and-cli/hmr/boundaries.mdx
+++ b/modules/docs/ko/tools-and-cli/hmr/boundaries.mdx
@@ -248,7 +248,7 @@ async create(body: PostForm) {
   const user = await UserModel.findById(body.userId);
 
   if (!user.canCreatePost()) {  // 👈 방금 추가한 메서드 바로 사용!
-    throw new UnauthorizedError("You don't have permission to create posts");
+    throw new UnauthorizedException("You don't have permission to create posts");
   }
 
   return PostModel.save(body);


### PR DESCRIPTION
> 이 PR은 AI(Claude)에 의해 자동으로 생성되었습니다. 모든 변경은 리뷰어의 판단에 따라 수용 또는 거부될 수 있으며, 코드베이스의 ownership은 전적으로 메인테이너에게 있습니다.

## 무엇을, 왜

sonamu-docs의 코드 예제에서 사용된 `UnauthorizedError` 클래스를 실제 소스코드에 존재하는 `UnauthorizedException`으로 교체합니다.

### 참조한 Issue

- **#44** (내일 새벽에 AI에게 맡길 일들): "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다"

### 이 작업을 선정한 이유

1. `so-exceptions.ts`에 정의된 모든 예외 클래스는 `Exception` 접미사를 사용합니다: `BadRequestException`, `UnauthorizedException`, `NotFoundException` 등. `UnauthorizedError`라는 클래스는 소스코드 어디에도 존재하지 않습니다.
2. PR #196에서 유사한 예외 클래스명 수정(`BadRequestError` → `BadRequestException` 등)이 이미 머지된 선례가 있으나, `UnauthorizedError` 사용처는 당시 수정 범위에서 누락되었습니다.
3. 문서의 코드 예제를 그대로 복사하여 사용하는 사용자가 `ReferenceError: UnauthorizedError is not defined` 런타임 에러를 겪게 됩니다.

## 접근 방식

### 교체 대상 (8파일 = ko 4 + en 4, 총 18개소)

| 문서 | 변경 수 | 변경 내용 |
|------|---------|-----------|
| `auth.mdx` (ko/en) | 5+5 | guardHandler·getContext 예제의 `throw new UnauthorizedError(...)` → `UnauthorizedException` |
| `server.mdx` (ko/en) | 2+2 | guardHandler 예제의 `throw new UnauthorizedError(...)` → `UnauthorizedException` |
| `boundaries.mdx` (ko/en) | 1+1 | HMR 경계 예제의 `throw new UnauthorizedError(...)` → `UnauthorizedException` |
| `using-services.mdx` (ko/en) | 1+1 | 서비스 사용 예제의 `throw new UnauthorizedError()` → `UnauthorizedException` |

### 이렇게 하지 않으면

- 문서 예제 코드를 그대로 사용하면 `ReferenceError: UnauthorizedError is not defined` 에러가 발생합니다.
- `so-exceptions.ts`에서 `{ UnauthorizedException }` 을 import한 후에도 `UnauthorizedError`를 사용하면 에러가 발생합니다.
- 동일한 예외 체계(`*Exception` 접미사)를 따르는 나머지 문서들과 불일치합니다.

### 영향 범위

- 문서 예제 코드만 변경합니다. 소스 코드나 런타임 동작에는 영향이 없습니다.
- 예외의 의미(인증 실패 시 throw)는 동일하며, 클래스명만 실제 존재하는 것으로 교체됩니다.

### 확인 방법

- `grep -rn "UnauthorizedError" modules/docs/` 실행 시 결과가 없어야 합니다.
- `modules/sonamu/src/exceptions/so-exceptions.ts`의 29행에서 `export class UnauthorizedException extends SoException` 확인.

### 추후 사람의 확인이 필요한 부분

- 이 수정은 1:1 클래스명 교체이므로 추가 판단이 필요한 부분은 없습니다.