### PR TITLE
[Nightly 2026-07-21] context·workflow·agent 문서의 미존재 DB.getPuri()·DB.query() 호출을 실제 클래스 BaseModel의 API로 일괄 교체 (ko/en 6파일)

### DIFF
--- a/modules/docs/en/advanced-features/ai-agents/creating-agents.mdx
+++ b/modules/docs/en/advanced-features/ai-agents/creating-agents.mdx
@@ -271,6 +271,7 @@ export const HotelBookingAgent = new HotelBookingAgentClass();
 
 ```typescript
 import { BaseAgentClass, tools } from "sonamu/ai";
+import { BaseModel } from "sonamu";
 import { z } from "zod";
 
 class DataAnalystAgentClass extends BaseAgentClass<{
@@ -298,11 +299,11 @@ class DataAnalystAgentClass extends BaseAgentClass<{
       throw new Error("Only SELECT queries are allowed");
     }
 
-    const result = await DB.query(input.query);
+    const result = await BaseModel.getDB("r").raw(input.query);
 
     return {
       rows: result.rows,
-      rowCount: result.rowCount,
+      rowCount: result.rows.length,
     };
   }
 

--- a/modules/docs/en/advanced-features/workflows/worker-setup.mdx
+++ b/modules/docs/en/advanced-features/workflows/worker-setup.mdx
@@ -221,9 +221,9 @@ CREATE TABLE workflow_steps (
 
 ```typescript
 // Query via Puri (workflow_runs is a framework-internal table, not an entity, so use the .knex escape hatch)
-import { DB } from "sonamu";
+import { BaseModel } from "sonamu";
 
-const puri = DB.getPuri("r");
+const puri = BaseModel.getPuri("r");
 const runs = await puri.knex.table("workflow_runs").where("status", "running").select("*");
 ```
 

--- a/modules/docs/en/api-development/context/custom-context.mdx
+++ b/modules/docs/en/api-development/context/custom-context.mdx
@@ -82,7 +82,7 @@ declare module "sonamu" {
 // middleware/auth.middleware.ts
 import { FastifyRequest, FastifyReply } from "fastify";
 import jwt from "jsonwebtoken";
-import { Sonamu, DB } from "sonamu";
+import { Sonamu, BaseModel } from "sonamu";
 
 export async function authMiddleware(request: FastifyRequest, reply: FastifyReply) {
   // Extract token from Authorization header
@@ -105,7 +105,7 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
     };
 
     // Get user info from DB
-    const rdb = DB.getPuri("r");
+    const rdb = BaseModel.getPuri("r");
     const user = await rdb.table("users").where("id", payload.userId).first();
 
     if (!user) {
@@ -128,7 +128,7 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
     };
 
     // Update last activity time
-    const wdb = DB.getPuri("w");
+    const wdb = BaseModel.getPuri("w");
     await wdb.table("users").where("id", user.id).update({ last_activity_at: new Date() });
   } catch (error) {
     reply.status(401);
@@ -142,7 +142,7 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
 ```typescript
 // middleware/tenant.middleware.ts
 import { FastifyRequest } from "fastify";
-import { Sonamu, DB } from "sonamu";
+import { Sonamu, BaseModel } from "sonamu";
 
 export async function tenantMiddleware(request: FastifyRequest) {
   const context = Sonamu.getContext();
@@ -155,7 +155,7 @@ export async function tenantMiddleware(request: FastifyRequest) {
     return; // No tenant info
   }
 
-  const rdb = DB.getPuri("r");
+  const rdb = BaseModel.getPuri("r");
 
   // Get tenant
   const tenant = await rdb.table("tenants")

--- a/modules/docs/ko/advanced-features/ai-agents/creating-agents.mdx
+++ b/modules/docs/ko/advanced-features/ai-agents/creating-agents.mdx
@@ -267,6 +267,7 @@ export const HotelBookingAgent = new HotelBookingAgentClass();
 
 ```typescript
 import { BaseAgentClass, tools } from "sonamu/ai";
+import { BaseModel } from "sonamu";
 import { z } from "zod";
 
 class DataAnalystAgentClass extends BaseAgentClass<{
@@ -294,11 +295,11 @@ class DataAnalystAgentClass extends BaseAgentClass<{
       throw new Error("SELECT 쿼리만 허용됩니다");
     }
 
-    const result = await DB.query(input.query);
+    const result = await BaseModel.getDB("r").raw(input.query);
 
     return {
       rows: result.rows,
-      rowCount: result.rowCount,
+      rowCount: result.rows.length,
     };
   }
 

--- a/modules/docs/ko/advanced-features/workflows/worker-setup.mdx
+++ b/modules/docs/ko/advanced-features/workflows/worker-setup.mdx
@@ -221,9 +221,9 @@ CREATE TABLE workflow_steps (
 
 ```typescript
 // Puri를 통해 조회 (workflow_runs는 entity가 아닌 프레임워크 내부 테이블이므로 .knex 이스케이프 해치 사용)
-import { DB } from "sonamu";
+import { BaseModel } from "sonamu";
 
-const puri = DB.getPuri("r");
+const puri = BaseModel.getPuri("r");
 const runs = await puri.knex.table("workflow_runs").where("status", "running").select("*");
 ```
 

--- a/modules/docs/ko/api-development/context/custom-context.mdx
+++ b/modules/docs/ko/api-development/context/custom-context.mdx
@@ -82,7 +82,7 @@ declare module "sonamu" {
 // middleware/auth.middleware.ts
 import { FastifyRequest, FastifyReply } from "fastify";
 import jwt from "jsonwebtoken";
-import { Sonamu, DB } from "sonamu";
+import { Sonamu, BaseModel } from "sonamu";
 
 export async function authMiddleware(request: FastifyRequest, reply: FastifyReply) {
   // Authorization 헤더에서 토큰 추출
@@ -105,7 +105,7 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
     };
 
     // DB에서 사용자 정보 조회
-    const rdb = DB.getPuri("r");
+    const rdb = BaseModel.getPuri("r");
     const user = await rdb.table("users").where("id", payload.userId).first();
 
     if (!user) {
@@ -128,7 +128,7 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
     };
 
     // 마지막 활동 시간 업데이트
-    const wdb = DB.getPuri("w");
+    const wdb = BaseModel.getPuri("w");
     await wdb.table("users").where("id", user.id).update({ last_activity_at: new Date() });
   } catch (error) {
     reply.status(401);
@@ -142,7 +142,7 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
 ```typescript
 // middleware/tenant.middleware.ts
 import { FastifyRequest } from "fastify";
-import { Sonamu, DB } from "sonamu";
+import { Sonamu, BaseModel } from "sonamu";
 
 export async function tenantMiddleware(request: FastifyRequest) {
   const context = Sonamu.getContext();
@@ -155,7 +155,7 @@ export async function tenantMiddleware(request: FastifyRequest) {
     return; // 테넌트 정보 없음
   }
 
-  const rdb = DB.getPuri("r");
+  const rdb = BaseModel.getPuri("r");
 
   // 테넌트 조회
   const tenant = await rdb.table("tenants")


### PR DESCRIPTION
> 이 PR은 AI(Claude)에 의해 자동으로 생성되었습니다. 모든 변경은 리뷰어의 판단에 따라 수용 또는 거부될 수 있으며, 코드베이스의 ownership은 전적으로 메인테이너에게 있습니다.

## 무엇을, 왜

sonamu-docs의 코드 예제에서 사용된 `DB.getPuri()`와 `DB.query()` 호출을 실제 소스코드에 존재하는 API로 교체합니다. `DB` 싱글턴(`DBClass`)에는 이 두 메서드가 정의되어 있지 않아, 문서 예제를 그대로 사용하면 런타임 에러가 발생합니다.

### 참조한 Issue

- **#44** (내일 새벽에 AI에게 맡길 일들): "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다"

### 이 작업을 선정한 이유

1. `modules/sonamu/src/database/db.ts`의 `DBClass`에는 `getPuri()` 메서드가 존재하지 않습니다. `getPuri()`는 `modules/sonamu/src/database/base-model.ts`의 `BaseModelClass`(58행)에만 정의되어 있습니다.
2. `DBClass`에는 `query()` 메서드도 존재하지 않습니다. raw SQL 실행은 `getDB().raw()` (Knex 인스턴스의 메서드)를 통해 수행합니다.
3. PR #212(UnauthorizedError→UnauthorizedException), #196(BadRequestError 등) 등 기존 Nightly PR에서 유사한 미존재 API 참조를 교정한 선례가 있으나, `DB.getPuri()`와 `DB.query()`는 수정 범위에서 누락되었습니다.
4. 문서의 코드 예제를 그대로 복사하여 사용하는 사용자가 `TypeError: DB.getPuri is not a function` 또는 `TypeError: DB.query is not a function` 런타임 에러를 겪게 됩니다.

## 접근 방식

### 교체 대상 (6파일 = ko 3 + en 3, 총 10개소)

| 문서 | 변경 내용 |
|------|-----------|
| `custom-context.mdx` (ko/en) | `import { ..., DB }` → `import { ..., BaseModel }`, `DB.getPuri("r")` → `BaseModel.getPuri("r")`, `DB.getPuri("w")` → `BaseModel.getPuri("w")` (각 파일 3개소, 총 6개소) |
| `worker-setup.mdx` (ko/en) | `import { DB }` → `import { BaseModel }`, `DB.getPuri("r")` → `BaseModel.getPuri("r")` (각 파일 1개소, 총 2개소) |
| `creating-agents.mdx` (ko/en) | `import { BaseModel } from "sonamu"` 추가, `DB.query(input.query)` → `BaseModel.getDB("r").raw(input.query)`, `result.rowCount` → `result.rows.length` (각 파일 1개소, 총 2개소) |

### 교체 근거

- **`DB.getPuri()` → `BaseModel.getPuri()`**: `BaseModel`은 `BaseModelClass`의 싱글턴 인스턴스로 `modules/sonamu/src/database/base-model.ts:615`에서 export됩니다. 프레임워크 내부에서도 `BaseModel.getDB("w")` 패턴으로 사용됩니다 (`modules/sonamu/src/testing/fixture-manager.ts`). 문서에서도 `BaseModel.getPuri("w")` 패턴이 이미 사용 중입니다 (`modules/docs/ko/testing/fixtures/loading-fixtures.mdx:65`).
- **`DB.query()` → `BaseModel.getDB("r").raw()`**: `getDB()`는 `Knex` 인스턴스를 반환하며, Knex의 `.raw()` 메서드가 raw SQL 실행을 담당합니다. 반환 형태가 `{ rows, rowCount }` 형식이 아닌 `{ rows }` 형식이므로 `rowCount`를 `rows.length`로 교체했습니다.

### 이렇게 하지 않으면

- 문서 예제 코드를 그대로 사용하면 `TypeError: DB.getPuri is not a function` 에러가 발생합니다.
- `DB.query()`를 호출하면 `TypeError: DB.query is not a function` 에러가 발생합니다.
- 사용자가 문서에서 `DB`로 import하고 `getPuri()`를 호출하는 것이 올바른 패턴이라고 오해하게 됩니다.

### 영향 범위

- 문서 예제 코드만 변경합니다. 소스 코드나 런타임 동작에는 영향이 없습니다.
- DB 접근 의도는 동일하게 유지되며, 호출 대상만 실제 존재하는 API로 교체됩니다.

### 확인 방법

- `grep -rn "DB\.getPuri" modules/docs/` 실행 시 결과가 없어야 합니다.
- `grep -rn "DB\.query\b" modules/docs/` 실행 시 결과가 없어야 합니다.
- `grep -n "getPuri" modules/sonamu/src/database/db.ts` 실행 시 결과가 없음을 확인 (DB에 getPuri가 없음).
- `grep -n "getPuri" modules/sonamu/src/database/base-model.ts` 실행 시 58행에서 확인 가능.

### 추후 사람의 확인이 필요한 부분

- `creating-agents.mdx`의 `DB.query()` → `BaseModel.getDB("r").raw()` 교체에서, Knex `.raw()` 반환값의 `rows` 속성은 PostgreSQL 드라이버(pg) 기준입니다. 다른 드라이버에서는 반환 형태가 다를 수 있으나, sonamu는 PostgreSQL만 지원하므로 문제가 없을 것으로 판단했습니다.