### PR TITLE
[Nightly 2026-07-23] PostgreSQL 스키마 리더의 DB 에러 처리 수정 및 SSE·nested-relations 문서의 잘못된 import/타입 정정 (소스 1파일 + ko/en 6파일)

### DIFF
--- a/modules/docs/en/advanced-features/sse/creating-sse-endpoints.mdx
+++ b/modules/docs/en/advanced-features/sse/creating-sse-endpoints.mdx
@@ -12,7 +12,8 @@ A decorator for defining SSE endpoints.
 ### Basic Usage
 
 ```typescript
-import { type Context, BaseModelClass, stream, z } from "sonamu";
+import { type Context, BaseModelClass, stream } from "sonamu";
+import { z } from "zod";
 
 class NotificationModelClass extends BaseModelClass {
   @stream({

--- a/modules/docs/en/database/subsets/nested-relations.mdx
+++ b/modules/docs/en/database/subsets/nested-relations.mdx
@@ -102,9 +102,10 @@ LoaderQuery is defined in `subset-loaders.ts` files:
 ```typescript
 // src/application/user/user.subset-loaders.ts
 
-import type { SubsetLoaderMap } from "sonamu";
+import type { PuriLoaderQueries } from "sonamu";
+import type { UserSubsetKey } from "../sonamu.generated";
 
-export const UserSubsetLoaders: SubsetLoaderMap<"User"> = {
+export const UserSubsetLoaders: PuriLoaderQueries<UserSubsetKey> = {
   // Add posts loader to Subset A
   A: [
     {
@@ -133,7 +134,7 @@ export const UserSubsetLoaders: SubsetLoaderMap<"User"> = {
 
 ```typescript
 // Department Entity
-export const DepartmentSubsetLoaders: SubsetLoaderMap<"Department"> = {
+export const DepartmentSubsetLoaders: PuriLoaderQueries<DepartmentSubsetKey> = {
   P: [
     {
       as: "employees",
@@ -184,7 +185,7 @@ dept.employees.forEach((emp) => {
 
 ```typescript
 // Project Entity
-export const ProjectSubsetLoaders: SubsetLoaderMap<"Project"> = {
+export const ProjectSubsetLoaders: PuriLoaderQueries<ProjectSubsetKey> = {
   P: [
     {
       as: "members",
@@ -240,7 +241,7 @@ LoaderQuery can be **nested recursively**:
 
 ```typescript
 // Department Entity
-export const DepartmentSubsetLoaders: SubsetLoaderMap<"Department"> = {
+export const DepartmentSubsetLoaders: PuriLoaderQueries<DepartmentSubsetKey> = {
   P: [
     {
       as: "employees",

--- a/modules/docs/en/frontend-integration/generated-services/useSSEStream.mdx
+++ b/modules/docs/en/frontend-integration/generated-services/useSSEStream.mdx
@@ -450,7 +450,8 @@ SSE endpoints are created using the `@stream` decorator and `ctx.createSSE()`.
 
 ```typescript
 // ai.model.ts (backend)
-import { BaseModelClass, stream, Sonamu, z } from "sonamu";
+import { BaseModelClass, stream, Sonamu } from "sonamu";
+import { z } from "zod";
 
 class AIModelClass extends BaseModelClass {
   @stream({

--- a/modules/docs/ko/advanced-features/sse/creating-sse-endpoints.mdx
+++ b/modules/docs/ko/advanced-features/sse/creating-sse-endpoints.mdx
@@ -12,7 +12,8 @@ SSE 엔드포인트를 정의하는 데코레이터입니다.
 ### 기본 사용법
 
 ```typescript
-import { type Context, BaseModelClass, stream, z } from "sonamu";
+import { type Context, BaseModelClass, stream } from "sonamu";
+import { z } from "zod";
 
 class NotificationModelClass extends BaseModelClass {
   @stream({

--- a/modules/docs/ko/database/subsets/nested-relations.mdx
+++ b/modules/docs/ko/database/subsets/nested-relations.mdx
@@ -102,9 +102,10 @@ LoaderQuery는 `subset-loaders.ts` 파일에서 정의합니다:
 ```typescript
 // src/application/user/user.subset-loaders.ts
 
-import type { SubsetLoaderMap } from "sonamu";
+import type { PuriLoaderQueries } from "sonamu";
+import type { UserSubsetKey } from "../sonamu.generated";
 
-export const UserSubsetLoaders: SubsetLoaderMap<"User"> = {
+export const UserSubsetLoaders: PuriLoaderQueries<UserSubsetKey> = {
   // Subset A에 posts 로더 추가
   A: [
     {
@@ -133,7 +134,7 @@ export const UserSubsetLoaders: SubsetLoaderMap<"User"> = {
 
 ```typescript
 // Department Entity
-export const DepartmentSubsetLoaders: SubsetLoaderMap<"Department"> = {
+export const DepartmentSubsetLoaders: PuriLoaderQueries<DepartmentSubsetKey> = {
   P: [
     {
       as: "employees",
@@ -184,7 +185,7 @@ dept.employees.forEach((emp) => {
 
 ```typescript
 // Project Entity
-export const ProjectSubsetLoaders: SubsetLoaderMap<"Project"> = {
+export const ProjectSubsetLoaders: PuriLoaderQueries<ProjectSubsetKey> = {
   P: [
     {
       as: "members",
@@ -240,7 +241,7 @@ LoaderQuery는 **재귀적으로 중첩**할 수 있습니다:
 
 ```typescript
 // Department Entity
-export const DepartmentSubsetLoaders: SubsetLoaderMap<"Department"> = {
+export const DepartmentSubsetLoaders: PuriLoaderQueries<DepartmentSubsetKey> = {
   P: [
     {
       as: "employees",

--- a/modules/docs/ko/frontend-integration/generated-services/useSSEStream.mdx
+++ b/modules/docs/ko/frontend-integration/generated-services/useSSEStream.mdx
@@ -450,7 +450,8 @@ SSE 엔드포인트는 `@stream` 데코레이터와 `ctx.createSSE()`로 만듭�
 
 ```typescript
 // ai.model.ts (백엔드)
-import { BaseModelClass, stream, Sonamu, z } from "sonamu";
+import { BaseModelClass, stream, Sonamu } from "sonamu";
+import { z } from "zod";
 
 class AIModelClass extends BaseModelClass {
   @stream({

--- a/modules/sonamu/src/migration/postgresql-schema-reader.ts
+++ b/modules/sonamu/src/migration/postgresql-schema-reader.ts
@@ -90,8 +90,7 @@ class PostgreSQLSchemaReaderClass {
       if (e instanceof Error && e.message.includes("Table not found")) {
         return null;
       }
-      console.error(e);
-      return null;
+      throw e;
     }
 
     // vector 컬럼의 dimensions 조회


### PR DESCRIPTION
> 이 PR은 AI(Claude)에 의해 자동으로 생성되었습니다. 모든 변경은 리뷰어의 판단에 따라 수용 또는 거부될 수 있으며, 코드베이스의 ownership은 전적으로 메인테이너에게 있습니다.

## 무엇을, 왜

[#44](https://github.com/cartanova-ai/sonamu/issues/44)와 [#43](https://github.com/cartanova-ai/sonamu/issues/43)을 참조하여 3가지 개선을 수행합니다.

### 1. `getMigrationSetFromDB` 예상치 못한 DB 에러를 re-throw하도록 수정 (소스코드 버그)

**파일**: `modules/sonamu/src/migration/postgresql-schema-reader.ts`

**문제**: `getMigrationSetFromDB`에서 `readTable()`이 "Table not found" 외의 에러를 던졌을 때, `console.error(e)` 후 `null`을 반환했습니다. 호출부인 `migrator.ts:420-422`에서는 `null`을 "기존 테이블 없음"으로 해석하여 `generateCreateCode(entitySet)`를 호출합니다.

**왜 문제인가**:
- DB 연결 타임아웃, 권한 에러, 일시적 네트워크 장애 등이 발생하면, 이미 존재하는 테이블에 대해 CREATE TABLE 마이그레이션 코드가 생성됩니다
- 이 코드를 실행하면 `relation already exists` 에러가 발생하거나, 더 위험한 경우 기존 데이터가 손상될 수 있습니다
- 에러를 조용히 삼키고 잘못된 결과를 반환하는 것보다, 에러를 전파하여 마이그레이션 생성을 중단시키는 것이 안전합니다

**수정**: `console.error(e); return null;`을 `throw e;`로 변경합니다. "Table not found" 분기는 그대로 유지되어 신규 테이블 감지는 정상 동작합니다.

### 2. SSE 문서의 `z` import 경로 정정 (ko/en 4파일)

**파일**: `creating-sse-endpoints.mdx`, `useSSEStream.mdx` (ko/en)

**문제**: `z` 객체(zod 스키마 빌더)를 `import { ..., z } from "sonamu"`로 import하고 있으나, `modules/sonamu/src/index.ts`에서 `z`를 re-export하지 않습니다. 이 코드를 그대로 사용하면 `z is not exported from "sonamu"` 에러가 발생합니다.

**수정**: `z`를 `import { z } from "zod"`로 분리합니다. 실제 프로젝트 코드(miomock)에서도 `z`는 `"zod"`에서 직접 import합니다.

### 3. nested-relations 문서의 미존재 `SubsetLoaderMap` 타입 정정 (ko/en 2파일)

**파일**: `nested-relations.mdx` (ko/en)

**문제**: `SubsetLoaderMap`이라는 타입은 sonamu 소스코드 어디에도 존재하지 않습니다. 실제로 사용되는 타입은 `PuriLoaderQueries<TSubsetKey>`이며, 자동 생성 코드(`sonamu.generated.sso.ts`)에서도 이 타입을 사용합니다.

**수정**: `import type { SubsetLoaderMap } from "sonamu"`를 `import type { PuriLoaderQueries } from "sonamu"`로 변경하고, `SubsetLoaderMap<"User">`를 `PuriLoaderQueries<UserSubsetKey>` 패턴으로 일관되게 교체합니다.

## 접근 방식을 선택한 이유

- **스키마 리더 수정**: `null`은 "Table not found"를 의미하도록 설계되었으므로, 다른 에러에서도 `null`을 반환하는 것은 계약 위반입니다. re-throw가 가장 단순하고 안전한 수정입니다.
- **문서 수정**: `"sonamu"` 대신 `"zod"` import, `SubsetLoaderMap` 대신 `PuriLoaderQueries`는 모두 실제 코드에서 사용되는 정확한 패턴입니다.

## 이렇게 하지 않으면

- 스키마 리더: 일시적 DB 장애 중 마이그레이션을 생성하면 잘못된 CREATE TABLE 코드가 나와 혼란을 줍니다.
- 문서: 사용자가 코드 예제를 복사하면 즉시 TypeScript 에러가 발생하여 신뢰도가 떨어집니다.

## 영향 범위

- **스키마 리더 수정**: `getMigrationSetFromDB`를 호출하는 `migrator.ts:compareMigrations`에 영향. 기존에 "Table not found"로 올바르게 `null`을 반환하던 경로는 변경 없음. 예상치 못한 에러 경로에서만 동작이 변경됨 (기존: silent null → 변경: throw).
- **문서 수정**: 6개 문서 파일의 코드 예제만 변경. 런타임 동작에 영향 없음.

## 변경 영향 확인 방법

1. **스키마 리더**: `pnpm --filter sonamu test:type` 통과 확인 (완료). DB 연결이 정상인 환경에서 `pnpm --filter miomock-api test`로 마이그레이션 테스트를 실행하면 기존과 동일하게 동작해야 합니다.
2. **문서**: 문서 코드 예제의 import문이 실제 패키지 export와 일치하는지 확인.

## 사람의 확인이 필요한 부분

- **스키마 리더 수정**: re-throw로 변경하면 마이그레이션 생성 시 DB 에러가 사용자에게 바로 노출됩니다. 이것이 의도한 동작인지, 혹은 별도의 에러 메시지 래핑이 필요한지 판단이 필요합니다.
- **miomock 통합 테스트**: 이 환경에서 3개 테스트 파일(migrator.getStatus, migrator.generatedColumn, 그리고 fixture 관련 1파일)이 DB 연결 타임아웃으로 실패하고 있습니다. 이는 master 브랜치에서도 동일하게 실패하므로 이 PR의 변경과는 무관한 환경 이슈입니다.