### PR TITLE
[Nightly 2026-07-24] 문서 코드 예제의 ListResult 타입 파라미터를 실제 시그니처(LP, T)에 맞게 일괄 정정 (ko/en 14파일)

### DIFF
--- a/modules/docs/en/core-concepts/entity/defining-entities.mdx
+++ b/modules/docs/en/core-concepts/entity/defining-entities.mdx
@@ -195,7 +195,7 @@ Defines field combinations for API responses.
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams,
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
   return this.executeSubsetQuery({ subset, qb, params });
 }

--- a/modules/docs/en/core-concepts/model/api-decorator.mdx
+++ b/modules/docs/en/core-concepts/model/api-decorator.mdx
@@ -498,7 +498,7 @@ async findById(id: number): Promise<User> {
   resourceName: "Users",
   cacheControl: { maxAge: 30 },
 })
-async findMany(params: UserListParams): Promise<ListResult<User>> {
+async findMany(params: UserListParams): Promise<ListResult<UserListParams, User>> {
   const { qb } = this.getSubsetQueries("A");
   
   if (params.keyword) {

--- a/modules/docs/en/core-concepts/model/basemodel-methods.mdx
+++ b/modules/docs/en/core-concepts/model/basemodel-methods.mdx
@@ -158,7 +158,7 @@ getSubsetQueries<T extends TSubsetKey>(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
   
   // Add conditions
@@ -175,7 +175,7 @@ async findMany<T extends UserSubsetKey>(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb, onSubset } = this.getSubsetQueries(subset);
 
   // Access fields only in subset "P"
@@ -192,7 +192,7 @@ async findMany<T extends UserSubsetKey>(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb, onSubset } = this.getSubsetQueries(subset);
 
   // Only access fields in both A and P
@@ -235,7 +235,7 @@ executeSubsetQuery<T extends TSubsetKey>(
     debug?: boolean;
     optimizeCountQuery?: boolean;
   }
-): Promise<ListResult<TSubsetMapping[T]>>
+): Promise<ListResult<LP, TSubsetMapping[T]>>
 ```
 
 **Parameters**:
@@ -266,7 +266,7 @@ executeSubsetQuery<T extends TSubsetKey>(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
   
   if (params.keyword) {
@@ -696,7 +696,7 @@ async findMany<T extends UserSubsetKey, LP extends UserListParams>(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
 
   // Date range filter

--- a/modules/docs/en/core-concepts/model/business-logic.mdx
+++ b/modules/docs/en/core-concepts/model/business-logic.mdx
@@ -329,7 +329,7 @@ async updateStatus(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
 
   // Conditional filtering

--- a/modules/docs/en/core-concepts/model/what-is-model.mdx
+++ b/modules/docs/en/core-concepts/model/what-is-model.mdx
@@ -163,7 +163,7 @@ const user = await UserModel.findById("INVALID", 1);
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
 
   // Automatically SELECT only fields matching the subset
@@ -253,7 +253,7 @@ class UserModelClass extends BaseModelClass {
   }
 
   @api({ httpMethod: "GET" })
-  async findMany(params: UserListParams): Promise<ListResult<User>> {
+  async findMany(params: UserListParams): Promise<ListResult<UserListParams, User>> {
     // ...
   }
 

--- a/modules/docs/en/faq/api.mdx
+++ b/modules/docs/en/faq/api.mdx
@@ -105,7 +105,7 @@ async getUser(id: number, includeProfile?: boolean): Promise<User> {
 
 ```typescript
 @api({ httpMethod: "GET" })
-async listUsers(listParams: UserListParams): Promise<ListResult<User>> {
+async listUsers(listParams: UserListParams): Promise<ListResult<UserListParams, User>> {
   // GET /user/listUsers?num=20&page=1&orderBy=id-desc
   return this.list("A", listParams);
 }
@@ -512,7 +512,7 @@ async downloadFile(id: number): Promise<Buffer> {
 
 ```typescript
 @api({ httpMethod: "GET" })
-async listUsers(listParams: UserListParams): Promise<ListResult<UserA>> {
+async listUsers(listParams: UserListParams): Promise<ListResult<UserListParams, UserA>> {
   // ListResult = { rows: T[], total: number }
   return this.list("A", listParams);
 }

--- a/modules/docs/en/tools-and-cli/sonamu-cli/scaffold.mdx
+++ b/modules/docs/en/tools-and-cli/sonamu-cli/scaffold.mdx
@@ -452,7 +452,7 @@ async getUserStats(userId: number) { }   // get + Noun + Type
 // ✅ Consistent return types
 Promise<User | null>      // Single record (nullable)
 Promise<User[]>           // Multiple records
-Promise<ListResult<User>> // Pagination
+Promise<ListResult<UserListParams, User>> // Pagination
 ```
 
 ### 4. Git Management

--- a/modules/docs/ko/core-concepts/entity/defining-entities.mdx
+++ b/modules/docs/ko/core-concepts/entity/defining-entities.mdx
@@ -192,7 +192,7 @@ API 응답에서 사용할 필드 조합을 정의합니다.
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams,
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
   return this.executeSubsetQuery({ subset, qb, params });
 }

--- a/modules/docs/ko/core-concepts/model/api-decorator.mdx
+++ b/modules/docs/ko/core-concepts/model/api-decorator.mdx
@@ -498,7 +498,7 @@ async findById(id: number): Promise<User> {
   resourceName: "Users",
   cacheControl: { maxAge: 30 },
 })
-async findMany(params: UserListParams): Promise<ListResult<User>> {
+async findMany(params: UserListParams): Promise<ListResult<UserListParams, User>> {
   const { qb } = this.getSubsetQueries("A");
   
   if (params.keyword) {

--- a/modules/docs/ko/core-concepts/model/basemodel-methods.mdx
+++ b/modules/docs/ko/core-concepts/model/basemodel-methods.mdx
@@ -158,7 +158,7 @@ getSubsetQueries<T extends TSubsetKey>(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
   
   // 조건 추가
@@ -175,7 +175,7 @@ async findMany<T extends UserSubsetKey>(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb, onSubset } = this.getSubsetQueries(subset);
 
   // subset "P"에만 있는 필드 접근
@@ -192,7 +192,7 @@ async findMany<T extends UserSubsetKey>(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb, onSubset } = this.getSubsetQueries(subset);
 
   // A와 P 둘 다 있는 필드만 접근 가능
@@ -235,7 +235,7 @@ executeSubsetQuery<T extends TSubsetKey>(
     debug?: boolean;
     optimizeCountQuery?: boolean;
   }
-): Promise<ListResult<TSubsetMapping[T]>>
+): Promise<ListResult<LP, TSubsetMapping[T]>>
 ```
 
 **파라미터**:
@@ -266,7 +266,7 @@ executeSubsetQuery<T extends TSubsetKey>(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
   
   if (params.keyword) {
@@ -695,7 +695,7 @@ async findMany<T extends UserSubsetKey, LP extends UserListParams>(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
 
   // 날짜 범위 필터

--- a/modules/docs/ko/core-concepts/model/business-logic.mdx
+++ b/modules/docs/ko/core-concepts/model/business-logic.mdx
@@ -329,7 +329,7 @@ async updateStatus(
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
 
   // 조건부 필터링

--- a/modules/docs/ko/core-concepts/model/what-is-model.mdx
+++ b/modules/docs/ko/core-concepts/model/what-is-model.mdx
@@ -163,7 +163,7 @@ const user = await UserModel.findById("INVALID", 1);
 async findMany<T extends UserSubsetKey>(
   subset: T,
   params: UserListParams
-): Promise<ListResult<UserSubsetMapping[T]>> {
+): Promise<ListResult<UserListParams, UserSubsetMapping[T]>> {
   const { qb } = this.getSubsetQueries(subset);
 
   // subset에 맞는 필드만 자동 SELECT
@@ -252,7 +252,7 @@ class UserModelClass extends BaseModelClass {
   }
 
   @api({ httpMethod: "GET" })
-  async findMany(params: UserListParams): Promise<ListResult<User>> {
+  async findMany(params: UserListParams): Promise<ListResult<UserListParams, User>> {
     // ...
   }
 

--- a/modules/docs/ko/faq/api.mdx
+++ b/modules/docs/ko/faq/api.mdx
@@ -105,7 +105,7 @@ async getUser(id: number, includeProfile?: boolean): Promise<User> {
 
 ```typescript
 @api({ httpMethod: "GET" })
-async listUsers(listParams: UserListParams): Promise<ListResult<User>> {
+async listUsers(listParams: UserListParams): Promise<ListResult<UserListParams, User>> {
   // GET /user/listUsers?num=20&page=1&orderBy=id-desc
   return this.list("A", listParams);
 }
@@ -511,7 +511,7 @@ async downloadFile(id: number): Promise<Buffer> {
 
 ```typescript
 @api({ httpMethod: "GET" })
-async listUsers(listParams: UserListParams): Promise<ListResult<UserA>> {
+async listUsers(listParams: UserListParams): Promise<ListResult<UserListParams, UserA>> {
   // ListResult = { rows: T[], total: number }
   return this.list("A", listParams);
 }

--- a/modules/docs/ko/tools-and-cli/sonamu-cli/scaffold.mdx
+++ b/modules/docs/ko/tools-and-cli/sonamu-cli/scaffold.mdx
@@ -452,7 +452,7 @@ async getUserStats(userId: number) { }   // get + Noun + Type
 // ✅ 일관된 반환 타입
 Promise<User | null>      // 단일 레코드 (nullable)
 Promise<User[]>           // 다중 레코드
-Promise<ListResult<User>> // 페이지네이션
+Promise<ListResult<UserListParams, User>> // 페이지네이션
 ```
 
 ### 4. Git 관리


### PR DESCRIPTION
> 이 PR은 AI(Claude)에 의해 자동으로 생성되었습니다. 모든 변경은 리뷰어의 판단에 따라 수용 또는 거부될 수 있으며, 코드베이스의 ownership은 전적으로 메인테이너에게 있습니다.

## 무엇을, 왜

[#44](https://github.com/cartanova-ai/sonamu/issues/44)와 [#43](https://github.com/cartanova-ai/sonamu/issues/43)을 참조하여, 문서 코드 예제의 `ListResult` 타입 파라미터 불일치를 수정합니다.

### ListResult 타입 파라미터 정정 (ko/en 14파일)

**파일**: `defining-entities.mdx`, `what-is-model.mdx`, `api-decorator.mdx`, `basemodel-methods.mdx`, `business-logic.mdx`, `faq/api.mdx`, `scaffold.mdx` (각 ko/en)

**문제**: 문서의 코드 예제에서 `ListResult`를 1개 타입 파라미터로 사용하고 있으나, 실제 타입 정의(`modules/sonamu/src/utils/model.ts`)는 2개 타입 파라미터 `LP`(ListParams)와 `T`를 필요로 합니다.

```typescript
// 실제 타입 정의
export type ListResult<
  LP extends { queryMode?: SonamuQueryMode },
  T,
> = LP["queryMode"] extends "list"
  ? { rows: WithSimilarity<LP, T>[] }
  : LP["queryMode"] extends "count"
    ? { total: number }
    : { rows: WithSimilarity<LP, T>[]; total: number };
```

문서에서는 `ListResult<UserSubsetMapping[T]>`나 `ListResult<User>`처럼 1개 파라미터만 전달하고 있었습니다. 이는 `LP` 파라미터가 누락된 형태로, TypeScript 컴파일러는 이를 타입 에러로 보고합니다.

**왜 문제인가**:
- 문서 예제를 그대로 복사하여 사용하면 TypeScript 컴파일 에러 발생 (`Generic type 'ListResult' requires 2 type argument(s)`)
- `ListResult`의 핵심 기능인 `queryMode` 기반 조건부 타입 추론이 문서에서 제대로 설명되지 않음
- 실제 코드 생성 결과물(`model.template.ts`, `services.generated.ts`)은 이미 올바르게 2-파라미터를 사용 중이므로, 문서만 뒤처진 상태

**수정**:
- `ListResult<UserSubsetMapping[T]>` → `ListResult<UserListParams, UserSubsetMapping[T]>`
- `ListResult<User>` → `ListResult<UserListParams, User>`
- `ListResult<TSubsetMapping[T]>` (executeSubsetQuery 시그니처) → `ListResult<LP, TSubsetMapping[T]>`

## 접근 방식

`ListResult` 타입의 첫 번째 파라미터 `LP`는 `queryMode` 필드를 가진 ListParams 타입입니다. 각 문서 예시에서 해당 Entity의 ListParams 타입(예: `UserListParams`)을 LP 위치에 삽입하여 실제 사용 패턴과 일치시켰습니다.

실제 코드 생성 템플릿(`model.template.ts:114-117`)에서는 `<T extends EntitySubsetKey, LP extends EntityListParams>` 두 제네릭을 선언하고 `ListResult<LP, EntitySubsetMapping[T]>`를 반환합니다. 문서의 "표준 findMany 패턴" 섹션(`basemodel-methods.mdx:637-640`)은 이미 이 올바른 패턴을 사용하고 있었으므로, 나머지 예제들을 이 패턴에 맞추었습니다.

## 영향 범위

- 문서 전용 변경으로 런타임 코드에 영향 없음
- ko/en 14개 `.mdx` 파일에서 총 28개 라인 수정 (각 라인은 1-파라미터 → 2-파라미터 형태 변경)

## 확인 방법

1. 문서 내 `ListResult<` 검색 시 모든 사용처가 2개 타입 파라미터를 전달하는지 확인:
   ```bash
   grep -rn "Promise<ListResult<" modules/docs/ --include="*.mdx" | grep -v "ListResult<.*,.*>"
   ```
   결과가 없으면 모든 곳이 정정된 것입니다.

2. 실제 타입 정의와 대조:
   - `modules/sonamu/src/utils/model.ts:8-15`: `ListResult<LP, T>` 정의
   - `modules/sonamu/src/template/implementations/model.template.ts:117`: 생성 템플릿의 올바른 사용 패턴

## 검증

- `pnpm check` (oxlint + oxfmt): 통과
- 문서 전용 변경으로 소스코드 빌드/테스트에 영향 없음

## 사람의 확인이 필요한 부분

- 일부 문서 예시에서 LP 제네릭을 직접 선언하지 않고 `UserListParams`를 직접 넣었습니다. 이는 간결한 예시를 위한 선택이지만, `<T extends UserSubsetKey, LP extends UserListParams>` 패턴으로 통일하는 것이 더 나은지 메인테이너 판단이 필요합니다.