### PR TITLE
chore(react-components): 버전 0.4.6으로 올려 배포 (clearable)

### DIFF
--- a/modules/react-components/package.json
+++ b/modules/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonamu-kit/react-components",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "license": "MIT",
   "author": "CartaNova <dev@cartanova.ai>",
   "repository": {


### PR DESCRIPTION
#217(Input clearable)이 stale 로컬에서 0.4.5로 올렸으나 master는 이미 0.4.5가 퍼블리시된 상태여서 CI publish가 스킵됐다. 코드는 정상 머지됐고, 배포만 되도록 **0.4.6**으로 patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)