### PR TITLE
feat(cli): scaffold view_list / view_form CLI 러너 배선

### DIFF
--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/bin/cli.ts
+++ b/modules/sonamu/src/bin/cli.ts
@@ -197,8 +197,8 @@ async function bootstrap() {
         stub_entity,
         scaffold_model,
         scaffold_model_test,
-        // scaffold_view_list,
-        // scaffold_view_form,
+        scaffold_view_list,
+        scaffold_view_form,
         cone_gen,
         sync,
         build_all,
@@ -979,6 +979,19 @@ async function scaffold_model(entityId: string) {
 
 async function scaffold_model_test(entityId: string) {
   await Sonamu.syncer.generateTemplate("model_test", {
+    entityId,
+  });
+}
+
+async function scaffold_view_list(entityId: string) {
+  await Sonamu.syncer.generateTemplate("view_list", {
+    entityId,
+    extra: undefined,
+  });
+}
+
+async function scaffold_view_form(entityId: string) {
+  await Sonamu.syncer.generateTemplate("view_form", {
     entityId,
   });
 }


### PR DESCRIPTION
## 요약

view 스캐폴딩 로직은 예전 `react-components/scripts/scaffold.ts`에서 sonamu 템플릿(`view_list`/`view_form`)으로 이관됐고 **UI 스캐폴딩에서는 정상 동작**하나, **CLI 러너는 이관 후 재배선되지 않은 채 주석으로 남아** 있었다. 에이전트가 CLI로도 view를 스캐폴딩할 수 있도록 배선한다.

## 변경

- `scaffold_view_list` / `scaffold_view_form` 함수 추가 (`scaffold_model`과 동일하게 `Sonamu.syncer.generateTemplate` 호출)
- `runners` 등록의 주석 해제 (`args`의 view_list/view_form 항목은 이미 선언돼 있었음)
- `package.json`: `0.10.4` → `0.10.5` (patch)

## 검증 (miomock)

- `sonamu scaffold view_list Account` → 신규 파일 생성 확인 (`web/src/routes/admin/accounts/index.tsx`)
- `sonamu scaffold view_list/view_form Tag` → 기존 파일 존재 시 `AlreadyProcessedException`으로 `overwrite:false` 정상 동작
- 검증 산출물은 원복, `pnpm check`/`test:type` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)