### PR TITLE
[sonamu] feat(SON-510): puri ensureJoin 추가

### DIFF
--- a/examples/miomock/api/sonamu.lock
+++ b/examples/miomock/api/sonamu.lock
@@ -65,7 +65,7 @@
   },
   {
     "path": "api/src/application/department/department.model.ts",
-    "checksum": "92302d97cfe157939d54b8b38017c7a9b32d44b4"
+    "checksum": "5b48aa113d2051f5ec7ecaa8798ec1e3df4a93d8"
   },
   {
     "path": "api/src/application/department/department.types.ts",

--- a/examples/miomock/api/src/application/department/department.model.ts
+++ b/examples/miomock/api/src/application/department/department.model.ts
@@ -79,7 +79,7 @@ class DepartmentModelClass extends BaseModelClass<
       ...rawParams,
     };
 
-    const { qb, onSubset } = this.getSubsetQueries(subset);
+    const { qb } = this.getSubsetQueries(subset);
 
     // id
     if (params.id) {
@@ -87,7 +87,11 @@ class DepartmentModelClass extends BaseModelClass<
     }
 
     if (params.company_name) {
-      onSubset(["A", "P", "P2"]).where("company.name", params.company_name);
+      // subset에 company JOIN이 이미 있으면 재사용하고, 없을 때만 추가한다.
+      qb.ensureJoin({ company: "companies" }, "departments.company_id", "company.id").where(
+        "company.name",
+        params.company_name,
+      );
     }
 
     // search-keyword
@@ -129,6 +133,7 @@ class DepartmentModelClass extends BaseModelClass<
       qb,
       params,
       enhancers,
+      debug: false,
     });
   }
 

--- a/modules/docs/en/database/puri/joins.mdx
+++ b/modules/docs/en/database/puri/joins.mdx
@@ -164,6 +164,41 @@ const results = await db
   key → INNER JOIN 3. NULLABLE foreign key → LEFT JOIN 4. Consider business requirements
 </Tip>
 
+## Reusing an Existing JOIN
+
+Use `ensureJoin()` or `ensureLeftJoin()` when a Model adds a JOIN that may already have been added
+by a Subset query.
+
+```typescript
+const results = await db
+  .table("patient_timeline_events")
+  .ensureJoin(
+    { patient: "patients" },
+    "patient_timeline_events.patient_id",
+    "patient.id",
+  )
+  .where("patient.organization_id", organizationId)
+  .select({
+    id: "patient_timeline_events.id",
+    patientName: "patient.name",
+  });
+```
+
+Puri compares JOINs by alias. If the alias, table, JOIN type, left column, and right column all
+match, it reuses the existing JOIN. If the alias is new, it adds the JOIN. Reusing an alias with a
+different definition throws an error before SQL execution.
+
+The same physical table can still be joined more than once under different aliases.
+
+```typescript
+db.table("documents")
+  .ensureJoin({ created_by: "users" }, "documents.created_by_id", "created_by.id")
+  .ensureJoin({ updated_by: "users" }, "documents.updated_by_id", "updated_by.id");
+```
+
+`ensureJoin()` and `ensureLeftJoin()` support simple column equality JOINs against tables. Callback
+and subquery JOINs continue to use `join()` and `leftJoin()` and are not considered reusable.
+
 ## Self JOIN - Self Reference
 
 Use **aliases** when joining the same table.

--- a/modules/docs/ko/database/puri/joins.mdx
+++ b/modules/docs/ko/database/puri/joins.mdx
@@ -162,6 +162,41 @@ const results = await db
   → INNER JOIN 3. NULLABLE 외래 키 → LEFT JOIN 4. 비즈니스 요구사항 고려
 </Tip>
 
+## 기존 JOIN 재사용
+
+Subset 쿼리가 추가했을 수 있는 JOIN을 Model에서 다시 사용할 때는 `ensureJoin()` 또는
+`ensureLeftJoin()`을 사용합니다.
+
+```typescript
+const results = await db
+  .table("patient_timeline_events")
+  .ensureJoin(
+    { patient: "patients" },
+    "patient_timeline_events.patient_id",
+    "patient.id",
+  )
+  .where("patient.organization_id", organizationId)
+  .select({
+    id: "patient_timeline_events.id",
+    patientName: "patient.name",
+  });
+```
+
+Puri는 alias를 기준으로 JOIN을 비교합니다. alias, 테이블, JOIN 타입, 왼쪽 컬럼, 오른쪽 컬럼이
+모두 같으면 기존 JOIN을 재사용하고, alias가 없으면 새 JOIN을 추가합니다. 같은 alias에 다른 정의를
+사용하면 SQL 실행 전에 오류가 발생합니다.
+
+같은 물리 테이블도 alias가 다르면 각각 JOIN할 수 있습니다.
+
+```typescript
+db.table("documents")
+  .ensureJoin({ created_by: "users" }, "documents.created_by_id", "created_by.id")
+  .ensureJoin({ updated_by: "users" }, "documents.updated_by_id", "updated_by.id");
+```
+
+`ensureJoin()`과 `ensureLeftJoin()`은 테이블의 단순 컬럼 동등 JOIN만 지원합니다. callback 또는
+서브쿼리 JOIN은 기존처럼 `join()`과 `leftJoin()`을 사용하며 재사용 대상으로 판정하지 않습니다.
+
 ## Self JOIN - 자기 참조
 
 같은 테이블을 조인할 때는 **별칭(alias)**을 사용합니다.

--- a/modules/sonamu/src/database/__tests__/puri.test.ts
+++ b/modules/sonamu/src/database/__tests__/puri.test.ts
@@ -7,6 +7,7 @@ type TestSchema = {
   users: {
     id: number;
     name: string;
+    department_id: number | null;
     payload: {
       actor: {
         id: string;
@@ -17,6 +18,14 @@ type TestSchema = {
     tags: string[];
     state: string;
     readonly __json__: readonly ["payload", "tags", "state"];
+  };
+  departments: {
+    id: number;
+    name: string;
+  };
+  companies: {
+    id: number;
+    name: string;
   };
 };
 
@@ -97,5 +106,179 @@ describe("Puri JSONB containment", () => {
       "Puri JSONB containment value must be JSON-serializable; JSON.stringify returned undefined.",
     );
     expect(query.rawQuery().toSQL().sql).toBe('select * from "users"');
+  });
+});
+
+describe("Puri ensureJoin", () => {
+  it("기존의 동일한 JOIN을 재사용한다", () => {
+    const query = usersQuery()
+      .join({ department: "departments" }, "users.department_id", "department.id")
+      .ensureJoin({ department: "departments" }, "users.department_id", "department.id");
+
+    expect(query.toQuery().match(/join "departments" as "department"/g)).toHaveLength(1);
+  });
+
+  it("등록되지 않은 JOIN을 추가한다", () => {
+    const query = usersQuery().ensureJoin(
+      { department: "departments" },
+      "users.department_id",
+      "department.id",
+    );
+
+    expect(query.toQuery()).toContain(
+      'join "departments" as "department" on "users"."department_id" = "department"."id"',
+    );
+  });
+
+  it("같은 alias의 JOIN 조건이 다르면 실행 전에 오류를 던진다", () => {
+    const query = usersQuery().join(
+      { department: "departments" },
+      "users.department_id",
+      "department.id",
+    );
+
+    expect(() =>
+      query.ensureJoin({ department: "departments" }, "users.id", "department.id"),
+    ).toThrowError(
+      [
+        'Join alias "department" is already registered with a different definition.',
+        "Existing: JOIN departments AS department ON users.department_id = department.id",
+        "Requested: JOIN departments AS department ON users.id = department.id",
+      ].join("\n"),
+    );
+  });
+
+  it.each([
+    {
+      name: "테이블",
+      create: () =>
+        usersQuery()
+          .join({ department: "departments" }, "users.department_id", "department.id")
+          .ensureJoin({ department: "companies" }, "users.department_id", "department.id"),
+      requested: "Requested: JOIN companies AS department ON users.department_id = department.id",
+    },
+    {
+      name: "JOIN 타입",
+      create: () =>
+        usersQuery()
+          .join({ department: "departments" }, "users.department_id", "department.id")
+          .ensureLeftJoin({ department: "departments" }, "users.department_id", "department.id"),
+      requested:
+        "Requested: LEFT JOIN departments AS department ON users.department_id = department.id",
+    },
+    {
+      name: "왼쪽 조건",
+      create: () =>
+        usersQuery()
+          .join({ department: "departments" }, "users.department_id", "department.id")
+          .ensureJoin({ department: "departments" }, "users.id", "department.id"),
+      requested: "Requested: JOIN departments AS department ON users.id = department.id",
+    },
+    {
+      name: "오른쪽 조건",
+      create: () =>
+        usersQuery()
+          .join({ department: "departments" }, "users.department_id", "department.id")
+          .ensureJoin({ department: "departments" }, "users.department_id", "department.name"),
+      requested:
+        "Requested: JOIN departments AS department ON users.department_id = department.name",
+    },
+  ])("같은 alias의 $name 정의가 다르면 실행 전에 오류를 던진다", ({ create, requested }) => {
+    expect(create).toThrowError(
+      'Join alias "department" is already registered with a different definition.',
+    );
+    expect(create).toThrowError(requested);
+  });
+
+  it("일반 JOIN은 같은 alias를 중복 등록할 수 없다", () => {
+    const query = usersQuery().join(
+      { department: "departments" },
+      "users.department_id",
+      "department.id",
+    );
+
+    expect(() =>
+      query.join({ department: "departments" }, "users.department_id", "department.id"),
+    ).toThrowError(/Join alias "department" is already registered/);
+  });
+
+  it("같은 테이블을 서로 다른 alias로 JOIN할 수 있다", () => {
+    const query = usersQuery()
+      .ensureJoin(
+        { primary_department: "departments" },
+        "users.department_id",
+        "primary_department.id",
+      )
+      .ensureJoin({ fallback_department: "departments" }, "users.id", "fallback_department.id");
+
+    expect(query.toQuery()).toContain('join "departments" as "primary_department"');
+    expect(query.toQuery()).toContain('join "departments" as "fallback_department"');
+  });
+
+  it("기존의 동일한 LEFT JOIN을 재사용한다", () => {
+    const query = usersQuery()
+      .leftJoin({ department: "departments" }, "users.department_id", "department.id")
+      .ensureLeftJoin({ department: "departments" }, "users.department_id", "department.id");
+
+    expect(query.toQuery().match(/left join "departments" as "department"/g)).toHaveLength(1);
+  });
+
+  it("callback JOIN은 동일성을 추론하지 않는다", () => {
+    const query = usersQuery().join({ department: "departments" }, (join) => {
+      join.on("users.department_id", "department.id");
+    });
+
+    expect(() =>
+      query.ensureJoin({ department: "departments" }, "users.department_id", "department.id"),
+    ).toThrowError(/Existing: JOIN departments AS department with opaque condition/);
+  });
+
+  it("clone은 JOIN registry를 독립적으로 복제한다", () => {
+    const original = usersQuery().ensureJoin(
+      { department: "departments" },
+      "users.department_id",
+      "department.id",
+    );
+    const cloned = original
+      .clone()
+      .ensureJoin({ department: "departments" }, "users.department_id", "department.id")
+      .ensureJoin({ fallback: "departments" }, "users.id", "fallback.id");
+
+    expect(original.toQuery()).not.toContain('as "fallback"');
+    expect(cloned.toQuery()).toContain('as "fallback"');
+    expect(cloned.toQuery().match(/join "departments" as "department"/g)).toHaveLength(1);
+  });
+
+  it("JOIN을 clear한 뒤 같은 alias를 다시 등록할 수 있다", () => {
+    const query = usersQuery()
+      .ensureJoin({ department: "departments" }, "users.department_id", "department.id")
+      .clear("join")
+      .ensureJoin({ department: "departments" }, "users.department_id", "department.id");
+
+    expect(query.toQuery().match(/join "departments" as "department"/g)).toHaveLength(1);
+  });
+
+  it("clearJoin으로 삭제한 alias를 다시 등록할 수 있다", () => {
+    const query = usersQuery()
+      .ensureJoin({ department: "departments" }, "users.department_id", "department.id")
+      .clearJoin("department")
+      .ensureJoin({ department: "departments" }, "users.department_id", "department.id");
+
+    expect(query.toQuery().match(/join "departments" as "department"/g)).toHaveLength(1);
+  });
+
+  it("clearJoin은 subquery JOIN의 registry도 함께 제거한다", () => {
+    const departmentIds = new Puri<
+      TestSchema,
+      { departments: TestSchema["departments"] },
+      TestSchema["departments"]
+    >(db, "departments").select({ id: "departments.id" });
+    const query = usersQuery()
+      .join({ department: departmentIds }, "users.department_id", "department.id")
+      .clearJoin("department")
+      .ensureJoin({ department: "departments" }, "users.department_id", "department.id");
+
+    expect(query.toQuery()).not.toContain('select "id" from "departments"');
+    expect(query.toQuery().match(/join "departments" as "department"/g)).toHaveLength(1);
   });
 });

--- a/modules/sonamu/src/database/puri.ts
+++ b/modules/sonamu/src/database/puri.ts
@@ -61,6 +61,24 @@ type PuriOrderByRuntimeItem = {
 };
 type PuriOrderByRuntimeEntry = string | PuriOrderByExpression | PuriOrderByRuntimeItem;
 
+type FromRegistration = {
+  kind: "from";
+  alias: string;
+  table: string | null;
+};
+
+type JoinRegistration = {
+  kind: "join";
+  alias: string;
+  table: string | null;
+  joinType: "join" | "leftJoin";
+  left: string | null;
+  right: string | null;
+  reusable: boolean;
+};
+
+type CorrelationRegistration = FromRegistration | JoinRegistration;
+
 function normalizeFuzzyOperator(operator?: string): FuzzyOperator {
   const normalized = operator?.trim() ?? "<%";
   const fuzzyOperator = FUZZY_OPERATORS.find((candidate) => candidate === normalized);
@@ -123,6 +141,7 @@ function isSqlExpression(value: PuriOrderByRuntimeEntry): value is PuriOrderByEx
 export class Puri<TSchema, TTables extends Record<string, any>, TResult> {
   private knexQuery: Knex.QueryBuilder;
   private tableSpec: TableSpec | null = null;
+  private correlationRegistry = new Map<string, CorrelationRegistration>();
 
   // 생성자 시그니처들
   constructor(knex: Knex, tableName: string);
@@ -135,6 +154,11 @@ export class Puri<TSchema, TTables extends Record<string, any>, TResult> {
       // Case: new Puri(knex, "users")
       this.knexQuery = this.knex(tableNameOrSource).from(tableNameOrSource);
       this.tableSpec = this.safeGetTableSpec(tableNameOrSource);
+      this.correlationRegistry.set(tableNameOrSource, {
+        kind: "from",
+        alias: tableNameOrSource,
+        table: tableNameOrSource,
+      });
     } else if (typeof tableNameOrSource === "object") {
       const entries = Object.entries(tableNameOrSource);
       if (entries.length !== 1) {
@@ -145,9 +169,11 @@ export class Puri<TSchema, TTables extends Record<string, any>, TResult> {
       if (typeof source === "string") {
         this.knexQuery = this.knex(source).from({ [alias]: source });
         this.tableSpec = this.safeGetTableSpec(source);
+        this.correlationRegistry.set(alias, { kind: "from", alias, table: source });
       } else if (source instanceof Puri) {
         const subqueryBuilder = source.rawQuery();
         this.knexQuery = this.knex.from(subqueryBuilder.as(alias));
+        this.correlationRegistry.set(alias, { kind: "from", alias, table: null });
       } else {
         throw new Error("Invalid table specification");
       }
@@ -559,19 +585,27 @@ export class Puri<TSchema, TTables extends Record<string, any>, TResult> {
   // CLEAR
   clear(statement: ClearStatements): this {
     this.knexQuery.clear(statement);
+    if (statement === "join") {
+      this.clearJoinRegistrations();
+    }
     return this;
   }
 
   // knex에 없어서 직접 구현함
   clearJoin(alias: string): this {
+    let removed = false;
     (this.knexQuery as any)._statements = (this.knexQuery as any)._statements.filter((s: any) => {
       if ("joinType" in s) {
-        const [_alias, _table] = Object.entries(s.table)[0];
-        return _alias !== alias;
+        const shouldRemove = this.getKnexJoinAlias(s.table) === alias;
+        removed ||= shouldRemove;
+        return !shouldRemove;
       } else {
         return true;
       }
     });
+    if (removed && this.correlationRegistry.get(alias)?.kind === "join") {
+      this.correlationRegistry.delete(alias);
+    }
     return this;
   }
 
@@ -625,6 +659,22 @@ export class Puri<TSchema, TTables extends Record<string, any>, TResult> {
     return this.__commonJoin("join", tableNameOrSpec, ...args);
   }
 
+  // ENSURE JOIN: 테이블 + Alias
+  ensureJoin<TJoinTable extends keyof TSchema, TJoinAlias extends string>(
+    tableSpec: { [K in TJoinAlias]: TJoinTable },
+    left: AvailableColumns<TTables>,
+    right: `${TJoinAlias}.${ColumnKeys<TSchema[TJoinTable]>}`,
+  ): Puri<TSchema, TTables & Record<TJoinAlias, TSchema[TJoinTable]>, TResult>;
+  // ENSURE JOIN: 테이블명
+  ensureJoin<TJoinTable extends keyof TSchema>(
+    tableName: TJoinTable,
+    left: AvailableColumns<TTables>,
+    right: `${TJoinTable & string}.${ColumnKeys<TSchema[TJoinTable]>}`,
+  ): Puri<TSchema, TTables & Record<TJoinTable, TSchema[TJoinTable]>, TResult>;
+  ensureJoin(tableNameOrSpec: any, left: string, right: string): any {
+    return this.__ensureJoin("join", tableNameOrSpec, left, right);
+  }
+
   // LEFT JOIN: 서브쿼리 + Alias
   leftJoin<TJoinAlias extends string, TSubResult>(
     tableSpec: { [K in TJoinAlias]: Puri<TSchema, any, TSubResult> },
@@ -676,7 +726,38 @@ export class Puri<TSchema, TTables extends Record<string, any>, TResult> {
     return this.__commonJoin("leftJoin", tableNameOrSpec, ...args);
   }
 
+  // ENSURE LEFT JOIN: 테이블 + Alias
+  ensureLeftJoin<
+    TJoinTable extends keyof TSchema,
+    TJoinAlias extends string,
+    TLeft extends AvailableColumns<TTables>,
+  >(
+    tableSpec: { [K in TJoinAlias]: TJoinTable },
+    left: TLeft,
+    right: `${TJoinAlias}.${ColumnKeys<TSchema[TJoinTable]>}`,
+  ): Puri<
+    TSchema,
+    TTables & Record<TJoinAlias, TSchema[TJoinTable] & LeftJoinMarkerFor<TTables, TLeft>>,
+    TResult
+  >;
+  // ENSURE LEFT JOIN: 테이블명
+  ensureLeftJoin<TJoinTable extends keyof TSchema, TLeft extends AvailableColumns<TTables>>(
+    tableName: TJoinTable,
+    left: TLeft,
+    right: `${TJoinTable & string}.${ColumnKeys<TSchema[TJoinTable]>}`,
+  ): Puri<
+    TSchema,
+    TTables & Record<TJoinTable, TSchema[TJoinTable] & LeftJoinMarkerFor<TTables, TLeft>>,
+    TResult
+  >;
+  ensureLeftJoin(tableNameOrSpec: any, left: string, right: string): any {
+    return this.__ensureJoin("leftJoin", tableNameOrSpec, left, right);
+  }
+
   __commonJoin(joinType: "join" | "leftJoin", tableNameOrSpec: any, ...args: any[]): this {
+    const registration = this.createJoinRegistration(joinType, tableNameOrSpec, args);
+    this.assertCorrelationAvailable(registration);
+
     if (typeof tableNameOrSpec === "string") {
       // Case 1: join("posts", ...)
       const tableName = tableNameOrSpec;
@@ -734,7 +815,152 @@ export class Puri<TSchema, TTables extends Record<string, any>, TResult> {
       throw new Error("Invalid arguments");
     }
 
+    this.correlationRegistry.set(registration.alias, registration);
     return this;
+  }
+
+  private __ensureJoin(
+    joinType: "join" | "leftJoin",
+    tableNameOrSpec: string | Record<string, string>,
+    left: string,
+    right: string,
+  ): this {
+    const requested = this.createJoinRegistration(joinType, tableNameOrSpec, [left, right]);
+    if (!requested.reusable) {
+      throw new Error(
+        `${joinType === "join" ? "ensureJoin" : "ensureLeftJoin"} only supports physical tables with simple column equality conditions.`,
+      );
+    }
+    const existing = this.correlationRegistry.get(requested.alias);
+
+    if (!existing) {
+      return this.__commonJoin(joinType, tableNameOrSpec, left, right);
+    }
+
+    if (this.isSameJoinRegistration(existing, requested)) {
+      return this;
+    }
+
+    throw this.createJoinConflictError(existing, requested);
+  }
+
+  private createJoinRegistration(
+    joinType: "join" | "leftJoin",
+    tableNameOrSpec: any,
+    args: any[],
+  ): JoinRegistration {
+    let alias: string;
+    let table: string | null;
+
+    if (typeof tableNameOrSpec === "string") {
+      alias = tableNameOrSpec;
+      table = tableNameOrSpec;
+    } else if (typeof tableNameOrSpec === "object") {
+      const entries = Object.entries(tableNameOrSpec);
+      if (entries.length !== 1) {
+        throw new Error("Table spec must have exactly one entry");
+      }
+      assert(entries[0]);
+      const [[joinAlias, spec]] = entries;
+      alias = joinAlias;
+      table = typeof spec === "string" ? spec : null;
+    } else {
+      throw new Error("Invalid arguments");
+    }
+
+    const [left, right] = args;
+    const reusable =
+      table !== null && args.length === 2 && typeof left === "string" && typeof right === "string";
+
+    return {
+      kind: "join",
+      alias,
+      table,
+      joinType,
+      left: reusable ? left : null,
+      right: reusable ? right : null,
+      reusable,
+    };
+  }
+
+  private assertCorrelationAvailable(requested: JoinRegistration): void {
+    const existing = this.correlationRegistry.get(requested.alias);
+    if (existing) {
+      if (this.isSameJoinRegistration(existing, requested)) {
+        throw new Error(
+          `Join alias "${requested.alias}" is already registered. Use ensureJoin() or ensureLeftJoin() to reuse an identical join.`,
+        );
+      }
+      throw this.createJoinConflictError(existing, requested);
+    }
+  }
+
+  private isSameJoinRegistration(
+    existing: CorrelationRegistration,
+    requested: JoinRegistration,
+  ): existing is JoinRegistration {
+    return (
+      existing.kind === "join" &&
+      existing.reusable &&
+      requested.reusable &&
+      existing.table === requested.table &&
+      existing.joinType === requested.joinType &&
+      existing.left === requested.left &&
+      existing.right === requested.right
+    );
+  }
+
+  private createJoinConflictError(
+    existing: CorrelationRegistration,
+    requested: JoinRegistration,
+  ): Error {
+    return new Error(
+      [
+        `Join alias "${requested.alias}" is already registered with a different definition.`,
+        `Existing: ${this.formatCorrelationRegistration(existing)}`,
+        `Requested: ${this.formatCorrelationRegistration(requested)}`,
+      ].join("\n"),
+    );
+  }
+
+  private formatCorrelationRegistration(registration: CorrelationRegistration): string {
+    if (registration.kind === "from") {
+      return `FROM ${registration.table ?? "subquery"} AS ${registration.alias}`;
+    }
+
+    const joinKeyword = registration.joinType === "join" ? "JOIN" : "LEFT JOIN";
+    const source = registration.table ?? "opaque source";
+    const condition = registration.reusable
+      ? ` ON ${registration.left} = ${registration.right}`
+      : " with opaque condition";
+    return `${joinKeyword} ${source} AS ${registration.alias}${condition}`;
+  }
+
+  private clearJoinRegistrations(): void {
+    for (const [alias, registration] of this.correlationRegistry) {
+      if (registration.kind === "join") {
+        this.correlationRegistry.delete(alias);
+      }
+    }
+  }
+
+  private getKnexJoinAlias(table: unknown): string | null {
+    if (typeof table === "string") {
+      return table;
+    }
+    if (typeof table === "object" && table !== null) {
+      if (
+        "_single" in table &&
+        typeof table._single === "object" &&
+        table._single !== null &&
+        "as" in table._single &&
+        typeof table._single.as === "string"
+      ) {
+        return table._single.as;
+      }
+      return Object.keys(table)[0] ?? null;
+    }
+    return null;
   }
 
   // WHERE: 객체 - 사용: .where({ "u.id": 1, "u.status": "active" })
@@ -1278,6 +1504,7 @@ export class Puri<TSchema, TTables extends Record<string, any>, TResult> {
     // 'dual'은 더미 테이블이며, 바로 아래 줄에서 knexQuery가 덮어씌워집니다.
     const newPuri = new Puri<TSchema, TTables, TResult>(this.knex, "dual");
     newPuri.knexQuery = this.knexQuery.clone();
+    newPuri.correlationRegistry = new Map(this.correlationRegistry);
     return newPuri;
   }
 

--- a/modules/sonamu/src/database/puri.types.test-d.ts
+++ b/modules/sonamu/src/database/puri.types.test-d.ts
@@ -661,3 +661,59 @@ describe("Puri orderBy methods", () => {
     query.orderBy(["name", "missing_column"]);
   });
 });
+
+describe("Puri ensureJoin methods", () => {
+  it("ensureJoin 이후 alias 컬럼을 타입 안전하게 사용할 수 있다", () => {
+    type Query = Puri<MockSchema, { users: MockSchema["users"] }, MockSchema["users"]>;
+    const query = {} as Query;
+
+    const joined = query.ensureJoin(
+      { department: "departments" },
+      "users.department_id",
+      "department.id",
+    );
+
+    expectTypeOf(joined.where("department.name", "개발팀")).toEqualTypeOf(joined);
+
+    // @ts-expect-error JOIN한 테이블에 없는 컬럼은 사용할 수 없다.
+    joined.where("department.email", "dev@example.com");
+  });
+
+  it("ensureLeftJoin은 nullable FK의 객체 타입을 유지한다", () => {
+    type Query = Puri<MockSchema, { users: MockSchema["users"] }, MockSchema["users"]>;
+    const query = {} as Query;
+
+    const result = query
+      .ensureLeftJoin({ department: "departments" }, "users.department_id", "department.id")
+      .select({ department: { id: "department.id" } })
+      .first();
+
+    expectTypeOf(result).resolves.toEqualTypeOf<{
+      department: { id: number } | null;
+    }>();
+  });
+
+  it("ensureLeftJoin은 non-null FK의 객체를 non-null로 추론한다", () => {
+    type Query = Puri<MockSchema, { employees: MockSchema["employees"] }, MockSchema["employees"]>;
+    const query = {} as Query;
+
+    const result = query
+      .ensureLeftJoin({ user: "users" }, "employees.user_id", "user.id")
+      .select({ user: { id: "user.id" } })
+      .first();
+
+    expectTypeOf(result).resolves.toEqualTypeOf<{
+      user: { id: number };
+    }>();
+  });
+
+  it("ensureJoin은 callback 형식을 허용하지 않는다", () => {
+    type Query = Puri<MockSchema, { users: MockSchema["users"] }, MockSchema["users"]>;
+    const query = {} as Query;
+
+    // @ts-expect-error callback JOIN은 동일성을 판정할 수 없으므로 지원하지 않는다.
+    query.ensureJoin({ department: "departments" }, (join) => {
+      join.on("users.department_id", "department.id");
+    });
+  });
+});

--- a/modules/sonamu/src/skills/sonamu/puri.md
+++ b/modules/sonamu/src/skills/sonamu/puri.md
@@ -231,6 +231,36 @@ db.table("orders")
   .select({ id: "orders.id", total: "oi.total" });
 ```
 
+### Reusing generated JOINs
+
+Use `ensureJoin()` or `ensureLeftJoin()` when a Model adds a JOIN that may already have been added
+by a Subset query.
+
+```typescript
+db.table("patient_timeline_events")
+  .ensureJoin(
+    { patient: "patients" },
+    "patient_timeline_events.patient_id",
+    "patient.id",
+  )
+  .where("patient.organization_id", organizationId);
+```
+
+Puri compares JOINs by alias. If the alias, table, JOIN type, left column, and right column all
+match, the existing JOIN is reused. If the alias is new, the JOIN is added. Reusing an alias with a
+different definition throws an error before SQL execution.
+
+Different aliases for the same physical table remain valid:
+
+```typescript
+db.table("documents")
+  .ensureJoin({ created_by: "users" }, "documents.created_by_id", "created_by.id")
+  .ensureJoin({ updated_by: "users" }, "documents.updated_by_id", "updated_by.id");
+```
+
+`ensureJoin()` and `ensureLeftJoin()` support table equality JOINs only. Callback and subquery JOINs
+continue to use `join()` or `leftJoin()` and are not considered reusable.
+
 ## ORDER BY & LIMIT
 
 ```typescript


### PR DESCRIPTION
## 배경

서브셋 쿼리가 자동 생성하는 JOIN과 모델 코드에서 추가하는 JOIN이 겹칠 수 있습니다.
지금까지는 같은 relation을 여러 alias로 중복 JOIN하거나, 중복을 피하려고 JOIN 여부를 직접 관리해야 했습니다.
이를 해결하기 위해 동일한 JOIN이면 재사용하고, 없으면 추가하는 `ensureJoin()` / `ensureLeftJoin()`을 추가합니다.

## 동작 방식

- alias가 미등록: 새 JOIN을 추가하고 registry에 등록
- alias가 등록됨 + 정의 동일 (테이블, JOIN 타입, 왼쪽/오른쪽 컬럼 모두 일치): 기존 JOIN 재사용 (no-op)
- alias가 등록됨 + 정의 다름: SQL 실행 전에 즉시 에러. 메시지에 기존 정의와 요청 정의를 포맷해서 표시 (Existing: JOIN ... / Requested: JOIN ...)

```
Error: Join alias "company" is already registered with a different definition.
Existing: JOIN companies AS company ON departments.company_id = company.id
Requested: LEFT JOIN companies AS company ON departments.company_id = company.id
```

## 예시

```
if (params.company_name) {
    qb.ensureJoin({ company: "companies" }, "departments.company_id", "company.id").where(
        "company.name",
        params.company_name,
    );
}
```