### PR TITLE
fix(migration): 생성 코드의 Knex import를 type-only로

### DIFF
--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/migration/code-generation.ts
+++ b/modules/sonamu/src/migration/code-generation.ts
@@ -757,7 +757,7 @@ async function generateCreateCode_ColumnAndIndexes(
 
   // 컬럼, 인덱스 처리
   const lines: string[] = [
-    'import { Knex } from "knex";',
+    'import type { Knex } from "knex";',
     "",
     "export async function up(knex: Knex): Promise<void> {",
     ...helperDefinitions,
@@ -1083,7 +1083,7 @@ async function generateCreateCode_Foreign(
   }
 
   const lines: string[] = [
-    'import { Knex } from "knex";',
+    'import type { Knex } from "knex";',
     "",
     "export async function up(knex: Knex): Promise<void> {",
     `return knex.schema.alterTable("${table}", (table) => {`,
@@ -1304,7 +1304,7 @@ async function generateAlterCode_ColumnAndIndexes(
   ];
 
   const lines: string[] = [
-    'import { Knex } from "knex";',
+    'import type { Knex } from "knex";',
     "",
     "export async function up(knex: Knex): Promise<void> {",
     ...(upBuilderLines.length > 0
@@ -1776,7 +1776,7 @@ async function generateAlterCode_Foreigns(
   }
 
   const lines: string[] = [
-    'import { Knex } from "knex";',
+    'import type { Knex } from "knex";',
     "",
     "export async function up(knex: Knex): Promise<void> {",
     `return knex.schema.alterTable("${table}", (table) => {`,
@@ -2104,7 +2104,7 @@ async function generatePkTypeChangeMigration(
   }
 
   const lines: string[] = [
-    'import { Knex } from "knex";',
+    'import type { Knex } from "knex";',
     "",
     "export async function up(knex: Knex): Promise<void> {",
     ...upLines,


### PR DESCRIPTION
## 문제

`sonamu migrate generate`가 만드는 마이그레이션 첫 줄이 `import { Knex } from "knex"`(값 import)였다. knex는 CJS라 ESM 런타임에서 죽는다:

```
SyntaxError: Named export 'Knex' not found. The requested module 'knex' is a
CommonJS module, which may not support all module.exports as named exports.
```

`Knex`는 `up(knex: Knex)` 타입으로만 쓰이므로 값 import할 이유가 없다.

## 변경

- `src/migration/code-generation.ts`의 생성 코드 리터럴 **5곳**(create/alter/FK/PK 타입변경 등)을 `import type { Knex } from "knex"`로 교체
- `verbatimModuleSyntax`/`isolatedModules` 환경에서도 안전
- `package.json`: `0.10.5` → `0.10.6`

## 왜 지금까지 안 드러났나

이미 적용된 마이그레이션은 재로드되지 않는다. `knex_migrations` 기록이 없는 **새 DB에서 처음부터 migrate run**을 돌릴 때만 첫 파일에서 멈춘다.

## 검증 (miomock)

임시 nullable 컬럼 추가 → `migrate generate` → 생성물 첫 줄이 type-only import(`import { type Knex }`, oxfmt 정규화형)로 확인. 검증 산출물은 원복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)