### PR TITLE
fix(migration): Knex 스냅샷 갱신 + DB 연결 실패 fast-fail/노출

### DIFF
--- a/examples/miomock/api/src/sonamu-test/__snapshots__/migrator.preparedCodes.test.ts.snap
+++ b/examples/miomock/api/src/sonamu-test/__snapshots__/migrator.preparedCodes.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Migrator - preparedCodes 생성 > FK 변경 감지 (onUpdate/onDelete) 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable("users", (table) => {
@@ -24,7 +24,7 @@ export async function down(knex: Knex): Promise<void> {
     "type": "normal",
   },
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.alterTable("users", (table) => {
@@ -52,7 +52,7 @@ export async function down(knex: Knex): Promise<void> {
 exports[`Migrator - preparedCodes 생성 > FK 삭제 감지 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable("users", (table) => {
@@ -73,7 +73,7 @@ export async function down(knex: Knex): Promise<void> {
     "type": "normal",
   },
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.alterTable("users", (table) => {
@@ -97,7 +97,7 @@ export async function down(knex: Knex): Promise<void> {
 exports[`Migrator - preparedCodes 생성 > FK 추가 감지 (BelongsToOne) 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable("users", (table) => {
@@ -118,7 +118,7 @@ export async function down(knex: Knex): Promise<void> {
     "type": "normal",
   },
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.alterTable("users", (table) => {
@@ -144,7 +144,7 @@ exports[`Migrator - preparedCodes 생성 > FK 추가 감지 (HasMany) 1`] = `[]`
 exports[`Migrator - preparedCodes 생성 > FK 추가 감지 (ManyToMany) 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable("labels", (table) => {
@@ -162,7 +162,7 @@ export async function down(knex: Knex): Promise<void> {
     "type": "normal",
   },
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable("users__labels", (table) => {
@@ -181,7 +181,7 @@ export async function down(knex: Knex): Promise<void> {
     "type": "normal",
   },
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.alterTable("users__labels", (table) => {
@@ -209,7 +209,7 @@ export async function down(knex: Knex): Promise<void> {
 exports[`Migrator - preparedCodes 생성 > FK 추가 감지 (OneToOne) 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable("users", (table) => {
@@ -230,7 +230,7 @@ export async function down(knex: Knex): Promise<void> {
     "type": "normal",
   },
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.alterTable("users", (table) => {
@@ -258,7 +258,7 @@ export async function down(knex: Knex): Promise<void> {
 exports[`Migrator - preparedCodes 생성 > 신규 엔티티 감지 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable("test_entities", (table) => {
@@ -286,7 +286,7 @@ export async function down(knex: Knex): Promise<void> {
 exports[`Migrator - preparedCodes 생성 > 인덱스 삭제 감지 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable("users", (table) => {
@@ -310,7 +310,7 @@ export async function down(knex: Knex): Promise<void> {
 exports[`Migrator - preparedCodes 생성 > 컬럼 삭제 감지 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable("users", (table) => {
@@ -336,7 +336,7 @@ export async function down(knex: Knex): Promise<void> {
 exports[`Migrator - preparedCodes 생성 > 컬럼 속성 변경 감지 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable("users", (table) => {
@@ -362,7 +362,7 @@ export async function down(knex: Knex): Promise<void> {
 exports[`Migrator - preparedCodes 생성 > 컬럼 이름 변경 감지 (Drop & Add) 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable("users", (table) => {
@@ -392,7 +392,7 @@ export async function down(knex: Knex): Promise<void> {
 exports[`Migrator - preparedCodes 생성 > 컬럼 추가 감지 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable("users", (table) => {
@@ -419,7 +419,7 @@ export async function down(knex: Knex): Promise<void> {
 exports[`Migrator - preparedCodes 생성 > 코드 정렬 순서 1`] = `
 [
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable("test_order_entities", (table) => {
@@ -442,7 +442,7 @@ export async function down(knex: Knex): Promise<void> {
     "type": "normal",
   },
   {
-    "formatted": "import { Knex } from "knex";
+    "formatted": "import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.alterTable("test_order_entities", (table) => {

--- a/examples/miomock/api/src/sonamu-test/migrator.preparedCodes.test.ts
+++ b/examples/miomock/api/src/sonamu-test/migrator.preparedCodes.test.ts
@@ -172,7 +172,7 @@ describe("Migrator - preparedCodes 생성", () => {
     expect(alterCode).toBeDefined();
     expect(alterCode?.formatted).toMatchInlineSnapshot(
       `
-      "import { Knex } from "knex";
+      "import type { Knex } from "knex";
 
       export async function up(knex: Knex): Promise<void> {
         await knex.raw(
@@ -257,7 +257,7 @@ describe("Migrator - preparedCodes 생성", () => {
     expect(alterCode).toBeDefined();
     expect(alterCode?.formatted).toMatchInlineSnapshot(
       `
-      "import { Knex } from "knex";
+      "import type { Knex } from "knex";
 
       export async function up(knex: Knex): Promise<void> {
         await knex.raw(\`CREATE INDEX users_bio_index ON users USING gist(bio);\`);
@@ -301,7 +301,7 @@ describe("Migrator - preparedCodes 생성", () => {
     expect(alterCode).toBeDefined();
     expect(alterCode?.formatted).toMatchInlineSnapshot(
       `
-      "import { Knex } from "knex";
+      "import type { Knex } from "knex";
 
       export async function up(knex: Knex): Promise<void> {
         await knex.raw(
@@ -337,7 +337,7 @@ describe("Migrator - preparedCodes 생성", () => {
     expect(alterCode).toBeDefined();
     expect(alterCode?.formatted).toMatchInlineSnapshot(
       `
-      "import { Knex } from "knex";
+      "import type { Knex } from "knex";
 
       export async function up(knex: Knex): Promise<void> {
         await knex.raw(
@@ -374,7 +374,7 @@ describe("Migrator - preparedCodes 생성", () => {
     expect(alterCode).toBeDefined();
     expect(alterCode?.formatted).toMatchInlineSnapshot(
       `
-      "import { Knex } from "knex";
+      "import type { Knex } from "knex";
 
       export async function up(knex: Knex): Promise<void> {
         await knex.raw(
@@ -413,7 +413,7 @@ describe("Migrator - preparedCodes 생성", () => {
     expect(alterCode).toBeDefined();
     expect(alterCode?.formatted).toMatchInlineSnapshot(
       `
-      "import { Knex } from "knex";
+      "import type { Knex } from "knex";
 
       export async function up(knex: Knex): Promise<void> {
         await knex.raw(

--- a/modules/sonamu/src/database/knex.ts
+++ b/modules/sonamu/src/database/knex.ts
@@ -12,14 +12,17 @@ export function createKnexInstance(config: Knex.Config): Knex {
   }
 
   config.pool = {
+    // 아래는 기본값이며, 호출측이 config.pool로 덮어쓸 수 있다.
+    // (예: 마이그레이션 상태 조회는 fail-fast를 위해 짧은 타임아웃 + propagateCreateError를 지정)
     maxConnectionLifetimeMillis: 1800000,
     maxConnectionLifetimeJitterMillis: 300000,
-    ...config.pool,
     propagateCreateError: false,
     idleTimeoutMillis: 10000,
     reapIntervalMillis: 1000,
     acquireTimeoutMillis: 30000,
     createTimeoutMillis: 30000,
+    ...config.pool,
+    // validate/afterCreate는 항상 프레임워크 기본값을 사용한다.
     validate: (connection: unknown) => {
       if (typeof connection !== "object" || connection === null) return false;
       const conn = connection as Record<string, unknown>;

--- a/modules/sonamu/src/migration/migrator.ts
+++ b/modules/sonamu/src/migration/migrator.ts
@@ -29,6 +29,31 @@ export type MigrationResult = {
   applied: string[];
 }[];
 
+// 마이그레이션 상태 조회 시 DB 연결 확인 타임아웃(ms).
+// createKnexInstance의 커넥션 획득 타임아웃(30초)에 status/list/currentVersion이
+// 각각 걸리면 CLI/UI가 최대 수십 초 hang한다. 정상 응답은 수백 ms이므로 5초면 충분하다.
+const MIGRATION_CONN_TIMEOUT_MS = 5000;
+
+/**
+ * 주어진 Promise가 ms 안에 완료되지 않으면 onTimeout 에러로 reject한다.
+ * 원본 Promise 자체는 계속 진행되므로, 호출측에서 커넥션 정리(destroy)를 책임진다.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, onTimeout: () => Error): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(onTimeout()), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
 export class Migrator {
   private isMissingMigrationTableError(error: unknown): boolean {
     if (typeof error !== "object" || error === null) {
@@ -117,9 +142,57 @@ export class Migrator {
     const statuses = await Promise.all(
       connKeys.map(async (connKey) => {
         const knexOptions = Sonamu.dbConfig[connKey];
-        const tConn = createKnexInstance(knexOptions);
+        const connection = knexOptions.connection as Knex.PgConnectionConfig;
+        // 상태 조회용 커넥션은 fail-fast로 만든다: 불통 DB에서 커넥션 획득을 무한정
+        // 재시도하며 CLI 프로세스가 종료되지 않는 것을 막는다.
+        // - connectionTimeoutMillis: 소켓 연결 자체를 5초 안에 포기 → 소켓이 정리되어 프로세스가 종료됨
+        // - propagateCreateError: 첫 연결 실패를 즉시 전파(풀 재시도 없이 바로 실패)
+        const tConn = createKnexInstance({
+          ...knexOptions,
+          connection: {
+            ...(connection as Record<string, unknown>),
+            connectionTimeoutMillis: MIGRATION_CONN_TIMEOUT_MS,
+          },
+          pool: {
+            ...knexOptions.pool,
+            min: 0,
+            acquireTimeoutMillis: MIGRATION_CONN_TIMEOUT_MS,
+            createTimeoutMillis: MIGRATION_CONN_TIMEOUT_MS,
+            propagateCreateError: true,
+          },
+        });
+        const connString =
+          `pg://${connection.user ?? ""}@${connection.host}:${connection.port}/${connection.database}` as ConnString;
 
         try {
+          // DB 연결 확인: 불통 DB에서 status/list/currentVersion이 커넥션 획득
+          // 타임아웃까지 hang하는 것을 막기 위해, 먼저 5초 안에 응답하는지 확인한다.
+          try {
+            await withTimeout(
+              tConn.raw("select 1"),
+              MIGRATION_CONN_TIMEOUT_MS,
+              () =>
+                new Error(
+                  `DB 연결 시간 초과 (${MIGRATION_CONN_TIMEOUT_MS}ms) — ${connection.host}:${connection.port}/${connection.database}`,
+                ),
+            );
+          } catch (err) {
+            console.warn(
+              chalk.yellow(
+                `${connKey}의 마이그레이션 상태를 가져오는 데에 실패하였습니다. 데이터베이스에 연결할 수 없습니다.\n시도한 연결 설정:\n${JSON.stringify(knexOptions.connection, null, 2)}\n발생한 에러:\n${err}\n`,
+              ),
+            );
+            migrationStatusError = err instanceof Error ? err.message : String(err);
+            return {
+              name: connKey,
+              connKey,
+              connString,
+              currentVersion: "error" as const,
+              status: "error" as const,
+              pending: [] as string[],
+            };
+          }
+
           const status: number | "error" = await (async () => {
             try {
               return await tConn.migrate.status();
@@ -164,20 +237,21 @@ export class Migrator {
           })();
           Naite.t("migrator:getStatus:status", status);
 
-          const connection = knexOptions.connection as Knex.PgConnectionConfig;
-
           return {
             name: connKey,
             connKey,
-            connString: `pg://${connection.user ?? ""}@${connection.host}:${
-              connection.port
-            }/${connection.database}` as ConnString,
+            connString,
             currentVersion,
             status: status,
             pending,
           };
         } finally {
-          await tConn.destroy();
+          // 불통 DB의 커넥션 정리가 커넥션 획득 타임아웃까지 hang하지 않도록 감싼다.
+          await withTimeout(
+            tConn.destroy(),
+            MIGRATION_CONN_TIMEOUT_MS,
+            () => new Error("connection destroy timeout"),
+          ).catch(() => {});
         }
       }),
     );

--- a/modules/sonamu/ui-web/src/routes/migrations.tsx
+++ b/modules/sonamu/ui-web/src/routes/migrations.tsx
@@ -306,10 +306,16 @@ function MigrationsIndex(_props: MigrationsIndexProps) {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {conns.some((conn) => conn.status === "error" || !!migrationStatusError) && (
+                {(conns.some((conn) => conn.status === "error") || !!migrationStatusError) && (
                   <TableRow>
                     <TableCell colSpan={6}>
-                      <b>{SD("migration.error.connections")}</b>
+                      <b className="text-destructive">{SD("migration.error.connections")}</b>
+                      {/* 실제 연결 실패 원인(대상 DB·에러 메시지)을 노출해 진단을 돕는다. */}
+                      {migrationStatusError && (
+                        <pre className="mt-1 text-xs text-destructive whitespace-pre-wrap break-all">
+                          {migrationStatusError}
+                        </pre>
+                      )}
                     </TableCell>
                   </TableRow>
                 )}


### PR DESCRIPTION
0.10.6에 묶어서 배포되는 마이그레이션 관련 두 건. (0.10.6은 #222 배포가 스냅샷 CI 실패로 스킵되어 npm 미게시 → 이 PR로 함께 게시)

## 1. Knex type-only import 스냅샷 갱신 (CI 실패 해소)

#222에서 생성 코드가 `import type { Knex }`로 바뀌며 `migrator.preparedCodes` 스냅샷 19곳이 mismatch → 단위테스트 실패로 배포 스킵됐다. 생성물 첫 줄 import만 달라진 것으로 스냅샷을 갱신(다른 변경 없음).

## 2. DB 연결 실패 시 hang → fast-fail + 원인 노출

마이그레이션 상태 조회 시 DB가 응답하지 않으면 커넥션 획득이 무한 재시도되어, **CLI(에이전트 실행 포함)는 프로세스가 멈추고**, **UI 마이그레이션 탭은 로딩만 무한**히 돌며 아무 메시지도 안 나왔다.

- `migrator.getStatus`: 상태 조회 커넥션을 fail-fast로 생성 (`connectionTimeoutMillis` 5초 + `propagateCreateError`). 5초 타임아웃 가드/`destroy` 타임아웃으로 hang 방지.
- `knex.createKnexInstance`: 풀 타임아웃/`propagateCreateError` 기본값을 호출측이 덮을 수 있게 조정(`validate`/`afterCreate`는 기본값 유지). 기존 호출처는 해당 키 미지정이라 동작 불변.
- UI 마이그레이션 탭: 연결 오류 시 일반 문구 + 실제 원인(대상 DB·에러 메시지) 노출.

### 검증 (miomock)

- 응답 없는 호스트로 `migrate status` → 5초 내 "DB 연결 시간 초과" 출력 후 프로세스 **~7초 종료**(기존 60초+ hang)
- 정상 DB는 2초 응답, 회귀 없음
- `migrator.preparedCodes` 31 테스트 통과, `pnpm check`/`test:type` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)