### PR TITLE
feat(frame): BaseFrameClass에 getPuri 추가

### DIFF
--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/api/base-frame.ts
+++ b/modules/sonamu/src/api/base-frame.ts
@@ -3,8 +3,9 @@ import { type Logger } from "@logtape/logtape";
 import { type Knex } from "knex";
 
 import { type DBPreset } from "../database/db";
-// Static imports kept for non-async functions (getDB, getUpsertBuilder)
+// Static imports kept for non-async functions (getDB, getPuri, getUpsertBuilder)
 import { DB } from "../database/db";
+import { PuriWrapper } from "../database/puri-wrapper";
 import { UpsertBuilder } from "../database/upsert-builder";
 import { convertDomainToCategory } from "../logger/category";
 
@@ -17,6 +18,18 @@ export abstract class BaseFrameClass {
 
   getDB(which: DBPreset): Knex {
     return DB.getDB(which);
+  }
+
+  getPuri(which: DBPreset): PuriWrapper {
+    // 트랜잭션 컨텍스트에서 트랜잭션 획득
+    const trx = DB.getTransactionContext().getTransaction(which);
+    if (trx) {
+      return trx;
+    }
+
+    // 트랜잭션이 없으면 새로운 PuriWrapper 반환
+    const db = this.getDB(which);
+    return new PuriWrapper(db, new UpsertBuilder());
   }
 
   getUpsertBuilder() {


### PR DESCRIPTION
## 문제

`@transactional` 데코레이터는 `this`를 `BaseModelClass | BaseFrameClass`로 받아 `this.getPuri(dbPreset)`를 호출하는데(`decorators.ts:403`), `getPuri`가 `BaseModelClass`에만 있었다. 그래서 **Frame에서 `@transactional`을 쓰면 런타임에 실패**했다.

## 변경

`BaseFrameClass`에 `getPuri`를 BaseModel과 동일하게 구현 — 트랜잭션 컨텍스트에 해당 preset의 트랜잭션이 있으면 그것을, 없으면 새 `PuriWrapper`를 반환.

`package.json`: `0.10.6` → `0.10.7`

## 검증

- miomock 전체 테스트 **1405 passed** (62 파일)
- `tsc --noEmit` / `pnpm check` / `test:type` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)