### PR TITLE
fix(migration): json defaultTo 분기의 typeof 오타 수정

### DIFF
--- a/modules/sonamu/src/migration/code-generation.ts
+++ b/modules/sonamu/src/migration/code-generation.ts
@@ -885,7 +885,7 @@ function genNormalColumnDefinition(column: MigrationColumn): string {
   if (column.defaultTo !== undefined) {
     if (typeof column.defaultTo === "string" && column.defaultTo.startsWith(`"`)) {
       chains.push(`defaultTo(${column.defaultTo})`);
-    } else if (column.type === "json" && typeof column.defaultTo.startsWith('"')) {
+    } else if (column.type === "json" && typeof column.defaultTo === "string") {
       chains.push(`defaultTo(knex.raw("${column.defaultTo.replaceAll('"', "'")}::jsonb"))`);
     } else {
       chains.push(`defaultTo(knex.raw('${column.defaultTo}'))`);


### PR DESCRIPTION
`code-generation.ts:888`의 `typeof column.defaultTo.startsWith('"')`는 `typeof`가 호출 결과에 붙어 **항상 `"boolean"`(truthy)** 으로 평가됐다. 앞 분기에서 `"`로 시작하는 경우를 이미 걸러내므로, 이 분기의 의도는 문자열 여부 가드다.

`typeof column.defaultTo === "string"`으로 수정. 문자열 입력에 대한 동작은 그대로이며, 문자열이 아닌 `defaultTo`가 올 때 `.startsWith` 호출로 TypeError가 나던 것을 막는다.

> jsonb 기본값을 string으로 받는 컨벤션은 그대로 유지 (따옴표 없는 값을 자동 보정하는 대응은 넣지 않음).

**버전 범프 없음** — 다음 릴리스에 함께 나감.

## 검증
- miomock 전체 테스트 **1405 passed**
- `tsc --noEmit` / `pnpm check` / `test:type` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)