### PR TITLE
[Nightly 2026-08-10] NaiteReporter 호출 주체 JSDoc 정정 (buffer 분리 변경은 전제 오류로 되돌림, 소스 1파일)

### DIFF
--- a/modules/sonamu/src/naite/naite-reporter.ts
+++ b/modules/sonamu/src/naite/naite-reporter.ts
@@ -53,6 +53,11 @@ class NaiteReporterClass {
   private socket: Socket | null = null;
   private connected = false;
   private buffer: string[] = [];
+  /**
+   * run/start는 뷰어를 초기화하는 프로토콜 메시지이므로 buffer 상한 폐기 대상에서 제외합니다.
+   * 별도 슬롯에 보관했다가 연결 시 가장 먼저 전송합니다.
+   */
+  private bufferedRunStart: string | null = null;
 
   /**
    * 소켓 연결 시도
@@ -70,6 +75,11 @@ class NaiteReporterClass {
 
       this.socket.on("connect", () => {
         this.connected = true;
+        // 뷰어를 현재 run 기준으로 초기화한 뒤 결과들을 전송
+        if (this.bufferedRunStart) {
+          this.socket?.write(this.bufferedRunStart);
+          this.bufferedRunStart = null;
+        }
         // 버퍼에 쌓인 메시지 전송
         for (const msg of this.buffer) {
           this.socket?.write(msg);
@@ -103,10 +113,16 @@ class NaiteReporterClass {
     if (this.connected && this.socket) {
       this.socket.write(msg);
     } else {
-      // 연결 대기 중이면 버퍼에 저장, 상한 초과 시 오래된 메시지부터 폐기
-      this.buffer.push(msg);
-      if (this.buffer.length > MAX_BUFFERED_MESSAGES) {
-        this.buffer.shift();
+      if (data.type === "run/start") {
+        // 새 run이 시작되었으므로 이전 run의 미전송 메시지는 폐기
+        this.bufferedRunStart = msg;
+        this.buffer = [];
+      } else {
+        // 연결 대기 중이면 버퍼에 저장, 상한 초과 시 오래된 메시지부터 폐기
+        this.buffer.push(msg);
+        if (this.buffer.length > MAX_BUFFERED_MESSAGES) {
+          this.buffer.shift();
+        }
       }
     }
   }

--- a/modules/sonamu/src/naite/naite-reporter.ts
+++ b/modules/sonamu/src/naite/naite-reporter.ts
@@ -6,6 +6,11 @@
  *
  * 프로젝트별로 고유한 소켓을 사용하기 위해 sonamu.config.ts 경로의 해시를 사용합니다.
  *
+ * 모듈 싱글턴이지만 인스턴스는 프로세스마다 별개입니다. run/start·run/end는
+ * Vitest 메인 프로세스(NaiteVitestReporter 커스텀 리포터)에서, test/result는
+ * 각 worker 프로세스(bootstrap의 afterEach)에서 전송되므로 buffer와 소켓
+ * 연결을 서로 공유하지 않습니다.
+ *
  * fs mock 충돌을 피하기 위해 net 모듈만 사용합니다.
  */
 /* oxlint-disable @typescript-eslint/no-explicit-any */ // Naite는 expect와 호응하도록 any를 허용함
@@ -53,11 +58,6 @@ class NaiteReporterClass {
   private socket: Socket | null = null;
   private connected = false;
   private buffer: string[] = [];
-  /**
-   * run/start는 뷰어를 초기화하는 프로토콜 메시지이므로 buffer 상한 폐기 대상에서 제외합니다.
-   * 별도 슬롯에 보관했다가 연결 시 가장 먼저 전송합니다.
-   */
-  private bufferedRunStart: string | null = null;
 
   /**
    * 소켓 연결 시도
@@ -75,11 +75,6 @@ class NaiteReporterClass {
 
       this.socket.on("connect", () => {
         this.connected = true;
-        // 뷰어를 현재 run 기준으로 초기화한 뒤 결과들을 전송
-        if (this.bufferedRunStart) {
-          this.socket?.write(this.bufferedRunStart);
-          this.bufferedRunStart = null;
-        }
         // 버퍼에 쌓인 메시지 전송
         for (const msg of this.buffer) {
           this.socket?.write(msg);
@@ -113,22 +108,16 @@ class NaiteReporterClass {
     if (this.connected && this.socket) {
       this.socket.write(msg);
     } else {
-      if (data.type === "run/start") {
-        // 새 run이 시작되었으므로 이전 run의 미전송 메시지는 폐기
-        this.bufferedRunStart = msg;
-        this.buffer = [];
-      } else {
-        // 연결 대기 중이면 버퍼에 저장, 상한 초과 시 오래된 메시지부터 폐기
-        this.buffer.push(msg);
-        if (this.buffer.length > MAX_BUFFERED_MESSAGES) {
-          this.buffer.shift();
-        }
+      // 연결 대기 중이면 버퍼에 저장, 상한 초과 시 오래된 메시지부터 폐기
+      this.buffer.push(msg);
+      if (this.buffer.length > MAX_BUFFERED_MESSAGES) {
+        this.buffer.shift();
       }
     }
   }
 
   /**
-   * beforeAll에서 호출합니다.
+   * Vitest 커스텀 리포터(NaiteVitestReporter)의 onTestRunStart에서 호출합니다.
    * 테스트 run 시작을 알립니다 (데이터 클리어 신호).
    */
   async startTestRun(): Promise<void> {
@@ -143,7 +132,7 @@ class NaiteReporterClass {
   }
 
   /**
-   * afterEach에서 호출합니다.
+   * bootstrap()의 afterEach에서 호출합니다.
    * 테스트 케이스 결과를 traces와 함께 전송합니다.
    */
   async reportTestResult(
@@ -161,7 +150,7 @@ class NaiteReporterClass {
   }
 
   /**
-   * afterAll에서 호출합니다.
+   * Vitest 커스텀 리포터(NaiteVitestReporter)의 onTestRunEnd에서 호출합니다.
    * 테스트 run 종료를 알립니다.
    */
   async endTestRun(): Promise<void> {


### PR DESCRIPTION
> [!NOTE]
> **2026-08-14 재구성**: 원래 변경(buffer에서 `run/start` 분리 보관)은 전제가 성립하지 않아 되돌렸습니다. `run/start`는 Vitest **메인 프로세스**(NaiteVitestReporter 커스텀 리포터)에서, `test/result`는 **worker 프로세스**(bootstrap의 afterEach)에서 전송되어 서로 다른 NaiteReporter 인스턴스를 사용하므로, 같은 buffer에서 트리밍으로 유실될 수 없습니다. 이 PR은 오판의 근원이었던 낡은 JSDoc("beforeAll에서 호출합니다")을 실제 호출 구조에 맞게 정정하는 내용으로 재구성되었습니다. 상세 분석은 [리뷰 코멘트](https://github.com/cartanova-ai/sonamu/pull/226#issuecomment-5289558327) 참고.

---

<details>
<summary>원본 PR 본문 (재구성 이전)</summary>

## 이 PR은 무엇인가요?

이 PR은 **AI(Claude)가 자동으로 생성**했습니다. [#43 Nightly PR Directions](https://github.com/cartanova-ai/sonamu/issues/43)의 지침에 따라, 코드베이스를 1%만 더 낫게 만드는 것을 목표로 매일 밤 수행되는 작업의 결과물입니다.

**제안일 뿐이며, 판단과 결정은 전적으로 메인테이너에게 있습니다.** 의도와 다르거나 불필요하다고 판단되시면 편하게 닫아주세요.

## 어떤 issue를 참조했고, 왜 이 작업을 선정했나요?

- [#44 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44) — "코드에 예상치 못한 동작이나 버그 등 잠재적으로 위험한 포인트가 존재하는 경우 식별하고 제거"
- [#189 Nightly로 올린 PR의 Comment 확인](https://github.com/cartanova-ai/sonamu/issues/189) — "Nightly PR에 chatgpt-codex-connector[bot]의 comment가 달리면 반드시 확인하고, 수용할 경우 수정해야 합니다"

[PR #214](https://github.com/cartanova-ai/sonamu/pull/214)에 codex bot이 남긴 P2 리뷰 코멘트 2건을 검토했습니다.

| 지적 | 검토 결과 |
| --- | --- |
| 연결 대기 중 두 번째 `send()`의 메시지 유실 | **이미 해소됨.** 머지된 최종 코드에는 `else` 버퍼 폴백이 남아 있어 `connect` 핸들러에서 정상 플러시됩니다. 별도 조치 불필요. |
| 버퍼 트리밍 시 `run/start` 유실 | **유효한 미조치 문제.** 이번 PR에서 수정합니다. |

false positive로 판단한 1건은 그대로 두고, 실제로 재현 가능한 1건만 손댔습니다.

## 무엇이 문제였나요?

`NaiteReporter`는 VS Code extension이 꺼져 있을 때 메시지를 `buffer`에 쌓아두고, 상한(`MAX_BUFFERED_MESSAGES = 1000`)을 넘으면 `shift()`로 오래된 것부터 버립니다.

문제는 **`run/start`가 항상 그 run의 첫 메시지**라는 점입니다. 테스트 케이스가 1000개를 넘는 대규모 스위트를 extension 없이 돌리면, 가장 먼저 버려지는 것이 바로 `run/start`가 됩니다.

`run/start`는 뷰어 데이터를 클리어하는 신호(코드 주석: "테스트 run 시작을 알립니다 (데이터 클리어 신호)")이므로, 이것이 유실되면:

1. 테스트 도중 extension을 켠다 → 연결 성립 → 버퍼 플러시
2. 뷰어는 초기화 신호를 받지 못한 채 `test/result`만 수신
3. **이전 run의 결과 위에 현재 run의 결과가 덧씌워져 섞여 보임**

조용히 잘못된 화면을 보여주는 종류의 문제라, 사용자가 원인을 짚기 어렵습니다.

## 어떤 접근을 채택했고, 왜인가요?

`run/start`를 `buffer` 배열에서 분리해 `bufferedRunStart` 전용 슬롯에 보관합니다.

- **폐기 대상에서 원천 제외** — FIFO 트리밍이 프로토콜 메시지를 건드릴 수 없습니다.
- **연결 시 가장 먼저 전송** — 뷰어를 초기화한 뒤 결과들이 유입되므로 순서가 보장됩니다.
- **새 `run/start` 버퍼링 시 기존 buffer를 비움** — `bufferedRunStart`를 먼저 보내는 설계이므로, 이전 run의 미전송 메시지를 남겨두면 "초기화 → 옛 결과" 순서가 되어 오히려 화면이 깨집니다. 새 run이 시작된 시점에서 이전 run의 미전송분은 어차피 뷰어에서 클리어될 대상이므로 폐기가 정합적입니다.

대안으로 "트리밍 시 `run/start`가 아닌 가장 오래된 항목을 찾아 제거"도 검토했으나, 매 폐기마다 배열을 스캔해야 하고 순서 보장 로직이 오히려 복잡해져 채택하지 않았습니다.

기존 상수·필드·주석 스타일과 자료구조(문자열 배열 버퍼)는 그대로 두었고, 추가된 것은 필드 1개와 분기 1개뿐입니다.

## 영향 범위

- 파일: `modules/sonamu/src/naite/naite-reporter.ts` (+21 -5)
- 기능: Naite 테스트 리포터 → VS Code extension 소켓 전송
- **extension이 연결된 정상 경로는 코드 경로가 전혀 바뀌지 않습니다.** `this.connected && this.socket`인 경우 기존과 동일하게 즉시 `write()` 합니다. 변경은 오직 "연결 대기/실패 중 버퍼링" 경로에만 적용됩니다.
- 공개 API 변경 없음, 메시지 프로토콜 변경 없음.

## 확인 방법

가장 직접적인 재현 시나리오:

1. VS Code extension을 **끈 상태**에서 테스트 케이스 1000개 이상인 스위트 실행
2. 테스트가 중반쯤 진행됐을 때 extension을 켬
3. 뷰어에 이전 run의 결과가 섞이지 않고, 현재 run의 결과만 표시되는지 확인

수정 전에는 2번 시점에 `run/start`가 이미 폐기되어 이전 결과가 남아 있습니다.

검증 완료 항목:
- `tsc --noEmit` 통과
- `oxlint` / `oxfmt` 통과 (pre-commit lefthook)
- `pnpm test:type` 통과 (4 files / 53 tests / type errors 0)
- `tsdown` 빌드 성공 (222 files)

## 사람의 확인이 필요한 부분

- **런타임 통합 테스트는 수행하지 못했습니다.** `naite/` 디렉토리에 테스트 파일이 없고, 재현에 실제 VS Code extension의 Unix 소켓 서버가 필요해 정적 검토와 타입/빌드 검증까지만 진행했습니다. 위 "확인 방법"의 수동 재현으로 최종 확인 부탁드립니다.
- **"새 `run/start` 버퍼링 시 기존 buffer를 비운다"는 판단**은 뷰어 쪽 동작(`run/start` 수신 시 데이터 클리어)에 대한 코드 주석을 근거로 했습니다. `vscode-sonamu` 쪽 실제 구현과 어긋나지 않는지 확인해주시면 좋겠습니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


</details>
