### PR TITLE
[sonamu] feat(SON-530): Sonamu UI 마이그레이션 대상 선택 시 Production DB 선택 시 경고 창 출력

### DIFF
--- a/modules/sonamu/ui-web/src/i18n/en.ts
+++ b/modules/sonamu/ui-web/src/i18n/en.ts
@@ -104,6 +104,10 @@ const en: Record<DictKey, Dictionary[string]> = {
   "migration.noCodeFiles": "No migration code files",
   "migration.codeCollapsed": "Code is collapsed",
   "migration.confirm.deleteCodes": "Are you sure to delete the selected {count} migration codes?",
+  "migration.warning.production.title": "Production Database Warning",
+  "migration.warning.production.description":
+    "Production migrations can affect live data. Review the target before continuing.",
+  "migration.warning.production.confirm": "Select Production",
   "migration.error.connections":
     "Some connections are in error state. Please check the connection settings and try again.",
   "migration.status.pending": "PENDING",

--- a/modules/sonamu/ui-web/src/i18n/ko.ts
+++ b/modules/sonamu/ui-web/src/i18n/ko.ts
@@ -98,6 +98,10 @@ export default {
   "migration.noCodeFiles": "마이그레이션 코드 파일이 없습니다.",
   "migration.codeCollapsed": "코드 접힘",
   "migration.confirm.deleteCodes": "선택한 {count}개의 마이그레이션 코드를 삭제하시겠습니까?",
+  "migration.warning.production.title": "Production 데이터베이스 선택 경고",
+  "migration.warning.production.description":
+    "Production 마이그레이션은 운영 데이터에 영향을 줄 수 있습니다. 대상을 다시 확인해 주세요.",
+  "migration.warning.production.confirm": "Production 선택",
   "migration.error.connections":
     "일부 연결에서 오류가 발생했습니다. 연결 설정을 확인하고 다시 시도해주세요.",
   "migration.status.pending": "PENDING",

--- a/modules/sonamu/ui-web/src/routes/migrations.tsx
+++ b/modules/sonamu/ui-web/src/routes/migrations.tsx
@@ -1,4 +1,12 @@
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
   Button,
   Checkbox,
   Table,
@@ -23,6 +31,7 @@ import RefreshCwIcon from "~icons/lucide/refresh-cw";
 import ToggleLeftIcon from "~icons/lucide/toggle-left";
 import ToggleRightIcon from "~icons/lucide/toggle-right";
 import TrashIcon from "~icons/lucide/trash";
+import TriangleAlertIcon from "~icons/lucide/triangle-alert";
 
 import { useSonamuContext } from "../contexts/sonamu-provider";
 import { SonamuUIService } from "../services/sonamu-ui.service";
@@ -52,6 +61,39 @@ function MigrationsIndex(_props: MigrationsIndexProps) {
     targets: (keyof SonamuDBConfig)[];
   } | null>(null);
   const [isAllCodeViewerOpen, setAllCodeViewerOpen] = useState(false);
+  const [pendingConnKeys, setPendingConnKeys] = useState<(keyof SonamuDBConfig)[] | null>(null);
+
+  const selectConnKeys = (nextConnKeys: (keyof SonamuDBConfig)[]) => {
+    // Production을 새로 포함하는 선택은 사용자가 위험을 확인할 때까지 보류한다.
+    if (!selectedConnKeys.includes("production") && nextConnKeys.includes("production")) {
+      setPendingConnKeys(nextConnKeys);
+      return;
+    }
+    setSelectedConnKeys(nextConnKeys);
+  };
+
+  const handleProductionWarningOpenChange = (open: boolean) => {
+    if (!open) {
+      setPendingConnKeys(null);
+    }
+  };
+
+  const confirmProductionSelection = () => {
+    if (!pendingConnKeys) {
+      return;
+    }
+    setSelectedConnKeys(pendingConnKeys);
+    setPendingConnKeys(null);
+  };
+
+  const cancelProductionSelection = () => {
+    if (!pendingConnKeys) {
+      return;
+    }
+    // 명시적 취소는 운영 연결만 제외한 안전한 후보를 반영한다.
+    setSelectedConnKeys(pendingConnKeys.filter((connKey) => connKey !== "production"));
+    setPendingConnKeys(null);
+  };
 
   const toggleConnKeys = (preset: "ALL" | "LOCAL" | "REMOTE" | "TESTING" | "FIXTURE") => {
     const availableConnKeys = new Set((conns ?? []).map((conn) => conn.connKey));
@@ -75,11 +117,11 @@ function MigrationsIndex(_props: MigrationsIndexProps) {
     }
 
     if (targetKeys.filter((key) => selectedConnKeys.includes(key)).length === targetKeys.length) {
-      setSelectedConnKeys(selectedConnKeys.filter((key) => !targetKeys.includes(key)));
+      selectConnKeys(selectedConnKeys.filter((key) => !targetKeys.includes(key)));
     } else if (diff(targetKeys, selectedConnKeys).length > 0) {
-      setSelectedConnKeys(targetKeys);
+      selectConnKeys(targetKeys);
     } else {
-      setSelectedConnKeys(unique([...selectedConnKeys, ...targetKeys]));
+      selectConnKeys(unique([...selectedConnKeys, ...targetKeys]));
     }
   };
 
@@ -293,11 +335,9 @@ function MigrationsIndex(_props: MigrationsIndexProps) {
                         }
                         onCheckedChange={(checked) => {
                           if (checked) {
-                            setSelectedConnKeys(unique([...selectedConnKeys, conn.connKey]));
+                            selectConnKeys(unique([...selectedConnKeys, conn.connKey]));
                           } else {
-                            setSelectedConnKeys(
-                              selectedConnKeys.filter((key) => key !== conn.connKey),
-                            );
+                            selectConnKeys(selectedConnKeys.filter((key) => key !== conn.connKey));
                           }
                         }}
                       />
@@ -393,6 +433,31 @@ function MigrationsIndex(_props: MigrationsIndexProps) {
           onCompleted={handleActionModalCompleted}
         />
       )}
+      <AlertDialog open={pendingConnKeys !== null} onOpenChange={handleProductionWarningOpenChange}>
+        <AlertDialogContent className="border-2 border-red-600 bg-red-50">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2 text-red-700">
+              <TriangleAlertIcon className="size-6 shrink-0" />
+              {SD("migration.warning.production.title")}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-red-700">
+              {SD("migration.warning.production.description")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            {/* oxlint-disable-next-line jsx-a11y/no-autofocus */}
+            <AlertDialogCancel autoFocus onClick={cancelProductionSelection}>
+              {SD("common.cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 text-white hover:bg-red-700"
+              onClick={confirmProductionSelection}
+            >
+              {SD("migration.warning.production.confirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
Sonamu UI에서 마이그레이션 대상을 선택할 때 Production DB가 선택되면 경고 창을 띄웁니다.
취소 버튼 클릭 시 Production 선택이 해제됩니다.

<img width="528" height="209" alt="Screenshot 2026-08-10 at 10 57 33 AM" src="https://github.com/user-attachments/assets/612f3040-21c2-41b5-b446-78d10d4dbe01" />
