### PR TITLE
[Nightly 2026-08-11] codex 리뷰 미조치분 반영: 에이전트 도구 예제의 getDB()→getPuri() 및 인자 누락된 UnauthorizedException 정정 (ko/en 5파일)

### DIFF
--- a/modules/docs/en/advanced-features/ai-agents/creating-agents.mdx
+++ b/modules/docs/en/advanced-features/ai-agents/creating-agents.mdx
@@ -299,7 +299,7 @@ class DataAnalystAgentClass extends BaseAgentClass<{
       throw new Error("Only SELECT queries are allowed");
     }
 
-    const result = await BaseModel.getDB("r").raw(input.query);
+    const result = await BaseModel.getPuri("r").raw(input.query);
 
     return {
       rows: result.rows,

--- a/modules/docs/en/frontend-integration/generated-services/using-services.mdx
+++ b/modules/docs/en/frontend-integration/generated-services/using-services.mdx
@@ -407,7 +407,7 @@ class UserModelClass extends BaseModelClass {
 
     // Authorization checks possible
     if (!context.user) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException("Login is required");
     }
 
     return this.findById(id, [subset]);

--- a/modules/docs/ko/advanced-features/ai-agents/creating-agents.mdx
+++ b/modules/docs/ko/advanced-features/ai-agents/creating-agents.mdx
@@ -295,7 +295,7 @@ class DataAnalystAgentClass extends BaseAgentClass<{
       throw new Error("SELECT 쿼리만 허용됩니다");
     }
 
-    const result = await BaseModel.getDB("r").raw(input.query);
+    const result = await BaseModel.getPuri("r").raw(input.query);
 
     return {
       rows: result.rows,

--- a/modules/docs/ko/advanced-features/caching/cache-decorator.mdx
+++ b/modules/docs/ko/advanced-features/caching/cache-decorator.mdx
@@ -650,7 +650,7 @@ class DashboardModelClass extends BaseModelClass {
 
     // 권한 체크
     if (context.user?.id !== userId && context.user?.role !== "admin") {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException("권한이 없습니다");
     }
 
     // 대시보드 데이터 조회

--- a/modules/docs/ko/frontend-integration/generated-services/using-services.mdx
+++ b/modules/docs/ko/frontend-integration/generated-services/using-services.mdx
@@ -519,7 +519,7 @@ class UserModelClass extends BaseModelClass {
 
     // 권한 체크 등 가능
     if (!context.user) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException("로그인이 필요합니다");
     }
 
     return this.findById(id, [subset]);


### PR DESCRIPTION
## 이 PR은 무엇인가요?

이 PR은 **AI(Claude)가 자동으로 생성**했습니다. [#43 Nightly PR Directions](https://github.com/cartanova-ai/sonamu/issues/43)의 지침에 따라, 코드베이스를 1%만 더 낫게 만드는 것을 목표로 매일 밤 수행되는 작업의 결과물입니다.

**제안일 뿐이며, 판단과 결정은 전적으로 메인테이너에게 있습니다.** 의도와 다르거나 불필요하다고 판단되시면 편하게 닫아주세요.

## 어떤 issue를 참조했고, 왜 이 작업을 선정했나요?

- [#189 Nightly로 올린 PR의 Comment 확인](https://github.com/cartanova-ai/sonamu/issues/189) — "Nightly PR에 chatgpt-codex-connector[bot]의 comment가 달리면 반드시 확인하고, 수용할 경우 수정해야 합니다"
- [#197 Puri/UpsertBuilder를 우선 사용하도록 문서 수정](https://github.com/cartanova-ai/sonamu/issues/197) — "`.getDb()` 사용을 권장하는 문서의 내용은 `.getPuri()` 사용을 우선시하는 방향으로 수정되어야 합니다"
- [#44 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44) — "문서와 주석이 코드와 어긋나는 경우 설명을 업데이트"

머지된 Nightly PR에 codex bot이 남긴 리뷰 코멘트를 전수 조사한 결과, **아직 반영되지 않은 P2 지적 2건**을 발견했습니다. 두 건 모두 현재 master에서 재현되며, 마침 #197의 방향(getPuri 우선)과도 정확히 일치해 이번 작업 대상으로 선정했습니다.

| 출처 | 지적 | 현재 master 상태 |
| --- | --- | --- |
| [PR #213 리뷰](https://github.com/cartanova-ai/sonamu/pull/213#discussion) | 에이전트 도구 예제가 `BaseModel.getDB("r").raw()`로 TransactionContext를 우회 | **미조치** (ko:298 / en:302) |
| [PR #212 리뷰](https://github.com/cartanova-ai/sonamu/pull/212#discussion) | `UnauthorizedException()`을 인자 없이 호출 | **미조치** (3개소) |

지적을 무비판적으로 수용하지 않기 위해, 실제 소스코드에서 근거를 다시 확인한 뒤에만 손댔습니다.

## 무엇이 문제였나요?

### 1. `getDB("r").raw()` — 트랜잭션 컨텍스트 우회 (`creating-agents.mdx`)

`BaseModelClass.getPuri()`는 `DB.getTransactionContext().getTransaction(which)`를 먼저 조회해 진행 중인 트랜잭션이 있으면 그 핸들을 반환합니다(`modules/sonamu/src/database/base-model.ts:58`). 반면 `getDB()`는 컨텍스트와 무관하게 커넥션 풀 핸들을 그대로 돌려줍니다.

해당 예제는 마이그레이션/테스트가 아니라 **에이전트 도구의 비즈니스 로직**입니다. 사용자가 이 예제를 복사해 `@transactional` 흐름 안에서 호출하면, 같은 트랜잭션 안에서 방금 쓴 데이터를 조회 결과에서 보지 못하는 종류의 버그가 조용히 생깁니다. 저장소의 다른 문서(`get-puri.mdx`)도 비즈니스 로직에서는 `getPuri()`를 쓰고 `getDB()` 직접 사용은 migration/test/infrastructure로 제한하고 있어, 이 예제만 정책에서 벗어나 있었습니다.

### 2. `new UnauthorizedException()` — 그대로 복사하면 컴파일 실패

`UnauthorizedException`의 생성자는 `message: LocalizedString`을 **필수**로 받습니다(`modules/sonamu/src/exceptions/so-exceptions.ts:29`). 인자 없이 호출하는 예제를 복사하면 `Expected 1-2 arguments, but got 0` (TS2554)로 바로 막힙니다. 문서 내 다른 30여 곳은 모두 메시지를 넘기고 있어, 이 3개소만 예외적으로 누락된 상태였습니다.

## 어떤 접근을 채택했고, 왜인가요?

- **`getPuri("r").raw(...)`로 교체.** `PuriWrapper.raw()`는 내부적으로 `this.knex.raw(sql)`을 그대로 호출하므로(`puri-wrapper.ts:36`) 반환 타입이 `Knex.Raw`로 동일합니다. 즉 예제 뒷부분의 `result.rows` / `result.rows.length` 접근이 그대로 유효하며, **바뀌는 것은 "어느 커넥션에서 실행되는가"뿐**입니다. 예제의 구조나 설명 문장은 건드리지 않았습니다.
- **예외 메시지는 주변 예제와 동일한 문구로만 채움.** ko는 `"로그인이 필요합니다"` / `"권한이 없습니다"`, en은 `"Login is required"` — 모두 이미 같은 문서군에서 쓰이는 표현입니다. 새 표현을 발명하거나 예제 로직을 손대지 않았습니다.

`knex.raw()` → `upsertBuilder()` 교체(#197의 나머지 절반)는 이번 범위에 넣지 않았습니다. 대상 문서가 많고 예제별로 의도(마이그레이션인지 비즈니스 로직인지)를 개별 판단해야 해서, 한 PR에 섞으면 리뷰 부담이 커진다고 봤습니다.

## 영향 범위

- 문서 5파일, 총 5줄 (`+5 -5`). **소스코드 변경 없음, 동작 변경 없음.**
  - `ko|en/advanced-features/ai-agents/creating-agents.mdx`
  - `ko|en/frontend-integration/generated-services/using-services.mdx`
  - `ko/advanced-features/caching/cache-decorator.mdx`
- 영향 받는 것은 "문서를 보고 코드를 작성하는 사용자"입니다. 잘못된 예제를 복사해 생기는 (1) 트랜잭션 밖 조회, (2) 즉시 컴파일 실패 두 가지가 사라집니다.

## 확인 방법

```bash
# 1. 남아 있는 getDB 직접 호출이 API 레퍼런스(getDB 자체 설명)뿐인지
grep -rn 'BaseModel.getDB(' modules/docs/

# 2. 인자 없는 예외 생성이 더 이상 없는지
grep -rn 'Exception()' modules/docs/ | grep -v isSoException
```

검증 완료 항목:
- 루트 `pnpm check` 통과 (oxlint --type-aware + oxfmt + skill size/index check)

## 사람의 확인이 필요한 부분

- **`cache-decorator.mdx`의 ko/en 분량 불일치를 발견했지만 이번엔 손대지 않았습니다.** ko는 993줄, en은 659줄이고 이번에 수정한 `getUserDashboard` 예제 섹션 자체가 en에는 존재하지 않습니다. 문서 번역 누락으로 보이지만, 섹션 통째 이식은 이 PR의 범위(1줄 정정)를 크게 넘어서고 원저자의 의도(의도적 축약일 가능성)를 확인할 수 없어 보류했습니다. 별도 처리가 필요한지 판단 부탁드립니다.
- **codex bot 코멘트 수집 범위**는 `nightly` label이 달린 PR 40건의 issue comment + review comment 전수입니다. 그 외 경로로 달린 피드백이 있다면 놓쳤을 수 있습니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
