### PR TITLE
[Nightly 2026-08-12] BaseFrameClass.getPuri 추가(#224) 미반영으로 사실과 어긋난 Frame 문서의 "Frame엔 getPuri 없음" 서술 정정 (ko/en 8파일)

### DIFF
--- a/modules/docs/en/api-development/frames/creating-frames.mdx
+++ b/modules/docs/en/api-development/frames/creating-frames.mdx
@@ -90,8 +90,6 @@ export const HealthFrameInstance = new HealthFrame();
 ```typescript
 // health.frame.ts
 import { BaseFrameClass, api } from "sonamu";
-// Frames have no getPuri, so use an associated Model's getPuri.
-import { UserModel } from "./user/user.model";
 
 interface HealthCheckResponse {
   status: "ok" | "error";
@@ -114,7 +112,7 @@ class HealthFrame extends BaseFrameClass {
     let dbStatus: "connected" | "disconnected" = "disconnected";
 
     try {
-      const rdb = UserModel.getPuri("r");
+      const rdb = this.getPuri("r");
       await rdb.raw("SELECT 1");
       dbStatus = "connected";
     } catch (error) {
@@ -371,12 +369,13 @@ export const WeatherFrameInstance = new WeatherFrame();
 
 ## DB Access
 
-Frame can also access DB. Frame classes have no `getPuri`, so use an associated Model's `getPuri` to obtain the Puri query builder.
+Frame can also access DB. Frame classes provide `getPuri` just like Models, so obtain the Puri
+query builder with `this.getPuri()`.
 
 <Info>
-  The handle returned by `getPuri` is not bound to a specific table, so no matter which
-  Model's `getPuri` you use, you can query every registered table. The examples below assume
-  `import { UserModel } from "./user/user.model";` and `import { Puri } from "sonamu";`.
+  The handle returned by `getPuri` is not bound to a specific table, so even a Frame that is not
+  tied to an Entity can query every registered table. The examples below assume `import { Puri }
+  from "sonamu";`.
 </Info>
 
 ### Read Operations
@@ -391,7 +390,7 @@ class StatsFrame extends BaseFrameClass {
     totalPosts: number;
     totalComments: number;
   }> {
-    const rdb = UserModel.getPuri("r");
+    const rdb = this.getPuri("r");
 
     const { userCount } = await rdb
       .table("users")
@@ -428,7 +427,7 @@ class AdminFrame extends BaseFrameClass {
   async clearOldLogs(params: { beforeDate: Date }): Promise<{
     deletedCount: number;
   }> {
-    const wdb = UserModel.getPuri("w");
+    const wdb = this.getPuri("w");
 
     const deletedCount = await wdb
       .table("logs")

--- a/modules/docs/en/api-development/frames/use-cases.mdx
+++ b/modules/docs/en/api-development/frames/use-cases.mdx
@@ -109,8 +109,7 @@ class HealthFrame extends BaseFrameClass {
     let dbResponseTime: number | undefined;
 
     try {
-      // Frames have no getPuri, so use an associated Model's getPuri (e.g. UserModel).
-      const rdb = UserModel.getPuri("r");
+      const rdb = this.getPuri("r");
       const dbStart = Date.now();
       await rdb.raw("SELECT 1");
       dbResponseTime = Date.now() - dbStart;
@@ -595,8 +594,7 @@ class AdminStatsFrame extends BaseFrameClass {
 
   @api({ httpMethod: "GET" })
   async dashboard(): Promise<DashboardStats> {
-    // Frames have no getPuri, so use an associated Model's getPuri (e.g. UserModel).
-    const rdb = UserModel.getPuri("r");
+    const rdb = this.getPuri("r");
 
     // Date calculations
     const today = new Date();

--- a/modules/docs/en/api-development/frames/what-are-frames.mdx
+++ b/modules/docs/en/api-development/frames/what-are-frames.mdx
@@ -234,8 +234,7 @@ class HealthFrame extends BaseFrameClass {
     let dbStatus: "connected" | "disconnected" = "disconnected";
 
     try {
-      // Frames have no getPuri, so use an associated Model's getPuri (e.g. UserModel).
-      const rdb = UserModel.getPuri("r");
+      const rdb = this.getPuri("r");
       await rdb.raw("SELECT 1");
       dbStatus = "connected";
     } catch (error) {

--- a/modules/docs/en/faq/entity-and-model.mdx
+++ b/modules/docs/en/faq/entity-and-model.mdx
@@ -371,7 +371,7 @@ export const UtilFrame = new UtilFrameClass();
 **Frame characteristics:**
 
 - Extends `BaseFrameClass`
-- Provides `getDB(preset)`, `getUpsertBuilder()` methods
+- Provides `getDB(preset)`, `getPuri(preset)`, `getUpsertBuilder()` methods
 - No Entity, Subset, Model methods
 - Filename: `{name}.frame.ts`
 

--- a/modules/docs/ko/api-development/frames/creating-frames.mdx
+++ b/modules/docs/ko/api-development/frames/creating-frames.mdx
@@ -90,8 +90,6 @@ export const HealthFrameInstance = new HealthFrame();
 ```typescript
 // health.frame.ts
 import { BaseFrameClass, api } from "sonamu";
-// Frame에는 getPuri가 없으므로 연관 Model의 getPuri를 사용합니다.
-import { UserModel } from "./user/user.model";
 
 interface HealthCheckResponse {
   status: "ok" | "error";
@@ -114,7 +112,7 @@ class HealthFrame extends BaseFrameClass {
     let dbStatus: "connected" | "disconnected" = "disconnected";
 
     try {
-      const rdb = UserModel.getPuri("r");
+      const rdb = this.getPuri("r");
       await rdb.raw("SELECT 1");
       dbStatus = "connected";
     } catch (error) {
@@ -371,12 +369,13 @@ export const WeatherFrameInstance = new WeatherFrame();
 
 ## DB 접근
 
-Frame에서도 DB에 접근할 수 있습니다. Frame 클래스에는 `getPuri`가 없으므로, 연관된 Model의 `getPuri`를 통해 Puri 쿼리 빌더를 사용합니다.
+Frame에서도 DB에 접근할 수 있습니다. Frame 클래스도 Model과 동일하게 `getPuri`를 제공하므로,
+`this.getPuri()`로 Puri 쿼리 빌더를 얻습니다.
 
 <Info>
-  `getPuri`가 반환하는 핸들은 특정 테이블에 묶이지 않으므로, 어떤 Model의 `getPuri`를
-  사용하든 등록된 모든 테이블을 조회할 수 있습니다. 아래 예제는 `import { UserModel } from
-  "./user/user.model";`와 `import { Puri } from "sonamu";`를 전제로 합니다.
+  `getPuri`가 반환하는 핸들은 특정 테이블에 묶이지 않으므로, Entity와 연결되지 않은 Frame에서도
+  등록된 모든 테이블을 조회할 수 있습니다. 아래 예제는 `import { Puri } from "sonamu";`를
+  전제로 합니다.
 </Info>
 
 ### 읽기 작업
@@ -391,7 +390,7 @@ class StatsFrame extends BaseFrameClass {
     totalPosts: number;
     totalComments: number;
   }> {
-    const rdb = UserModel.getPuri("r");
+    const rdb = this.getPuri("r");
 
     const { userCount } = await rdb
       .table("users")
@@ -428,7 +427,7 @@ class AdminFrame extends BaseFrameClass {
   async clearOldLogs(params: { beforeDate: Date }): Promise<{
     deletedCount: number;
   }> {
-    const wdb = UserModel.getPuri("w");
+    const wdb = this.getPuri("w");
 
     const deletedCount = await wdb
       .table("logs")

--- a/modules/docs/ko/api-development/frames/use-cases.mdx
+++ b/modules/docs/ko/api-development/frames/use-cases.mdx
@@ -109,8 +109,7 @@ class HealthFrame extends BaseFrameClass {
     let dbResponseTime: number | undefined;
 
     try {
-      // Frame엔 getPuri가 없어 연관 Model(UserModel 등)의 getPuri를 사용
-      const rdb = UserModel.getPuri("r");
+      const rdb = this.getPuri("r");
       const dbStart = Date.now();
       await rdb.raw("SELECT 1");
       dbResponseTime = Date.now() - dbStart;
@@ -595,8 +594,7 @@ class AdminStatsFrame extends BaseFrameClass {
 
   @api({ httpMethod: "GET" })
   async dashboard(): Promise<DashboardStats> {
-    // Frame엔 getPuri가 없어 연관 Model(UserModel 등)의 getPuri를 사용
-    const rdb = UserModel.getPuri("r");
+    const rdb = this.getPuri("r");
 
     // 날짜 계산
     const today = new Date();

--- a/modules/docs/ko/api-development/frames/what-are-frames.mdx
+++ b/modules/docs/ko/api-development/frames/what-are-frames.mdx
@@ -234,8 +234,7 @@ class HealthFrame extends BaseFrameClass {
     let dbStatus: "connected" | "disconnected" = "disconnected";
 
     try {
-      // Frame엔 getPuri가 없어 연관 Model(UserModel 등)의 getPuri를 사용
-      const rdb = UserModel.getPuri("r");
+      const rdb = this.getPuri("r");
       await rdb.raw("SELECT 1");
       dbStatus = "connected";
     } catch (error) {

--- a/modules/docs/ko/faq/entity-and-model.mdx
+++ b/modules/docs/ko/faq/entity-and-model.mdx
@@ -371,7 +371,7 @@ export const UtilFrame = new UtilFrameClass();
 **Frame 특징:**
 
 - `BaseFrameClass` 상속
-- `getDB(preset)`, `getUpsertBuilder()` 메서드 제공
+- `getDB(preset)`, `getPuri(preset)`, `getUpsertBuilder()` 메서드 제공
 - Entity, Subset, Model 메서드 없음
 - 파일명: `{name}.frame.ts`
 


### PR DESCRIPTION
## 이 PR은 무엇인가요?

이 PR은 **AI(Claude)가 자동으로 생성**했습니다. [#43 Nightly PR Directions](https://github.com/cartanova-ai/sonamu/issues/43)의 지침에 따라, 코드베이스를 1%만 더 낫게 만드는 것을 목표로 매일 밤 수행되는 작업의 결과물입니다.

**제안일 뿐이며, 판단과 결정은 전적으로 메인테이너에게 있습니다.** 의도와 다르거나 불필요하다고 판단되시면 편하게 닫아주세요.

## 어떤 issue를 참조했고, 왜 이 작업을 선정했나요?

- [#44 내일 새벽에 AI에게 맡길 일들](https://github.com/cartanova-ai/sonamu/issues/44) — "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다", "git commit/push 등으로 소스코드가 업데이트 되었으나 문서의 내용이 outdated인 경우"

`modules/sonamu/src` 최근 커밋을 문서 반영 여부와 대조하다가, **[#224 feat(frame): BaseFrameClass에 getPuri 추가](https://github.com/cartanova-ai/sonamu/pull/224) (57dd1f9, 8/2 머지)가 문서에 전혀 반영되지 않은 것**을 발견했습니다.

이 커밋 이전에는 `getPuri`가 `BaseModelClass`에만 있었고, 문서는 그 제약을 전제로 "Frame에는 `getPuri`가 없으니 아무 Model의 `getPuri`를 빌려 쓰라"는 우회법을 안내하고 있었습니다. 지금은 `BaseFrameClass`가 `getPuri`를 직접 제공하므로(`modules/sonamu/src/api/base-frame.ts:23`), 이 안내는 **명백히 사실이 아닌 서술**이 되었습니다.

같은 커밋 이후 릴리스된 다른 기능들(`ensureJoin`/`ensureLeftJoin` 등)은 문서에 이미 반영되어 있어, 이 건만 누락된 상태였습니다.

## 무엇이 문제였나요?

Frame 문서 3종과 FAQ가 아래처럼 안내하고 있었습니다.

```typescript
// health.frame.ts
import { BaseFrameClass, api } from "sonamu";
// Frame에는 getPuri가 없으므로 연관 Model의 getPuri를 사용합니다.
import { UserModel } from "./user/user.model";
...
    const rdb = UserModel.getPuri("r");
```

문제는 세 가지입니다.

1. **사실과 다름.** `BaseFrameClass.getPuri()`가 `BaseModelClass.getPuri()`와 동일하게 구현되어 있습니다(트랜잭션 컨텍스트 조회 → 없으면 새 `PuriWrapper`).
2. **불필요한 결합을 권장함.** 헬스체크처럼 도메인과 무관한 Frame이 DB 핸들 하나 얻자고 `UserModel`을 import하게 됩니다. Frame은 애초에 "Entity와 결합되지 않는 API"인데, 문서가 그 성질을 스스로 깨뜨리는 예제를 보여주고 있었습니다.
3. **파일 내 자기모순.** `what-are-frames.mdx`는 같은 문서 안에서 Model 예제는 `this.getPuri("r")`, Frame 예제는 `UserModel.getPuri("r")` + "Frame엔 없어서"라는 주석을 함께 보여줍니다. 처음 읽는 사용자에게는 혼란입니다.

참고로 #224의 커밋 메시지에 따르면, `getPuri` 부재는 단순 불편이 아니라 **Frame에서 `@transactional`을 쓰면 런타임 실패**로 이어지던 실제 버그였습니다. 그만큼 "Frame엔 getPuri가 없다"는 기술이 남아 있으면 사용자가 이미 고쳐진 제약을 계속 우회하게 됩니다.

## 어떤 접근을 채택했고, 왜인가요?

- **예제를 `this.getPuri(...)`로 교체.** `examples/miomock`의 실제 Frame 구현도 `this.getDB("r")` 형태로 인스턴스 메서드를 직접 호출하고 있어(`dashboard.frame.ts:24`), 저장소의 실사용 관례와 일치합니다.
- **쓸모가 사라진 것만 제거.** `UserModel` import와 "Frame엔 getPuri가 없어" 주석은 우회를 위해 존재하던 것이므로 함께 지웠습니다. 예제의 로직·구조·설명 흐름은 그대로 두었습니다.
- **`<Info>` 블록은 지우지 않고 다시 씀.** "핸들이 특정 테이블에 묶이지 않는다"는 정보 자체는 여전히 유효합니다. 다만 근거를 "어떤 Model을 쓰든"에서 "Entity와 연결되지 않은 Frame에서도"로 바꿔, 원저자가 전달하려던 요점(테이블 자유도)을 유지했습니다.
- **FAQ의 메서드 목록에 `getPuri(preset)` 추가.** `getDB(preset)`, `getUpsertBuilder()`만 나열되어 있어 실제 클래스와 목록이 어긋나 있었습니다.

`getDB()` 사용 예제를 `getPuri()`로 바꾸는 작업(#197 계열)은 이번 범위에 넣지 않았습니다. 이 PR은 "#224로 인해 거짓이 된 서술의 정정"에만 한정했습니다.

## 영향 범위

- 문서 8파일 (`+24 -32`). **소스코드 변경 없음, 동작 변경 없음.**
  - `ko|en/api-development/frames/{what-are-frames,creating-frames,use-cases}.mdx`
  - `ko|en/faq/entity-and-model.mdx`
- 영향 받는 것은 "Frame 문서를 보고 코드를 작성하는 사용자"입니다. 이제 Frame에서 도메인 Model을 끌어오지 않고 `this.getPuri()`로 바로 DB에 접근하는 코드를 쓰게 됩니다.

## 확인 방법

```bash
# 1. 코드에 getPuri가 실재하는지
grep -n "getPuri" modules/sonamu/src/api/base-frame.ts

# 2. "Frame엔 getPuri가 없다"는 서술이 모두 사라졌는지 (결과 없음이 정상)
grep -rn "Frame엔 getPuri\|Frame에는 getPuri\|Frames have no getPuri\|Frame classes have no" modules/docs/

# 3. Frame 문서에 남은 UserModel 참조가 Model 설명용뿐인지
grep -rn "UserModel" modules/docs/{ko,en}/api-development/frames/
```

검증 완료 항목:
- 루트 `pnpm check` 통과 (oxlint --type-aware + oxfmt + skill size/index check)

## 사람의 확인이 필요한 부분

- **Frame 예제의 `frameName = "Health";` 패턴은 이번에 손대지 않았습니다.** `BaseFrameClass`의 `frameName`은 생성자 파라미터 프로퍼티(`public readonly`)이고, `examples/miomock`의 실제 Frame들은 이 필드를 선언하지 않습니다. 문서 예제 다수가 이 패턴을 쓰고 있어 TS 관점에서 그대로 복사 가능한지 확인이 필요해 보이나, 범위가 이 PR(“#224 미반영 정정”)을 벗어나고 원저자의 의도를 확정할 수 없어 보류했습니다. 별도 처리가 필요한지 판단 부탁드립니다.
- **문서 렌더링(빌드)은 확인하지 못했습니다.** `pnpm check`는 통과했으나 `modules/docs`의 MDX 빌드 파이프라인은 별도로 돌리지 않았습니다. 변경은 코드블록 내부와 `<Info>` 본문 텍스트뿐이라 구조적 위험은 낮다고 봅니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
