### PR TITLE
[Nightly 2026-08-13] Entity/scaffold 문서의 미존재 타입(EntityType·InferSelectModel)과 구식 .entity.ts·src/models 산출물 서술을 실제 entity.json·템플릿 출력으로 정정, business-logic 예제 Puri 전환 (ko/en 10파일)

### DIFF
--- a/modules/docs/en/core-concepts/model/business-logic.mdx
+++ b/modules/docs/en/core-concepts/model/business-logic.mdx
@@ -361,39 +361,54 @@ async findMany<T extends UserSubsetKey>(
 ### Complex JOINs
 
 ```typescript
-async findUsersWithStats(): Promise<UserWithStats[]> {
+async findUsersWithStats() {
   const rdb = this.getPuri("r");
 
-  return rdb.knex("users")
-    .select([
-      "users.*",
-      rdb.knex.raw("COUNT(DISTINCT posts.id) as post_count"),
-      rdb.knex.raw("COUNT(DISTINCT comments.id) as comment_count"),
-      rdb.knex.raw("AVG(posts.views) as avg_post_views"),
-    ])
-    .leftJoin("posts", "posts.user_id", "users.id")
-    .leftJoin("comments", "comments.user_id", "users.id")
+  return rdb
+    .table("users")
+    .select({
+      id: "users.id",
+      name: "users.name",
+      // COUNT(DISTINCT ...) cannot be expressed with Puri.count(), so use rawNumber
+      post_count: Puri.rawNumber("COUNT(DISTINCT posts.id)"),
+      comment_count: Puri.rawNumber("COUNT(DISTINCT comments.id)"),
+      avg_post_views: Puri.avg("posts.views"),
+    })
+    .leftJoin("posts", "users.id", "posts.user_id")
+    .leftJoin("comments", "users.id", "comments.user_id")
     .groupBy("users.id");
 }
 ```
 
+<Note>
+  In Puri, `join`/`leftJoin` take a column of an **already available table** first and a column of
+  the **newly joined table** second — the opposite order from Knex.
+</Note>
+
 ### Subquery Usage
 
 ```typescript
-async findTopUsers(limit: number): Promise<User[]> {
+async findTopUsers(limit: number) {
   const rdb = this.getPuri("r");
 
-  const subquery = rdb.knex("orders")
-    .select("user_id")
-    .sum("total_price as total_spent")
-    .groupBy("user_id")
+  const topUsers = rdb
+    .table("orders")
+    .select({
+      user_id: "orders.user_id",
+      total_spent: Puri.sum("orders.total_price"),
+    })
+    .groupBy("orders.user_id")
     .orderBy("total_spent", "desc")
-    .limit(limit)
-    .as("top_users");
+    .limit(limit);
 
-  return rdb.knex("users")
-    .select("users.*", "top_users.total_spent")
-    .joinRaw("JOIN ? ON users.id = top_users.user_id", [subquery]);
+  return rdb
+    .table("users")
+    .join({ top_users: topUsers }, "users.id", "top_users.user_id")
+    .select({
+      id: "users.id",
+      name: "users.name",
+      total_spent: "top_users.total_spent",
+    });
 }
 ```
 

--- a/modules/docs/en/tools-and-cli/sonamu-cli/scaffold.mdx
+++ b/modules/docs/en/tools-and-cli/sonamu-cli/scaffold.mdx
@@ -38,22 +38,32 @@ An interactive prompt appears:
 import { FileTree, FileItem } from "../../../snippets/FileTree.jsx";
 
 <FileTree>
-  <FileItem name="src/models/">
-    <FileItem name="User.model.ts" description="User Model class" />
+  <FileItem name="src/application/user/">
+    <FileItem name="user.model.ts" description="User Model class" />
   </FileItem>
 </FileTree>
 
 **Generated code**:
 
-```typescript title="src/models/User.model.ts"
-import { BaseModelClass } from "sonamu";
-import type { InferSelectModel } from "sonamu";
-import { UserEntity } from "../entities/User.entity";
-import type { UserSubsetKey, UserSubsetMapping } from "../sonamu.generated";
+```typescript title="src/application/user/user.model.ts"
+import {
+  api,
+  asArray,
+  BadRequestException,
+  BaseModelClass,
+  exhaustive,
+  NotFoundException,
+  type ListResult,
+} from "sonamu";
+
+import { SD } from "../../i18n/sd.generated";
+import { UserSubsetKey, UserSubsetMapping } from "../sonamu.generated";
 import { userLoaderQueries, userSubsetQueries } from "../sonamu.generated.sso";
+import { UserListParams, UserSaveParams } from "./user.types";
 
-export type User = InferSelectModel<typeof UserEntity>;
-
+/*
+  User Model
+*/
 class UserModelClass extends BaseModelClass<
   UserSubsetKey,
   UserSubsetMapping,
@@ -64,11 +74,37 @@ class UserModelClass extends BaseModelClass<
     super("User", userSubsetQueries, userLoaderQueries);
   }
 
-  // TODO: Add Model methods
+  @api({ httpMethod: "GET", clients: ["axios", "tanstack-query"], resourceName: "User" })
+  async findById<T extends UserSubsetKey>(subset: T, id: number): Promise<UserSubsetMapping[T]> {
+    // ...
+  }
+
+  @api({ httpMethod: "GET", clients: ["axios", "tanstack-query"], resourceName: "Users" })
+  async findMany<T extends UserSubsetKey, LP extends UserListParams>(
+    subset: T,
+    rawParams?: LP,
+  ): Promise<ListResult<LP, UserSubsetMapping[T]>> {
+    // handles id / search-keyword / orderBy, then calls executeSubsetQuery
+  }
+
+  @api({ httpMethod: "POST", clients: ["axios", "tanstack-mutation"] })
+  async save(spa: UserSaveParams[]): Promise<number[]> {
+    // ubRegister + transaction(ubUpsert)
+  }
+
+  @api({ httpMethod: "POST", clients: ["axios", "tanstack-mutation"], guards: ["admin"] })
+  async del(ids: number[]): Promise<number> {
+    // ...
+  }
 }
 
 export const UserModel = new UserModelClass();
 ```
+
+<Note>
+  The real output contains full bodies for `findById`/`findOne`/`findMany`/`save`/`del`; they are
+  elided above for brevity. When the Entity has a string primary key, `id` is generated as `string`.
+</Note>
 
 ### model_test - Generate Test File
 
@@ -81,56 +117,52 @@ pnpm scaffold model_test
 **Generated files**:
 
 <FileTree>
-  <FileItem name="src/models/">
-    <FileItem name="User.model.test.ts" description="User Model tests" />
+  <FileItem name="src/application/user/">
+    <FileItem name="user.model.test.ts" description="User Model tests" />
   </FileItem>
 </FileTree>
 
 **Generated code**:
 
-```typescript title="src/models/User.model.test.ts"
-import { beforeAll, describe, test } from "bun:test";
-import { expect } from "@jest/globals";
-import { FixtureManager } from "sonamu/test";
-import { UserModel } from "./User.model";
+```typescript title="src/application/user/user.model.test.ts"
+import { bootstrap, test } from "sonamu/test";
+import { describe, expect, vi } from "vitest";
 
-describe("User Model", () => {
-  beforeAll(async () => {
-    await FixtureManager.sync();
+bootstrap(vi);
+describe.skip("UserModelTest", () => {
+  test("Query", async () => {
+    expect(true).toBe(true);
   });
-
-  test("findById", async () => {
-    const user = await UserModel.findById(1);
-    expect(user).toBeDefined();
-    expect(user?.id).toBe(1);
-  });
-
-  test("findMany", async () => {
-    const users = await UserModel.findMany({
-      num: 10,
-      page: 1,
-    });
-    expect(users.rows.length).toBeGreaterThan(0);
-  });
-
-  // TODO: Add more tests
 });
 ```
 
-## View Scaffolding (In Development)
+<Warning>
+  The generated test starts as `describe.skip`. Remove `.skip` once you have written real
+  assertions.
+</Warning>
 
-<Info>
-View component auto-generation is currently in development.
-You can generate React components through **Sonamu UI**.
+## View Scaffolding
+
+Admin list and form components can also be generated from the CLI.
 
 ```bash
-# Run Sonamu UI
-pnpm sonamu ui
+# Generate the list screen
+pnpm scaffold view_list
 
-# Generate View in Scaffolding tab
+# Generate the create/edit form
+pnpm scaffold view_form
 ```
 
-</Info>
+**Generated files**:
+
+<FileTree>
+  <FileItem name="web/src/routes/admin/users/">
+    <FileItem name="index.tsx" description="User list screen" />
+    <FileItem name="form.tsx" description="User create/edit form" />
+  </FileItem>
+</FileTree>
+
+<Info>The same generators are available in the Scaffolding tab of **Sonamu UI**.</Info>
 
 ## Generated Code Structure
 
@@ -149,9 +181,6 @@ class UserModelClass extends BaseModelClass<
     super("User", userSubsetQueries, userLoaderQueries);
   }
 
-  // Entity type
-  entity = UserEntity;
-
   // Add methods here
   async findByEmail(email: string): Promise<User | null> {
     return this.getPuri("r").table("users").where("email", email).first();
@@ -162,9 +191,9 @@ class UserModelClass extends BaseModelClass<
 **Auto-generated features**:
 
 - ✅ TypeScript types
-- ✅ Entity connection
-- ✅ BaseModel inheritance
-- ✅ Basic CRUD methods
+- ✅ Subset/Loader query wiring
+- ✅ BaseModelClass inheritance
+- ✅ Basic CRUD methods (`findById`/`findOne`/`findMany`/`save`/`del`)
 
 **You need to add**:
 
@@ -178,17 +207,13 @@ class UserModelClass extends BaseModelClass<
 Generated test files include basic tests:
 
 ```typescript
-describe("User Model", () => {
-  beforeAll(async () => {
-    await FixtureManager.sync(); // Load fixtures
-  });
+import { bootstrap, test } from "sonamu/test";
+import { describe, expect, vi } from "vitest";
 
-  test("findById", async () => {
-    // Basic CRUD test
-  });
-
-  test("findMany", async () => {
-    // List query test
+bootstrap(vi); // Sonamu init + per-test transaction wrapping
+describe.skip("UserModelTest", () => {
+  test("Query", async () => {
+    expect(true).toBe(true);
   });
 });
 ```
@@ -204,17 +229,33 @@ describe("User Model", () => {
 
 ### 1. Define Entity
 
-```typescript title="src/entities/Product.entity.ts"
-export const ProductEntity = {
-  properties: [
-    { name: "id", type: "int", primaryKey: true, autoIncrement: true },
-    { name: "title", type: "string", length: 255 },
-    { name: "price", type: "decimal", precision: 10, scale: 2 },
-    { name: "category_id", type: "int" },
-    { name: "created_at", type: "datetime" },
+```json title="src/application/product/product.entity.json"
+{
+  "id": "Product",
+  "title": "Product",
+  "table": "products",
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
+    { "name": "created_at", "type": "date", "desc": "Created at", "dbDefault": "CURRENT_TIMESTAMP" },
+    { "name": "title", "type": "string", "length": 255, "desc": "Title" },
+    { "name": "price", "type": "numeric", "precision": 10, "scale": 2, "desc": "Price" },
+    {
+      "type": "relation",
+      "name": "category",
+      "relationType": "BelongsToOne",
+      "with": "Category",
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "desc": "Category"
+    }
   ],
-  belongsTo: [{ entityId: "Category", as: "category" }],
-} satisfies EntityType;
+  "indexes": [],
+  "subsets": { "A": ["id", "created_at", "title", "price", "category.id"] },
+  "enums": {
+    "ProductOrderBy": { "id-desc": "Newest" },
+    "ProductSearchField": { "id": "ID", "title": "Title" }
+  }
+}
 ```
 
 ### 2. Migration
@@ -235,7 +276,7 @@ pnpm scaffold model
 
 ### 4. Add Business Logic
 
-```typescript title="src/models/Product.model.ts"
+```typescript title="src/application/product/product.model.ts"
 class ProductModelClass extends BaseModelClass<
   ProductSubsetKey,
   ProductSubsetMapping,
@@ -269,12 +310,14 @@ pnpm scaffold model_test
 
 ### 6. Write Tests
 
-```typescript title="src/models/Product.model.test.ts"
-describe("Product Model", () => {
-  beforeAll(async () => {
-    await FixtureManager.sync();
-  });
+```typescript title="src/application/product/product.model.test.ts"
+import { bootstrap, test } from "sonamu/test";
+import { describe, expect, vi } from "vitest";
 
+import { ProductModel } from "./product.model";
+
+bootstrap(vi);
+describe("ProductModelTest", () => {
   test("findByCategory", async () => {
     const products = await ProductModel.findByCategory(1);
     expect(products.length).toBeGreaterThan(0);
@@ -293,7 +336,7 @@ describe("Product Model", () => {
 
 ### 7. Add API
 
-```typescript title="src/models/Product.model.ts"
+```typescript title="src/application/product/product.model.ts"
 class ProductModelClass extends BaseModelClass {
   @api({ httpMethod: "GET" })
   async findByCategory(categoryId: number) {
@@ -410,19 +453,25 @@ done
 
 ### 1. Complete Entity First
 
-```typescript
+```json
 // ✅ Scaffold after Entity is fully defined
-export const UserEntity = {
-  properties: [
-    // Define all fields
+{
+  "id": "User",
+  "title": "User",
+  "table": "users",
+  "props": [
+    // Define normal and relation props
   ],
-  indexes: [
+  "indexes": [
     // Define indexes
   ],
-  belongsTo: [
-    // Define relations
-  ],
-} satisfies EntityType;
+  "subsets": {
+    // Define response field sets
+  },
+  "enums": {
+    // Define OrderBy / SearchField and friends
+  }
+}
 ```
 
 ### 2. Incremental Extension
@@ -459,8 +508,8 @@ Promise<ListResult<UserListParams, User>> // Pagination
 
 ```bash
 # Commit generated files
-git add src/models/User.model.ts
-git add src/models/User.model.test.ts
+git add src/application/user/user.model.ts
+git add src/application/user/user.model.test.ts
 git commit -m "Add User model and tests"
 ```
 
@@ -474,7 +523,7 @@ git commit -m "Add User model and tests"
 
 ```bash
 # Backup existing file
-cp src/models/User.model.ts src/models/User.model.ts.bak
+cp src/application/user/user.model.ts src/application/user/user.model.ts.bak
 
 # Regenerate
 pnpm scaffold model

--- a/modules/docs/en/tools-and-cli/sonamu-cli/stub.mdx
+++ b/modules/docs/en/tools-and-cli/sonamu-cli/stub.mdx
@@ -88,30 +88,33 @@ pnpm stub entity Product --no-cones
 
 **Generated file**:
 
-```typescript title="src/entities/Product.entity.ts"
-import type { EntityType } from "sonamu";
-
-export const ProductEntity = {
-  properties: [
+```json title="src/application/product/product.entity.json"
+{
+  "id": "Product",
+  "title": "Product",
+  "table": "products",
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
     {
-      name: "id",
-      type: "int",
-      primaryKey: true,
-      autoIncrement: true,
-    },
-    {
-      name: "title",
-      type: "string",
-      length: 255,
-    },
-    {
-      name: "created_at",
-      type: "datetime",
-      default: "CURRENT_TIMESTAMP",
-    },
+      "name": "created_at",
+      "type": "date",
+      "desc": "등록일시",
+      "dbDefault": "CURRENT_TIMESTAMP"
+    }
   ],
-} satisfies EntityType;
+  "indexes": [],
+  "subsets": { "A": ["id", "created_at"] },
+  "enums": {
+    "ProductOrderBy": { "id-desc": "ID최신순" },
+    "ProductSearchField": { "id": "ID" }
+  }
+}
 ```
+
+<Note>
+  The default `desc` labels are emitted in Korean by the generator template. Rewrite them to match
+  your project's locale.
+</Note>
 
 ## Practice Scripts
 
@@ -229,43 +232,71 @@ Sonamu.runScript(async () => {
 
 Entities generated with `stub entity` include basic fields:
 
-```typescript
-export const ProductEntity = {
-  properties: [
-    { name: "id", type: "int", primaryKey: true, autoIncrement: true },
-    { name: "title", type: "string", length: 255 },
-    { name: "created_at", type: "datetime", default: "CURRENT_TIMESTAMP" },
+```json
+{
+  "id": "Product",
+  "title": "Product",
+  "table": "products",
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
+    {
+      "name": "created_at",
+      "type": "date",
+      "desc": "등록일시",
+      "dbDefault": "CURRENT_TIMESTAMP"
+    }
   ],
-} satisfies EntityType;
+  "indexes": [],
+  "subsets": { "A": ["id", "created_at"] },
+  "enums": {
+    "ProductOrderBy": { "id-desc": "ID최신순" },
+    "ProductSearchField": { "id": "ID" }
+  }
+}
 ```
 
 ### Customization
 
 Add needed fields after generation:
 
-```typescript
-export const ProductEntity = {
-  properties: [
-    // Basic fields
-    { name: "id", type: "int", primaryKey: true, autoIncrement: true },
-    { name: "title", type: "string", length: 255 },
-
-    // Additional fields
-    { name: "description", type: "text", nullable: true },
-    { name: "price", type: "decimal", precision: 10, scale: 2 },
-    { name: "stock", type: "int", default: 0 },
-    { name: "category_id", type: "int" },
-
-    // Timestamps
-    { name: "created_at", type: "datetime", default: "CURRENT_TIMESTAMP" },
-    { name: "updated_at", type: "datetime", onUpdate: "CURRENT_TIMESTAMP" },
+```json
+{
+  "id": "Product",
+  "title": "Product",
+  "table": "products",
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
+    { "name": "created_at", "type": "date", "desc": "Created at", "dbDefault": "CURRENT_TIMESTAMP" },
+    { "name": "title", "type": "string", "length": 255, "desc": "Title" },
+    { "name": "description", "type": "string", "nullable": true, "desc": "Description" },
+    { "name": "price", "type": "numeric", "precision": 10, "scale": 2, "desc": "Price" },
+    { "name": "stock", "type": "integer", "desc": "Stock", "dbDefault": 0 },
+    {
+      "type": "relation",
+      "name": "category",
+      "relationType": "BelongsToOne",
+      "with": "Category",
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "desc": "Category"
+    }
   ],
-
-  indexes: [{ fields: ["category_id"] }, { fields: ["title"], type: "fulltext" }],
-
-  belongsTo: [{ entityId: "Category", as: "category" }],
-} satisfies EntityType;
+  "indexes": [
+    { "type": "index", "name": "products_title_index", "columns": [{ "name": "title" }] }
+  ],
+  "subsets": { "A": ["id", "created_at", "title", "price", "category.id"] },
+  "enums": {
+    "ProductOrderBy": { "id-desc": "Newest" },
+    "ProductSearchField": { "id": "ID", "title": "Title" }
+  }
+}
 ```
+
+<Note>
+  FK columns such as `category_id` are created automatically from a `relation` prop when the
+  migration is generated. See [Defining Entities](/en/core-concepts/entity/defining-entities) for
+  the full list of prop types and field rules.
+</Note>
 
 ## Development Workflow
 
@@ -288,7 +319,7 @@ pnpm node -r dotenv/config --enable-source-maps dist/practices/p1-test-idea.js
 pnpm stub entity Order
 
 # Write Entity definition
-# src/entities/Order.entity.ts
+# src/application/order/order.entity.json
 
 # Create and apply migration
 pnpm migrate run

--- a/modules/docs/en/tools-and-cli/sonamu-ui/entity-management.mdx
+++ b/modules/docs/en/tools-and-cli/sonamu-ui/entity-management.mdx
@@ -41,13 +41,12 @@ When the modal opens, enter the following information:
 
 Created Entities include these basic fields by default:
 
-```typescript
+```json
 {
-  properties: [
-    { name: "id", type: "int", primaryKey: true, autoIncrement: true },
-    { name: "title", type: "string", length: 255 },
-    { name: "created_at", type: "datetime", default: "CURRENT_TIMESTAMP" },
-  ];
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
+    { "name": "created_at", "type": "date", "desc": "등록일시", "dbDefault": "CURRENT_TIMESTAMP" }
+  ]
 }
 ```
 
@@ -58,21 +57,26 @@ Created Entities include these basic fields by default:
 1. Click **[+ Add Property]** button
 2. Enter Property information:
 
-| Field        | Required    | Description             | Example                    |
-| ------------ | ----------- | ----------------------- | -------------------------- |
-| **Name**     | ✅          | Field name (snake_case) | `email`, `phone_number`    |
-| **Type**     | ✅          | Data type               | `string`, `int`, `decimal` |
-| **Length**   | Conditional | String length           | `255`                      |
-| **Nullable** |             | Allow NULL              | `true`                     |
-| **Default**  |             | Default value           | `0`, `CURRENT_TIMESTAMP`   |
-| **Comment**  |             | Description             | `User email`               |
+| Field           | Required    | Description             | Example                        |
+| --------------- | ----------- | ----------------------- | ------------------------------ |
+| **Name**        | ✅          | Field name (snake_case) | `email`, `phone_number`        |
+| **Type**        | ✅          | Data type               | `string`, `integer`, `numeric` |
+| **Length**      | Conditional | String length           | `255`                          |
+| **Nullable**    |             | Allow NULL              | `true`                         |
+| **DB Default**  |             | Database default value  | `0`, `CURRENT_TIMESTAMP`       |
+| **Description** |             | Description             | `User email`                   |
 
 **Supported data types**:
 
-- **String**: `string`, `text`, `mediumtext`, `longtext`
-- **Number**: `int`, `bigint`, `float`, `double`, `decimal`
-- **Date**: `date`, `datetime`, `timestamp`
-- **Other**: `boolean`, `json`, `enum`
+- **String**: `string` (falls back to `text` without a length), `uuid`, `searchText`
+- **Number**: `integer`, `bigInteger`, `number`, `numeric` (precision/scale)
+- **Date**: `date`
+- **Other**: `boolean`, `enum`, `json`, `virtual`, `vector`, `tsvector`, `relation`
+
+<Note>
+  Most scalar types also have an array form such as `integer[]` or `string[]`. See [Field
+  Types](/en/core-concepts/entity/field-types) for the full list.
+</Note>
 
 ### Editing a Property
 
@@ -97,28 +101,45 @@ Click the **[×]** button on the Property row.
 2. Click **[+ Add Index]** button
 3. Enter Index information:
 
-| Field      | Description                               | Example                       |
-| ---------- | ----------------------------------------- | ----------------------------- |
-| **Fields** | Index target fields (multiple selectable) | `email`, `created_at`         |
-| **Type**   | Index type                                | `index`, `unique`, `fulltext` |
-| **Where**  | Raw SQL predicate for partial indexes     | `deleted_at IS NULL`          |
+| Field              | Description                               | Example                              |
+| ------------------ | ----------------------------------------- | ------------------------------------ |
+| **Target Columns** | Index target fields (multiple selectable) | `email`, `created_at`                |
+| **Type**           | Index type                                | `index`, `unique`, `hnsw`, `ivfflat` |
+| **Where**          | Raw SQL predicate for partial indexes     | `deleted_at IS NULL`                 |
 
 **Index types**:
 
 - **index**: Regular index (improves search performance)
 - **unique**: Unique index (prevents duplicates)
-- **fulltext**: Full-text search index (text search)
+- **hnsw** / **ivfflat**: pgvector vector indexes
+
+<Note>
+  Full-text search is not a separate index type. Use a `searchText`/`tsvector` prop together with the
+  `using: "gin"` option — see [pgvector
+  setup](/en/advanced-features/vector-search/pgvector-setup).
+</Note>
 
 ### Composite Index
 
 Select multiple fields to create a composite index:
 
-```typescript
-indexes: [
-  { fields: ["user_id", "created_at"], type: "index" },
-  { fields: ["email"], type: "unique" },
-  { fields: ["email"], type: "unique", where: "deleted_at IS NULL" },
-];
+```json
+{
+  "indexes": [
+    {
+      "type": "index",
+      "name": "posts_user_id_created_at_index",
+      "columns": [{ "name": "user_id" }, { "name": "created_at" }]
+    },
+    { "type": "unique", "name": "users_email_unique", "columns": [{ "name": "email" }] },
+    {
+      "type": "unique",
+      "name": "users_email_active_unique",
+      "columns": [{ "name": "email" }],
+      "where": "deleted_at IS NULL"
+    }
+  ]
+}
 ```
 
 `where` is emitted as a PostgreSQL partial index predicate. Treat it as raw SQL: do not build it from
@@ -143,8 +164,16 @@ Example: `Post` belongs to `User`
 
 Generated code:
 
-```typescript
-belongsTo: [{ entityId: "User", as: "author" }];
+```json
+{
+  "type": "relation",
+  "name": "author",
+  "relationType": "BelongsToOne",
+  "with": "User",
+  "onUpdate": "CASCADE",
+  "onDelete": "CASCADE",
+  "desc": "Author"
+}
 ```
 
 ### hasMany (1:N Relationship)
@@ -163,8 +192,15 @@ Example: `User` has multiple `Posts`
 
 Generated code:
 
-```typescript
-hasMany: [{ entityId: "Post", as: "posts" }];
+```json
+{
+  "type": "relation",
+  "name": "posts",
+  "relationType": "HasMany",
+  "with": "Post",
+  "joinColumn": "user_id",
+  "desc": "Posts"
+}
 ```
 
 ## Managing Enums
@@ -176,30 +212,30 @@ Use Enums when a field can only have limited values.
 1. Click **[+ Add Enum]** button in the **Enums** section
 2. Enter Enum information:
 
-| Field      | Description                  | Example              |
-| ---------- | ---------------------------- | -------------------- |
-| **Name**   | Enum name                    | `UserRole`           |
-| **Values** | Value list (comma-separated) | `admin, user, guest` |
+| Field      | Description       | Example                      |
+| ---------- | ----------------- | ---------------------------- |
+| **Name**   | Enum name         | `UserRole`                   |
+| **Values** | Value/label pairs | `admin: Admin`, `user: User` |
 
 Generated code:
 
-```typescript
-enums: [
-  {
-    name: "UserRole",
-    values: ["admin", "user", "guest"],
-  },
-];
+```json
+{
+  "enums": {
+    "UserRole": { "admin": "Admin", "user": "User", "guest": "Guest" }
+  }
+}
 ```
 
 Using in Property:
 
-```typescript
+```json
 {
-  name: "role",
-  type: "enum",
-  enum: "UserRole",
-  default: "user"
+  "name": "role",
+  "type": "enum",
+  "id": "UserRole",
+  "desc": "Role",
+  "dbDefault": "user"
 }
 ```
 
@@ -237,37 +273,51 @@ AI analyzes the existing Entity and applies the modifications.
 
 ### E-commerce Product Entity
 
-```typescript
-export const ProductEntity = {
-  properties: [
-    { name: "id", type: "int", primaryKey: true, autoIncrement: true },
-    { name: "title", type: "string", length: 255 },
-    { name: "description", type: "text", nullable: true },
-    { name: "price", type: "decimal", precision: 10, scale: 2 },
-    { name: "stock", type: "int", default: 0 },
-    { name: "category_id", type: "int" },
-    { name: "status", type: "enum", enum: "ProductStatus" },
-    { name: "created_at", type: "datetime", default: "CURRENT_TIMESTAMP" },
-    { name: "updated_at", type: "datetime", onUpdate: "CURRENT_TIMESTAMP" },
-  ],
-
-  indexes: [
-    { fields: ["category_id"] },
-    { fields: ["title"], type: "fulltext" },
-    { fields: ["status", "created_at"] },
-  ],
-
-  belongsTo: [{ entityId: "Category", as: "category" }],
-
-  hasMany: [{ entityId: "Review", as: "reviews" }],
-
-  enums: [
+```json title="src/application/product/product.entity.json"
+{
+  "id": "Product",
+  "title": "Product",
+  "table": "products",
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
+    { "name": "created_at", "type": "date", "desc": "Created at", "dbDefault": "CURRENT_TIMESTAMP" },
+    { "name": "title", "type": "string", "length": 255, "desc": "Title" },
+    { "name": "description", "type": "string", "nullable": true, "desc": "Description" },
+    { "name": "price", "type": "numeric", "precision": 10, "scale": 2, "desc": "Price" },
+    { "name": "stock", "type": "integer", "desc": "Stock", "dbDefault": 0 },
+    { "name": "status", "type": "enum", "id": "ProductStatus", "desc": "Status" },
     {
-      name: "ProductStatus",
-      values: ["active", "inactive", "soldout"],
+      "type": "relation",
+      "name": "category",
+      "relationType": "BelongsToOne",
+      "with": "Category",
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "desc": "Category"
     },
+    {
+      "type": "relation",
+      "name": "reviews",
+      "relationType": "HasMany",
+      "with": "Review",
+      "joinColumn": "product_id",
+      "desc": "Reviews"
+    }
   ],
-} satisfies EntityType;
+  "indexes": [
+    {
+      "type": "index",
+      "name": "products_status_created_at_index",
+      "columns": [{ "name": "status" }, { "name": "created_at" }]
+    }
+  ],
+  "subsets": { "A": ["id", "created_at", "title", "price", "status", "category.id"] },
+  "enums": {
+    "ProductStatus": { "active": "Active", "inactive": "Inactive", "soldout": "Sold out" },
+    "ProductOrderBy": { "id-desc": "Newest" },
+    "ProductSearchField": { "id": "ID", "title": "Title" }
+  }
+}
 ```
 
 ## Applying Changes
@@ -281,7 +331,7 @@ After modifying an Entity, you need to **create and run a migration** to reflect
 3. **Run Migration**: Run migration to apply to DB
 4. **Scaffolding**: Generate Model and test code
 
-<Info>Entity files (`.entity.ts`) are **automatically saved** when modified in the UI.</Info>
+<Info>Entity files (`.entity.json`) are **automatically saved** when modified in the UI.</Info>
 
 ## Next Steps
 

--- a/modules/docs/en/tools-and-cli/sonamu-ui/scaffolding-tab.mdx
+++ b/modules/docs/en/tools-and-cli/sonamu-ui/scaffolding-tab.mdx
@@ -77,21 +77,28 @@ Click the **[Generate]** button to create the following file:
 import { FileTree, FileItem } from "../../../snippets/FileTree.jsx";
 
 <FileTree>
-  <FileItem name="src/models/">
-    <FileItem name="User.model.ts" description="User Model class" />
+  <FileItem name="src/application/user/">
+    <FileItem name="user.model.ts" description="User Model class" />
   </FileItem>
 </FileTree>
 
 ### Generated Code
 
-```typescript title="src/models/User.model.ts"
-import { BaseModelClass } from "sonamu";
-import type { InferSelectModel } from "sonamu";
-import { UserEntity } from "../entities/User.entity";
-import type { UserSubsetKey, UserSubsetMapping } from "../sonamu.generated";
-import { userLoaderQueries, userSubsetQueries } from "../sonamu.generated.sso";
+```typescript title="src/application/user/user.model.ts"
+import {
+  api,
+  asArray,
+  BadRequestException,
+  BaseModelClass,
+  exhaustive,
+  NotFoundException,
+  type ListResult,
+} from "sonamu";
 
-export type User = InferSelectModel<typeof UserEntity>;
+import { SD } from "../../i18n/sd.generated";
+import { UserSubsetKey, UserSubsetMapping } from "../sonamu.generated";
+import { userLoaderQueries, userSubsetQueries } from "../sonamu.generated.sso";
+import { UserListParams, UserSaveParams } from "./user.types";
 
 class UserModelClass extends BaseModelClass<
   UserSubsetKey,
@@ -103,7 +110,7 @@ class UserModelClass extends BaseModelClass<
     super("User", userSubsetQueries, userLoaderQueries);
   }
 
-  // TODO: Add Model methods
+  // findById / findOne / findMany / save / del are generated with @api decorators
 }
 
 export const UserModel = new UserModelClass();
@@ -136,46 +143,34 @@ Check the **☑ Model Test** checkbox.
 Click the **[Generate]** button to create the following file:
 
 <FileTree>
-  <FileItem name="src/models/">
-    <FileItem name="User.model.test.ts" description="User Model test" />
+  <FileItem name="src/application/user/">
+    <FileItem name="user.model.test.ts" description="User Model test" />
   </FileItem>
 </FileTree>
 
 ### Generated Code
 
-```typescript title="src/models/User.model.test.ts"
-import { beforeAll, describe, test } from "bun:test";
-import { expect } from "@jest/globals";
-import { FixtureManager } from "sonamu/test";
-import { UserModel } from "./User.model";
+```typescript title="src/application/user/user.model.test.ts"
+import { bootstrap, test } from "sonamu/test";
+import { describe, expect, vi } from "vitest";
 
-describe("User Model", () => {
-  beforeAll(async () => {
-    await FixtureManager.sync();
+bootstrap(vi);
+describe.skip("UserModelTest", () => {
+  test("Query", async () => {
+    expect(true).toBe(true);
   });
-
-  test("findById", async () => {
-    const user = await UserModel.findById(1);
-    expect(user).toBeDefined();
-    expect(user?.id).toBe(1);
-  });
-
-  test("findMany", async () => {
-    const users = await UserModel.findMany({
-      num: 10,
-      page: 1,
-    });
-    expect(users.rows.length).toBeGreaterThan(0);
-  });
-
-  // TODO: Add more tests
 });
 ```
 
-**Auto-generated tests**:
+<Warning>
+  The generated test starts as `describe.skip`. Remove `.skip` once you have written real
+  assertions.
+</Warning>
 
-- ✅ `findById`: Query single record by ID
-- ✅ `findMany`: List query (pagination)
+**What is generated**:
+
+- ✅ A `bootstrap(vi)` call (Sonamu init + per-test transaction wrapping)
+- ✅ An empty `describe.skip` block — you write the actual cases
 
 ## Batch Generation
 
@@ -188,12 +183,12 @@ describe("User Model", () => {
 **Result**:
 
 ```
-✓ User.model.ts created
-✓ User.model.test.ts created
-✓ Post.model.ts created
-✓ Post.model.test.ts created
-✓ Comment.model.ts created
-✓ Comment.model.test.ts created
+✓ user.model.ts created
+✓ user.model.test.ts created
+✓ post.model.ts created
+✓ post.model.test.ts created
+✓ comment.model.ts created
+✓ comment.model.test.ts created
 
 6 files generated successfully!
 ```
@@ -230,10 +225,10 @@ For new Entity only when adding:
 ✅ Code Generation Complete
 
 Generated files:
-  ✓ src/models/User.model.ts
-  ✓ src/models/User.model.test.ts
-  ✓ src/models/Post.model.ts
-  ✓ src/models/Post.model.test.ts
+  ✓ src/application/user/user.model.ts
+  ✓ src/application/user/user.model.test.ts
+  ✓ src/application/post/post.model.ts
+  ✓ src/application/post/post.model.test.ts
 
 Total: 4 files
 ```
@@ -246,8 +241,8 @@ When trying to generate files that already exist, a confirmation modal appears:
 ⚠️ Files Already Exist
 
 The following files will be overwritten:
-  • src/models/User.model.ts
-  • src/models/User.model.test.ts
+  • src/application/user/user.model.ts
+  • src/application/user/user.model.test.ts
 
 [Cancel] [Backup & Overwrite] [Overwrite]
 ```
@@ -263,20 +258,19 @@ The following files will be overwritten:
   overwriting customized Models.
 </Warning>
 
-## View Generation (In Development)
+## View Generation
 
-View component auto-generation is currently under development.
+The TemplateKey list on the Scaffolding tab includes View templates in addition to the Model ones.
 
-### Alternative: Use Other Sonamu UI Features
-
-Currently, you can manage Views through these methods:
-
-1. **Entity-based auto-generation**: Basic View templates are provided when creating Entities
-2. **Manual writing**: Write React components directly
-3. **Component library**: Use `@sonamu-kit/react-components`
+| TemplateKey         | Output location                                |
+| ------------------- | ---------------------------------------------- |
+| `view_list`         | `web/src/routes/admin/{entities}/index.tsx`    |
+| `view_form`         | `web/src/routes/admin/{entities}/form.tsx`     |
+| `view_search_input` | Search input component used by the list screen |
 
 <Info>
-  This document will be updated when View List and View Form generation features are added.
+  The same templates are available from the CLI: `pnpm scaffold view_list`, `pnpm scaffold
+  view_form`.
 </Info>
 
 ## Post-Generation Workflow
@@ -285,7 +279,7 @@ Currently, you can manage Views through these methods:
 
 Add business logic to the generated Model:
 
-```typescript title="src/models/User.model.ts"
+```typescript title="src/application/user/user.model.ts"
 class UserModelClass extends BaseModelClass<
   UserSubsetKey,
   UserSubsetMapping,
@@ -312,7 +306,7 @@ class UserModelClass extends BaseModelClass<
 
 Add more tests to the generated test file:
 
-```typescript title="src/models/User.model.test.ts"
+```typescript title="src/application/user/user.model.test.ts"
 describe("User Model - Extended", () => {
   test("findByEmail", async () => {
     const user = await UserModel.findByEmail("user@example.com");
@@ -392,7 +386,7 @@ When Entity structure changes significantly and Model needs regeneration:
 
 ```bash
 # Backup existing file
-cp src/models/User.model.ts src/models/User.model.ts.bak
+cp src/application/user/user.model.ts src/application/user/user.model.ts.bak
 
 # Regenerate in UI
 [Backup & Overwrite]

--- a/modules/docs/ko/core-concepts/model/business-logic.mdx
+++ b/modules/docs/ko/core-concepts/model/business-logic.mdx
@@ -361,39 +361,54 @@ async findMany<T extends UserSubsetKey>(
 ### 복잡한 JOIN
 
 ```typescript
-async findUsersWithStats(): Promise<UserWithStats[]> {
+async findUsersWithStats() {
   const rdb = this.getPuri("r");
 
-  return rdb.knex("users")
-    .select([
-      "users.*",
-      rdb.knex.raw("COUNT(DISTINCT posts.id) as post_count"),
-      rdb.knex.raw("COUNT(DISTINCT comments.id) as comment_count"),
-      rdb.knex.raw("AVG(posts.views) as avg_post_views"),
-    ])
-    .leftJoin("posts", "posts.user_id", "users.id")
-    .leftJoin("comments", "comments.user_id", "users.id")
+  return rdb
+    .table("users")
+    .select({
+      id: "users.id",
+      name: "users.name",
+      // COUNT(DISTINCT ...)는 Puri.count()로 표현할 수 없으므로 rawNumber를 사용합니다
+      post_count: Puri.rawNumber("COUNT(DISTINCT posts.id)"),
+      comment_count: Puri.rawNumber("COUNT(DISTINCT comments.id)"),
+      avg_post_views: Puri.avg("posts.views"),
+    })
+    .leftJoin("posts", "users.id", "posts.user_id")
+    .leftJoin("comments", "users.id", "comments.user_id")
     .groupBy("users.id");
 }
 ```
 
+<Note>
+  Puri의 `join`/`leftJoin`은 첫 번째 컬럼에 **이미 참조 가능한 테이블의 컬럼**을, 두 번째 컬럼에
+  **새로 조인하는 테이블의 컬럼**을 받습니다. Knex와 인자 순서가 반대인 점에 유의하세요.
+</Note>
+
 ### 서브쿼리 활용
 
 ```typescript
-async findTopUsers(limit: number): Promise<User[]> {
+async findTopUsers(limit: number) {
   const rdb = this.getPuri("r");
 
-  const subquery = rdb.knex("orders")
-    .select("user_id")
-    .sum("total_price as total_spent")
-    .groupBy("user_id")
+  const topUsers = rdb
+    .table("orders")
+    .select({
+      user_id: "orders.user_id",
+      total_spent: Puri.sum("orders.total_price"),
+    })
+    .groupBy("orders.user_id")
     .orderBy("total_spent", "desc")
-    .limit(limit)
-    .as("top_users");
+    .limit(limit);
 
-  return rdb.knex("users")
-    .select("users.*", "top_users.total_spent")
-    .joinRaw("JOIN ? ON users.id = top_users.user_id", [subquery]);
+  return rdb
+    .table("users")
+    .join({ top_users: topUsers }, "users.id", "top_users.user_id")
+    .select({
+      id: "users.id",
+      name: "users.name",
+      total_spent: "top_users.total_spent",
+    });
 }
 ```
 

--- a/modules/docs/ko/tools-and-cli/sonamu-cli/scaffold.mdx
+++ b/modules/docs/ko/tools-and-cli/sonamu-cli/scaffold.mdx
@@ -38,22 +38,32 @@ pnpm scaffold model
 import { FileTree, FileItem } from "../../../snippets/FileTree.jsx";
 
 <FileTree>
-  <FileItem name="src/models/">
-    <FileItem name="User.model.ts" description="User Model 클래스" />
+  <FileItem name="src/application/user/">
+    <FileItem name="user.model.ts" description="User Model 클래스" />
   </FileItem>
 </FileTree>
 
 **생성된 코드**:
 
-```typescript title="src/models/User.model.ts"
-import { BaseModelClass } from "sonamu";
-import type { InferSelectModel } from "sonamu";
-import { UserEntity } from "../entities/User.entity";
-import type { UserSubsetKey, UserSubsetMapping } from "../sonamu.generated";
+```typescript title="src/application/user/user.model.ts"
+import {
+  api,
+  asArray,
+  BadRequestException,
+  BaseModelClass,
+  exhaustive,
+  NotFoundException,
+  type ListResult,
+} from "sonamu";
+
+import { SD } from "../../i18n/sd.generated";
+import { UserSubsetKey, UserSubsetMapping } from "../sonamu.generated";
 import { userLoaderQueries, userSubsetQueries } from "../sonamu.generated.sso";
+import { UserListParams, UserSaveParams } from "./user.types";
 
-export type User = InferSelectModel<typeof UserEntity>;
-
+/*
+  User Model
+*/
 class UserModelClass extends BaseModelClass<
   UserSubsetKey,
   UserSubsetMapping,
@@ -64,11 +74,38 @@ class UserModelClass extends BaseModelClass<
     super("User", userSubsetQueries, userLoaderQueries);
   }
 
-  // TODO: Model 메서드 추가
+  @api({ httpMethod: "GET", clients: ["axios", "tanstack-query"], resourceName: "User" })
+  async findById<T extends UserSubsetKey>(subset: T, id: number): Promise<UserSubsetMapping[T]> {
+    // ...
+  }
+
+  @api({ httpMethod: "GET", clients: ["axios", "tanstack-query"], resourceName: "Users" })
+  async findMany<T extends UserSubsetKey, LP extends UserListParams>(
+    subset: T,
+    rawParams?: LP,
+  ): Promise<ListResult<LP, UserSubsetMapping[T]>> {
+    // id / search-keyword / orderBy 처리 후 executeSubsetQuery
+  }
+
+  @api({ httpMethod: "POST", clients: ["axios", "tanstack-mutation"] })
+  async save(spa: UserSaveParams[]): Promise<number[]> {
+    // ubRegister + transaction(ubUpsert)
+  }
+
+  @api({ httpMethod: "POST", clients: ["axios", "tanstack-mutation"], guards: ["admin"] })
+  async del(ids: number[]): Promise<number> {
+    // ...
+  }
 }
 
 export const UserModel = new UserModelClass();
 ```
+
+<Note>
+  실제 생성물에는 `findById`/`findOne`/`findMany`/`save`/`del`의 본문이 모두 채워져 있습니다. 위
+  예제는 지면상 본문을 생략한 것입니다. PK 타입이 문자열인 Entity라면 `id` 타입은 `string`으로
+  생성됩니다.
+</Note>
 
 ### model_test - 테스트 파일 생성
 
@@ -81,56 +118,52 @@ pnpm scaffold model_test
 **생성되는 파일**:
 
 <FileTree>
-  <FileItem name="src/models/">
-    <FileItem name="User.model.test.ts" description="User Model 테스트" />
+  <FileItem name="src/application/user/">
+    <FileItem name="user.model.test.ts" description="User Model 테스트" />
   </FileItem>
 </FileTree>
 
 **생성된 코드**:
 
-```typescript title="src/models/User.model.test.ts"
-import { beforeAll, describe, test } from "bun:test";
-import { expect } from "@jest/globals";
-import { FixtureManager } from "sonamu/test";
-import { UserModel } from "./User.model";
+```typescript title="src/application/user/user.model.test.ts"
+import { bootstrap, test } from "sonamu/test";
+import { describe, expect, vi } from "vitest";
 
-describe("User Model", () => {
-  beforeAll(async () => {
-    await FixtureManager.sync();
+bootstrap(vi);
+describe.skip("UserModelTest", () => {
+  test("Query", async () => {
+    expect(true).toBe(true);
   });
-
-  test("findById", async () => {
-    const user = await UserModel.findById(1);
-    expect(user).toBeDefined();
-    expect(user?.id).toBe(1);
-  });
-
-  test("findMany", async () => {
-    const users = await UserModel.findMany({
-      num: 10,
-      page: 1,
-    });
-    expect(users.rows.length).toBeGreaterThan(0);
-  });
-
-  // TODO: 추가 테스트 작성
 });
 ```
 
-## View 스캐폴딩 (개발 중)
+<Warning>
+  생성된 테스트는 `describe.skip`으로 시작합니다. 실제 테스트를 작성한 뒤 `.skip`을 제거해야
+  실행됩니다.
+</Warning>
 
-<Info>
-View 컴포넌트 자동 생성 기능은 현재 개발 중입니다. 
-**Sonamu UI**를 통해 React 컴포넌트를 생성할 수 있습니다.
+## View 스캐폴딩
+
+Admin 화면의 목록/폼 컴포넌트도 CLI로 생성할 수 있습니다.
 
 ```bash
-# Sonamu UI 실행
-pnpm sonamu ui
+# 목록 화면 생성
+pnpm scaffold view_list
 
-# Scaffolding 탭에서 View 생성
+# 등록/수정 폼 생성
+pnpm scaffold view_form
 ```
 
-</Info>
+**생성되는 파일**:
+
+<FileTree>
+  <FileItem name="web/src/routes/admin/users/">
+    <FileItem name="index.tsx" description="User 목록 화면" />
+    <FileItem name="form.tsx" description="User 등록/수정 폼" />
+  </FileItem>
+</FileTree>
+
+<Info>동일한 기능을 **Sonamu UI**의 Scaffolding 탭에서도 사용할 수 있습니다.</Info>
 
 ## 생성된 코드 구조
 
@@ -149,9 +182,6 @@ class UserModelClass extends BaseModelClass<
     super("User", userSubsetQueries, userLoaderQueries);
   }
 
-  // Entity 타입
-  entity = UserEntity;
-
   // 메서드 추가 위치
   async findByEmail(email: string): Promise<User | null> {
     return this.getPuri("r").table("users").where("email", email).first();
@@ -162,9 +192,9 @@ class UserModelClass extends BaseModelClass<
 **자동 생성되는 기능**:
 
 - ✅ TypeScript 타입
-- ✅ Entity 연결
-- ✅ BaseModel 상속
-- ✅ 기본 CRUD 메서드
+- ✅ Subset/Loader 쿼리 연결
+- ✅ BaseModelClass 상속
+- ✅ 기본 CRUD 메서드(`findById`/`findOne`/`findMany`/`save`/`del`)
 
 **직접 추가해야 하는 것**:
 
@@ -178,17 +208,13 @@ class UserModelClass extends BaseModelClass<
 생성된 테스트 파일은 기본 테스트를 포함합니다:
 
 ```typescript
-describe("User Model", () => {
-  beforeAll(async () => {
-    await FixtureManager.sync(); // Fixture 로드
-  });
+import { bootstrap, test } from "sonamu/test";
+import { describe, expect, vi } from "vitest";
 
-  test("findById", async () => {
-    // 기본 CRUD 테스트
-  });
-
-  test("findMany", async () => {
-    // 목록 조회 테스트
+bootstrap(vi); // Sonamu 초기화 + 테스트별 트랜잭션 래핑
+describe.skip("UserModelTest", () => {
+  test("Query", async () => {
+    expect(true).toBe(true);
   });
 });
 ```
@@ -204,17 +230,38 @@ describe("User Model", () => {
 
 ### 1. Entity 정의
 
-```typescript title="src/entities/Product.entity.ts"
-export const ProductEntity = {
-  properties: [
-    { name: "id", type: "int", primaryKey: true, autoIncrement: true },
-    { name: "title", type: "string", length: 255 },
-    { name: "price", type: "decimal", precision: 10, scale: 2 },
-    { name: "category_id", type: "int" },
-    { name: "created_at", type: "datetime" },
+```json title="src/application/product/product.entity.json"
+{
+  "id": "Product",
+  "title": "상품",
+  "table": "products",
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
+    {
+      "name": "created_at",
+      "type": "date",
+      "desc": "등록일시",
+      "dbDefault": "CURRENT_TIMESTAMP"
+    },
+    { "name": "title", "type": "string", "length": 255, "desc": "상품명" },
+    { "name": "price", "type": "numeric", "precision": 10, "scale": 2, "desc": "가격" },
+    {
+      "type": "relation",
+      "name": "category",
+      "relationType": "BelongsToOne",
+      "with": "Category",
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "desc": "카테고리"
+    }
   ],
-  belongsTo: [{ entityId: "Category", as: "category" }],
-} satisfies EntityType;
+  "indexes": [],
+  "subsets": { "A": ["id", "created_at", "title", "price", "category.id"] },
+  "enums": {
+    "ProductOrderBy": { "id-desc": "ID최신순" },
+    "ProductSearchField": { "id": "ID", "title": "상품명" }
+  }
+}
 ```
 
 ### 2. 마이그레이션
@@ -235,7 +282,7 @@ pnpm scaffold model
 
 ### 4. 비즈니스 로직 추가
 
-```typescript title="src/models/Product.model.ts"
+```typescript title="src/application/product/product.model.ts"
 class ProductModelClass extends BaseModelClass<
   ProductSubsetKey,
   ProductSubsetMapping,
@@ -269,12 +316,14 @@ pnpm scaffold model_test
 
 ### 6. 테스트 작성
 
-```typescript title="src/models/Product.model.test.ts"
-describe("Product Model", () => {
-  beforeAll(async () => {
-    await FixtureManager.sync();
-  });
+```typescript title="src/application/product/product.model.test.ts"
+import { bootstrap, test } from "sonamu/test";
+import { describe, expect, vi } from "vitest";
 
+import { ProductModel } from "./product.model";
+
+bootstrap(vi);
+describe("ProductModelTest", () => {
   test("findByCategory", async () => {
     const products = await ProductModel.findByCategory(1);
     expect(products.length).toBeGreaterThan(0);
@@ -293,7 +342,7 @@ describe("Product Model", () => {
 
 ### 7. API 추가
 
-```typescript title="src/models/Product.model.ts"
+```typescript title="src/application/product/product.model.ts"
 class ProductModelClass extends BaseModelClass {
   @api({ httpMethod: "GET" })
   async findByCategory(categoryId: number) {
@@ -410,19 +459,25 @@ done
 
 ### 1. Entity 먼저 완성하기
 
-```typescript
+```json
 // ✅ Entity를 완전히 정의한 후 scaffold
-export const UserEntity = {
-  properties: [
-    // 모든 필드 정의
+{
+  "id": "User",
+  "title": "사용자",
+  "table": "users",
+  "props": [
+    // 일반 필드와 relation 필드 정의
   ],
-  indexes: [
+  "indexes": [
     // 인덱스 정의
   ],
-  belongsTo: [
-    // 관계 정의
-  ],
-} satisfies EntityType;
+  "subsets": {
+    // 응답 필드 조합 정의
+  },
+  "enums": {
+    // OrderBy / SearchField 등 정의
+  }
+}
 ```
 
 ### 2. 점진적 확장
@@ -459,8 +514,8 @@ Promise<ListResult<UserListParams, User>> // 페이지네이션
 
 ```bash
 # 생성된 파일 커밋
-git add src/models/User.model.ts
-git add src/models/User.model.test.ts
+git add src/application/user/user.model.ts
+git add src/application/user/user.model.test.ts
 git commit -m "Add User model and tests"
 ```
 
@@ -474,7 +529,7 @@ git commit -m "Add User model and tests"
 
 ```bash
 # 기존 파일 백업
-cp src/models/User.model.ts src/models/User.model.ts.bak
+cp src/application/user/user.model.ts src/application/user/user.model.ts.bak
 
 # 재생성
 pnpm scaffold model

--- a/modules/docs/ko/tools-and-cli/sonamu-cli/stub.mdx
+++ b/modules/docs/ko/tools-and-cli/sonamu-cli/stub.mdx
@@ -88,29 +88,27 @@ pnpm stub entity Product --no-cones
 
 **생성된 파일**:
 
-```typescript title="src/entities/Product.entity.ts"
-import type { EntityType } from "sonamu";
-
-export const ProductEntity = {
-  properties: [
+```json title="src/application/product/product.entity.json"
+{
+  "id": "Product",
+  "title": "Product",
+  "table": "products",
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
     {
-      name: "id",
-      type: "int",
-      primaryKey: true,
-      autoIncrement: true,
-    },
-    {
-      name: "title",
-      type: "string",
-      length: 255,
-    },
-    {
-      name: "created_at",
-      type: "datetime",
-      default: "CURRENT_TIMESTAMP",
-    },
+      "name": "created_at",
+      "type": "date",
+      "desc": "등록일시",
+      "dbDefault": "CURRENT_TIMESTAMP"
+    }
   ],
-} satisfies EntityType;
+  "indexes": [],
+  "subsets": { "A": ["id", "created_at"] },
+  "enums": {
+    "ProductOrderBy": { "id-desc": "ID최신순" },
+    "ProductSearchField": { "id": "ID" }
+  }
+}
 ```
 
 ## Practice 스크립트
@@ -229,43 +227,76 @@ Sonamu.runScript(async () => {
 
 `stub entity`로 생성된 Entity는 기본 필드들을 포함합니다:
 
-```typescript
-export const ProductEntity = {
-  properties: [
-    { name: "id", type: "int", primaryKey: true, autoIncrement: true },
-    { name: "title", type: "string", length: 255 },
-    { name: "created_at", type: "datetime", default: "CURRENT_TIMESTAMP" },
+```json
+{
+  "id": "Product",
+  "title": "Product",
+  "table": "products",
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
+    {
+      "name": "created_at",
+      "type": "date",
+      "desc": "등록일시",
+      "dbDefault": "CURRENT_TIMESTAMP"
+    }
   ],
-} satisfies EntityType;
+  "indexes": [],
+  "subsets": { "A": ["id", "created_at"] },
+  "enums": {
+    "ProductOrderBy": { "id-desc": "ID최신순" },
+    "ProductSearchField": { "id": "ID" }
+  }
+}
 ```
 
 ### 커스터마이징
 
 생성 후 필요한 필드를 추가합니다:
 
-```typescript
-export const ProductEntity = {
-  properties: [
-    // 기본 필드
-    { name: "id", type: "int", primaryKey: true, autoIncrement: true },
-    { name: "title", type: "string", length: 255 },
-
-    // 추가 필드
-    { name: "description", type: "text", nullable: true },
-    { name: "price", type: "decimal", precision: 10, scale: 2 },
-    { name: "stock", type: "int", default: 0 },
-    { name: "category_id", type: "int" },
-
-    // 타임스탬프
-    { name: "created_at", type: "datetime", default: "CURRENT_TIMESTAMP" },
-    { name: "updated_at", type: "datetime", onUpdate: "CURRENT_TIMESTAMP" },
+```json
+{
+  "id": "Product",
+  "title": "Product",
+  "table": "products",
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
+    {
+      "name": "created_at",
+      "type": "date",
+      "desc": "등록일시",
+      "dbDefault": "CURRENT_TIMESTAMP"
+    },
+    { "name": "title", "type": "string", "length": 255, "desc": "상품명" },
+    { "name": "description", "type": "string", "nullable": true, "desc": "설명" },
+    { "name": "price", "type": "numeric", "precision": 10, "scale": 2, "desc": "가격" },
+    { "name": "stock", "type": "integer", "desc": "재고", "dbDefault": 0 },
+    {
+      "type": "relation",
+      "name": "category",
+      "relationType": "BelongsToOne",
+      "with": "Category",
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "desc": "카테고리"
+    }
   ],
-
-  indexes: [{ fields: ["category_id"] }, { fields: ["title"], type: "fulltext" }],
-
-  belongsTo: [{ entityId: "Category", as: "category" }],
-} satisfies EntityType;
+  "indexes": [
+    { "type": "index", "name": "products_title_index", "columns": [{ "name": "title" }] }
+  ],
+  "subsets": { "A": ["id", "created_at", "title", "price", "category.id"] },
+  "enums": {
+    "ProductOrderBy": { "id-desc": "ID최신순" },
+    "ProductSearchField": { "id": "ID", "title": "상품명" }
+  }
+}
 ```
+
+<Note>
+  `category_id` 같은 FK 컬럼은 `relation` prop으로 정의하면 마이그레이션 생성 시 자동으로
+  만들어집니다. Entity의 prop 타입과 필드 규칙은
+  [Entity 정의하기](/ko/core-concepts/entity/defining-entities)를 참고하세요.
+</Note>
 
 ## 개발 워크플로우
 
@@ -288,7 +319,7 @@ pnpm node -r dotenv/config --enable-source-maps dist/practices/p1-test-idea.js
 pnpm stub entity Order
 
 # Entity 정의 작성
-# src/entities/Order.entity.ts
+# src/application/order/order.entity.json
 
 # 마이그레이션 생성 및 적용
 pnpm migrate run

--- a/modules/docs/ko/tools-and-cli/sonamu-ui/entity-management.mdx
+++ b/modules/docs/ko/tools-and-cli/sonamu-ui/entity-management.mdx
@@ -40,13 +40,12 @@ Entity 탭은 두 가지 주요 영역으로 구성됩니다:
 
 생성된 Entity는 기본적으로 다음 필드를 포함합니다:
 
-```typescript
+```json
 {
-  properties: [
-    { name: "id", type: "int", primaryKey: true, autoIncrement: true },
-    { name: "title", type: "string", length: 255 },
-    { name: "created_at", type: "datetime", default: "CURRENT_TIMESTAMP" },
-  ];
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
+    { "name": "created_at", "type": "date", "desc": "등록일시", "dbDefault": "CURRENT_TIMESTAMP" }
+  ]
 }
 ```
 
@@ -57,21 +56,26 @@ Entity 탭은 두 가지 주요 영역으로 구성됩니다:
 1. **[+ Add Property]** 버튼 클릭
 2. Property 정보 입력:
 
-| 필드         | 필수   | 설명                | 예시                       |
-| ------------ | ------ | ------------------- | -------------------------- |
-| **Name**     | ✅     | 필드명 (snake_case) | `email`, `phone_number`    |
-| **Type**     | ✅     | 데이터 타입         | `string`, `int`, `decimal` |
-| **Length**   | 조건부 | 문자열 길이         | `255`                      |
-| **Nullable** |        | NULL 허용 여부      | `true`                     |
-| **Default**  |        | 기본값              | `0`, `CURRENT_TIMESTAMP`   |
-| **Comment**  |        | 설명                | `사용자 이메일`            |
+| 필드            | 필수   | 설명                | 예시                           |
+| --------------- | ------ | ------------------- | ------------------------------ |
+| **Name**        | ✅     | 필드명 (snake_case) | `email`, `phone_number`        |
+| **Type**        | ✅     | 데이터 타입         | `string`, `integer`, `numeric` |
+| **Length**      | 조건부 | 문자열 길이         | `255`                          |
+| **Nullable**    |        | NULL 허용 여부      | `true`                         |
+| **DB Default**  |        | DB 기본값           | `0`, `CURRENT_TIMESTAMP`       |
+| **Description** |        | 설명                | `사용자 이메일`                |
 
 **지원하는 데이터 타입**:
 
-- **문자열**: `string`, `text`, `mediumtext`, `longtext`
-- **숫자**: `int`, `bigint`, `float`, `double`, `decimal`
-- **날짜**: `date`, `datetime`, `timestamp`
-- **기타**: `boolean`, `json`, `enum`
+- **문자열**: `string`(길이 미지정 시 `text`), `uuid`, `searchText`
+- **숫자**: `integer`, `bigInteger`, `number`, `numeric`(precision/scale)
+- **날짜**: `date`
+- **기타**: `boolean`, `enum`, `json`, `virtual`, `vector`, `tsvector`, `relation`
+
+<Note>
+  대부분의 스칼라 타입은 `integer[]`, `string[]`처럼 `[]`를 붙인 배열 타입도 지원합니다. 전체 목록은
+  [필드 타입](/ko/core-concepts/entity/field-types) 문서를 참고하세요.
+</Note>
 
 ### Property 수정
 
@@ -96,26 +100,37 @@ Property 행의 **[×]** 버튼을 클릭합니다.
 2. **[+ Add Index]** 버튼 클릭
 3. Index 정보 입력:
 
-| 필드       | 설명                              | 예시                          |
-| ---------- | --------------------------------- | ----------------------------- |
-| **Fields** | 인덱스 대상 필드 (복수 선택 가능) | `email`, `created_at`         |
-| **Type**   | 인덱스 타입                       | `index`, `unique`, `fulltext` |
+| 필드               | 설명                              | 예시                                 |
+| ------------------ | --------------------------------- | ------------------------------------ |
+| **Target Columns** | 인덱스 대상 필드 (복수 선택 가능) | `email`, `created_at`                |
+| **Type**           | 인덱스 타입                       | `index`, `unique`, `hnsw`, `ivfflat` |
 
 **Index 타입**:
 
 - **index**: 일반 인덱스 (검색 성능 향상)
 - **unique**: 유니크 인덱스 (중복 방지)
-- **fulltext**: 전문 검색 인덱스 (텍스트 검색)
+- **hnsw** / **ivfflat**: pgvector 벡터 인덱스
+
+<Note>
+  전문 검색은 별도의 인덱스 타입이 아니라 `searchText`/`tsvector` prop과 `using: "gin"` 옵션으로
+  구성합니다. [벡터 검색](/ko/advanced-features/vector-search/pgvector-setup) 문서를 참고하세요.
+</Note>
 
 ### 복합 Index
 
 여러 필드를 선택하여 복합 인덱스를 생성할 수 있습니다:
 
-```typescript
-indexes: [
-  { fields: ["user_id", "created_at"], type: "index" },
-  { fields: ["email"], type: "unique" },
-];
+```json
+{
+  "indexes": [
+    {
+      "type": "index",
+      "name": "posts_user_id_created_at_index",
+      "columns": [{ "name": "user_id" }, { "name": "created_at" }]
+    },
+    { "type": "unique", "name": "users_email_unique", "columns": [{ "name": "email" }] }
+  ]
+}
 ```
 
 ## Relations 관리
@@ -137,8 +152,16 @@ indexes: [
 
 생성되는 코드:
 
-```typescript
-belongsTo: [{ entityId: "User", as: "author" }];
+```json
+{
+  "type": "relation",
+  "name": "author",
+  "relationType": "BelongsToOne",
+  "with": "User",
+  "onUpdate": "CASCADE",
+  "onDelete": "CASCADE",
+  "desc": "작성자"
+}
 ```
 
 ### hasMany (1:N 관계)
@@ -157,8 +180,15 @@ belongsTo: [{ entityId: "User", as: "author" }];
 
 생성되는 코드:
 
-```typescript
-hasMany: [{ entityId: "Post", as: "posts" }];
+```json
+{
+  "type": "relation",
+  "name": "posts",
+  "relationType": "HasMany",
+  "with": "Post",
+  "joinColumn": "user_id",
+  "desc": "게시글목록"
+}
 ```
 
 ## Enums 관리
@@ -170,30 +200,30 @@ hasMany: [{ entityId: "Post", as: "posts" }];
 1. **Enums** 섹션의 **[+ Add Enum]** 버튼 클릭
 2. Enum 정보 입력:
 
-| 필드       | 설명                  | 예시                 |
-| ---------- | --------------------- | -------------------- |
-| **Name**   | Enum 이름             | `UserRole`           |
-| **Values** | 값 목록 (쉼표로 구분) | `admin, user, guest` |
+| 필드       | 설명             | 예시                          |
+| ---------- | ---------------- | ----------------------------- |
+| **Name**   | Enum 이름        | `UserRole`                    |
+| **Values** | 값과 레이블의 쌍 | `admin: 관리자`, `user: 일반` |
 
 생성되는 코드:
 
-```typescript
-enums: [
-  {
-    name: "UserRole",
-    values: ["admin", "user", "guest"],
-  },
-];
+```json
+{
+  "enums": {
+    "UserRole": { "admin": "관리자", "user": "일반", "guest": "게스트" }
+  }
+}
 ```
 
 Property에서 사용:
 
-```typescript
+```json
 {
-  name: "role",
-  type: "enum",
-  enum: "UserRole",
-  default: "user"
+  "name": "role",
+  "type": "enum",
+  "id": "UserRole",
+  "desc": "권한",
+  "dbDefault": "user"
 }
 ```
 
@@ -231,37 +261,56 @@ AI가 기존 Entity를 분석하고 수정 사항을 적용합니다.
 
 ### 전자상거래 Product Entity
 
-```typescript
-export const ProductEntity = {
-  properties: [
-    { name: "id", type: "int", primaryKey: true, autoIncrement: true },
-    { name: "title", type: "string", length: 255 },
-    { name: "description", type: "text", nullable: true },
-    { name: "price", type: "decimal", precision: 10, scale: 2 },
-    { name: "stock", type: "int", default: 0 },
-    { name: "category_id", type: "int" },
-    { name: "status", type: "enum", enum: "ProductStatus" },
-    { name: "created_at", type: "datetime", default: "CURRENT_TIMESTAMP" },
-    { name: "updated_at", type: "datetime", onUpdate: "CURRENT_TIMESTAMP" },
-  ],
-
-  indexes: [
-    { fields: ["category_id"] },
-    { fields: ["title"], type: "fulltext" },
-    { fields: ["status", "created_at"] },
-  ],
-
-  belongsTo: [{ entityId: "Category", as: "category" }],
-
-  hasMany: [{ entityId: "Review", as: "reviews" }],
-
-  enums: [
+```json title="src/application/product/product.entity.json"
+{
+  "id": "Product",
+  "title": "상품",
+  "table": "products",
+  "props": [
+    { "name": "id", "type": "integer", "desc": "ID" },
     {
-      name: "ProductStatus",
-      values: ["active", "inactive", "soldout"],
+      "name": "created_at",
+      "type": "date",
+      "desc": "등록일시",
+      "dbDefault": "CURRENT_TIMESTAMP"
     },
+    { "name": "title", "type": "string", "length": 255, "desc": "상품명" },
+    { "name": "description", "type": "string", "nullable": true, "desc": "설명" },
+    { "name": "price", "type": "numeric", "precision": 10, "scale": 2, "desc": "가격" },
+    { "name": "stock", "type": "integer", "desc": "재고", "dbDefault": 0 },
+    { "name": "status", "type": "enum", "id": "ProductStatus", "desc": "상태" },
+    {
+      "type": "relation",
+      "name": "category",
+      "relationType": "BelongsToOne",
+      "with": "Category",
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "desc": "카테고리"
+    },
+    {
+      "type": "relation",
+      "name": "reviews",
+      "relationType": "HasMany",
+      "with": "Review",
+      "joinColumn": "product_id",
+      "desc": "리뷰목록"
+    }
   ],
-} satisfies EntityType;
+  "indexes": [
+    {
+      "type": "index",
+      "name": "products_status_created_at_index",
+      "columns": [{ "name": "status" }, { "name": "created_at" }]
+    }
+  ],
+  "subsets": { "A": ["id", "created_at", "title", "price", "status", "category.id"] },
+  "enums": {
+    "ProductStatus": { "active": "판매중", "inactive": "판매중지", "soldout": "품절" },
+    "ProductOrderBy": { "id-desc": "ID최신순" },
+    "ProductSearchField": { "id": "ID", "title": "상품명" }
+  }
+}
 ```
 
 ## 변경사항 적용
@@ -275,7 +324,7 @@ Entity를 수정한 후에는 **마이그레이션을 생성하고 실행**해�
 3. **Migration 실행**: 마이그레이션 실행하여 DB 반영
 4. **Scaffolding**: Model과 테스트 코드 생성
 
-<Info>Entity 파일(`.entity.ts`)은 UI에서 수정 시 **자동으로 저장**됩니다.</Info>
+<Info>Entity 파일(`.entity.json`)은 UI에서 수정 시 **자동으로 저장**됩니다.</Info>
 
 ## 다음 단계
 

--- a/modules/docs/ko/tools-and-cli/sonamu-ui/scaffolding-tab.mdx
+++ b/modules/docs/ko/tools-and-cli/sonamu-ui/scaffolding-tab.mdx
@@ -77,21 +77,28 @@ Scaffolding 탭은 두 가지 주요 영역으로 구성됩니다:
 import { FileTree, FileItem } from "../../../snippets/FileTree.jsx";
 
 <FileTree>
-  <FileItem name="src/models/">
-    <FileItem name="User.model.ts" description="User Model 클래스" />
+  <FileItem name="src/application/user/">
+    <FileItem name="user.model.ts" description="User Model 클래스" />
   </FileItem>
 </FileTree>
 
 ### 생성된 코드
 
-```typescript title="src/models/User.model.ts"
-import { BaseModelClass } from "sonamu";
-import type { InferSelectModel } from "sonamu";
-import { UserEntity } from "../entities/User.entity";
-import type { UserSubsetKey, UserSubsetMapping } from "../sonamu.generated";
-import { userLoaderQueries, userSubsetQueries } from "../sonamu.generated.sso";
+```typescript title="src/application/user/user.model.ts"
+import {
+  api,
+  asArray,
+  BadRequestException,
+  BaseModelClass,
+  exhaustive,
+  NotFoundException,
+  type ListResult,
+} from "sonamu";
 
-export type User = InferSelectModel<typeof UserEntity>;
+import { SD } from "../../i18n/sd.generated";
+import { UserSubsetKey, UserSubsetMapping } from "../sonamu.generated";
+import { userLoaderQueries, userSubsetQueries } from "../sonamu.generated.sso";
+import { UserListParams, UserSaveParams } from "./user.types";
 
 class UserModelClass extends BaseModelClass<
   UserSubsetKey,
@@ -103,7 +110,7 @@ class UserModelClass extends BaseModelClass<
     super("User", userSubsetQueries, userLoaderQueries);
   }
 
-  // TODO: Model 메서드 추가
+  // findById / findOne / findMany / save / del 이 @api 데코레이터와 함께 생성됩니다
 }
 
 export const UserModel = new UserModelClass();
@@ -135,46 +142,34 @@ Model과 동일하게 Entity를 선택합니다.
 **[Generate]** 버튼을 클릭하면 다음 파일이 생성됩니다:
 
 <FileTree>
-  <FileItem name="src/models/">
-    <FileItem name="User.model.test.ts" description="User Model 테스트" />
+  <FileItem name="src/application/user/">
+    <FileItem name="user.model.test.ts" description="User Model 테스트" />
   </FileItem>
 </FileTree>
 
 ### 생성된 코드
 
-```typescript title="src/models/User.model.test.ts"
-import { beforeAll, describe, test } from "bun:test";
-import { expect } from "@jest/globals";
-import { FixtureManager } from "sonamu/test";
-import { UserModel } from "./User.model";
+```typescript title="src/application/user/user.model.test.ts"
+import { bootstrap, test } from "sonamu/test";
+import { describe, expect, vi } from "vitest";
 
-describe("User Model", () => {
-  beforeAll(async () => {
-    await FixtureManager.sync();
+bootstrap(vi);
+describe.skip("UserModelTest", () => {
+  test("Query", async () => {
+    expect(true).toBe(true);
   });
-
-  test("findById", async () => {
-    const user = await UserModel.findById(1);
-    expect(user).toBeDefined();
-    expect(user?.id).toBe(1);
-  });
-
-  test("findMany", async () => {
-    const users = await UserModel.findMany({
-      num: 10,
-      page: 1,
-    });
-    expect(users.rows.length).toBeGreaterThan(0);
-  });
-
-  // TODO: 추가 테스트 작성
 });
 ```
 
-**자동 생성되는 테스트**:
+<Warning>
+  생성된 테스트는 `describe.skip`으로 시작합니다. 실제 테스트를 작성한 뒤 `.skip`을 제거해야
+  실행됩니다.
+</Warning>
 
-- ✅ `findById`: ID로 단일 레코드 조회
-- ✅ `findMany`: 목록 조회 (페이지네이션)
+**자동 생성되는 것**:
+
+- ✅ `bootstrap(vi)` 호출 (Sonamu 초기화 + 테스트별 트랜잭션 래핑)
+- ✅ 비어 있는 `describe.skip` 블록 (테스트 케이스는 직접 작성)
 
 ## 일괄 생성
 
@@ -187,12 +182,12 @@ describe("User Model", () => {
 **결과**:
 
 ```
-✓ User.model.ts created
-✓ User.model.test.ts created
-✓ Post.model.ts created
-✓ Post.model.test.ts created
-✓ Comment.model.ts created
-✓ Comment.model.test.ts created
+✓ user.model.ts created
+✓ user.model.test.ts created
+✓ post.model.ts created
+✓ post.model.test.ts created
+✓ comment.model.ts created
+✓ comment.model.test.ts created
 
 6 files generated successfully!
 ```
@@ -229,10 +224,10 @@ describe("User Model", () => {
 ✅ Code Generation Complete
 
 Generated files:
-  ✓ src/models/User.model.ts
-  ✓ src/models/User.model.test.ts
-  ✓ src/models/Post.model.ts
-  ✓ src/models/Post.model.test.ts
+  ✓ src/application/user/user.model.ts
+  ✓ src/application/user/user.model.test.ts
+  ✓ src/application/post/post.model.ts
+  ✓ src/application/post/post.model.test.ts
 
 Total: 4 files
 ```
@@ -245,8 +240,8 @@ Total: 4 files
 ⚠️ Files Already Exist
 
 The following files will be overwritten:
-  • src/models/User.model.ts
-  • src/models/User.model.test.ts
+  • src/application/user/user.model.ts
+  • src/application/user/user.model.test.ts
 
 [Cancel] [Backup & Overwrite] [Overwrite]
 ```
@@ -262,19 +257,20 @@ The following files will be overwritten:
   Model은 백업하거나 덮어쓰기를 피하세요.
 </Warning>
 
-## View 생성 (개발 중)
+## View 생성
 
-View 컴포넌트 자동 생성 기능은 현재 개발 중입니다.
+Scaffolding 탭의 TemplateKey 목록에는 Model 외에 View 템플릿도 포함되어 있습니다.
 
-### 대안: Sonamu UI의 다른 기능 사용
+| TemplateKey         | 생성 위치                                   |
+| ------------------- | ------------------------------------------- |
+| `view_list`         | `web/src/routes/admin/{entities}/index.tsx` |
+| `view_form`         | `web/src/routes/admin/{entities}/form.tsx`  |
+| `view_search_input` | 목록 화면에서 사용하는 검색 입력 컴포넌트   |
 
-현재는 다음 방법으로 View를 관리할 수 있습니다:
-
-1. **Entity 기반 자동 생성**: Entity를 생성하면 기본 View 템플릿이 제공됩니다
-2. **수동 작성**: React 컴포넌트를 직접 작성합니다
-3. **컴포넌트 라이브러리**: `@sonamu-kit/react-components` 활용
-
-<Info>View List와 View Form 생성 기능이 추가되면 이 문서가 업데이트됩니다.</Info>
+<Info>
+  동일한 템플릿을 CLI에서도 사용할 수 있습니다: `pnpm scaffold view_list`, `pnpm scaffold
+  view_form`.
+</Info>
 
 ## 생성 후 워크플로우
 
@@ -282,7 +278,7 @@ View 컴포넌트 자동 생성 기능은 현재 개발 중입니다.
 
 생성된 Model에 비즈니스 로직을 추가합니다:
 
-```typescript title="src/models/User.model.ts"
+```typescript title="src/application/user/user.model.ts"
 class UserModelClass extends BaseModelClass<
   UserSubsetKey,
   UserSubsetMapping,
@@ -309,7 +305,7 @@ class UserModelClass extends BaseModelClass<
 
 생성된 테스트 파일에 추가 테스트를 작성합니다:
 
-```typescript title="src/models/User.model.test.ts"
+```typescript title="src/application/user/user.model.test.ts"
 describe("User Model - Extended", () => {
   test("findByEmail", async () => {
     const user = await UserModel.findByEmail("user@example.com");
@@ -389,7 +385,7 @@ Entity 구조가 크게 변경되어 Model을 재생성해야 하는 경우:
 
 ```bash
 # 기존 파일 백업
-cp src/models/User.model.ts src/models/User.model.ts.bak
+cp src/application/user/user.model.ts src/application/user/user.model.ts.bak
 
 # UI에서 재생성
 [Backup & Overwrite]


### PR DESCRIPTION
## 이 PR은 무엇인가요?

**AI(Claude)가 자동으로 생성한 Nightly PR**입니다. [#43 Nightly PR Directions](https://github.com/cartanova-ai/sonamu/issues/43)의 지침에 따라, 작업 범위는 [#44](https://github.com/cartanova-ai/sonamu/issues/44)와 그 서브이슈인 [#189](https://github.com/cartanova-ai/sonamu/issues/189), [#197](https://github.com/cartanova-ai/sonamu/issues/197)의 description에서 가져왔습니다.

코드베이스의 소유권은 전적으로 메인테이너에게 있습니다. **문서만 수정했고 프레임워크 소스는 한 줄도 건드리지 않았습니다.** 판단이 틀렸다고 보이는 부분은 부담 없이 닫거나 부분만 골라 가져가 주세요.

## 왜 이 작업을 선정했나요?

#44는 "문서와 주석이 코드와 어긋나는 경우 설명을 업데이트해야 한다", #197은 "문서의 `knex.raw()` 기본 사용을 Puri 우선으로 바꿔야 한다"고 지시합니다. #189가 요구하는 열린 Nightly PR(#226, #228, #229)의 codex 코멘트 확인도 수행했으나, **세 PR 모두 코멘트가 하나도 달려 있지 않아 반영할 피드백이 없었습니다.**

문서 전반에서 `import ... from "sonamu"` 구문의 심볼을 실제 export와 대조한 결과, **`EntityType`과 `InferSelectModel` 두 타입이 sonamu 어디에도 존재하지 않는데 문서 예제에서는 import되고 있었습니다.** 단순 오타가 아니라, 해당 문서들이 **Entity가 `.entity.json`으로 관리되기 이전 시점의 서술을 그대로 유지**하고 있었던 것으로 보입니다. 신규 사용자가 CLI/UI 문서를 그대로 따라 하면 컴파일되지 않는 파일을 만들게 되므로 우선순위를 높게 봤습니다.

## 무엇을 어떻게 고쳤나요?

### 1. Entity 정의 형식 (`stub.mdx`, `entity-management.mdx`)

문서는 `src/entities/Product.entity.ts`에 `satisfies EntityType`을 붙인 TS 객체를 보여주고 있었지만, 실제 산출물은 `src/application/product/product.entity.json`입니다(`entity.template.ts:17`, `entity-manager.ts:44`).

- `properties`→`props`, `int`→`integer`, `datetime`→`date`, `default`→`dbDefault`
- `belongsTo`/`hasMany` 배열 → `relation` prop
- prop 타입 목록을 `NormalPropTypes`(`types.ts:1374`) 기준으로 정정 (`text`/`bigint`/`float` 등 미존재 타입 제거)
- index 타입을 `EntityIndexSchema`(`types.ts:1496`) 기준으로 정정 (`fulltext` → 실제로는 `index`/`unique`/`hnsw`/`ivfflat`)
- Sonamu UI 입력 필드명을 실제 모달 레이블(`DB Default`, `Description`, `Target Columns`)로 정정

**접근 방식**: 예제를 손으로 고치는 대신, 수정한 JSON 블록 전부를 실제 `EntityJsonSchema`로 파싱 검증했습니다. 전부 통과합니다.

### 2. scaffold 산출물 (`scaffold.mdx`, `scaffolding-tab.mdx`)

- 경로 `src/models/User.model.ts` → 실제 `src/application/user/user.model.ts`
- 존재하지 않는 `InferSelectModel<typeof UserEntity>` 제거, 실제 `model.template.ts` 출력(@api 데코레이터가 붙은 findById/findOne/findMany/save/del)으로 교체
- model_test 예제를 `bun:test`/`@jest/globals`/`FixtureManager.sync()` 조합에서 실제 출력인 `bootstrap(vi)` + `describe.skip` 스텁으로 교체
- `BaseModelClass`에 없는 `entity = UserEntity` 필드 제거
- **"View 스캐폴딩 (개발 중)"** 서술 갱신 — #219에서 CLI 러너가 배선되었고 UI도 `view_list`/`view_search_input`/`view_form`을 제공합니다

### 3. Puri 우선 적용 (`business-logic.mdx`) — #197

마이그레이션을 제외하고 ko 문서에 남아 있던 유일한 `knex.raw()`/`joinRaw()` 예제입니다.

- 집계는 `Puri.avg()`/`Puri.sum()`, `COUNT(DISTINCT ...)`는 `Puri.rawNumber()`
- `joinRaw` + `as()` 서브쿼리 → `join({ alias: subquery }, ...)`
- **부수적으로 발견**: Puri의 `join`/`leftJoin`은 Knex와 인자 순서가 반대입니다(참조 가능한 컬럼 먼저). 기존 예제는 Knex 순서였습니다. 정정하고 주의 문구를 추가했습니다.

## 이렇게 하지 않으면?

Entity/scaffold 문서는 신규 사용자의 첫 진입점입니다. 지금 상태로는 예제를 복사하면 (a) 존재하지 않는 타입을 import해 컴파일이 깨지고, (b) 실제로는 생성되지 않는 경로에 파일을 만들려 하며, (c) 이미 제공되는 View 스캐폴딩 기능을 "개발 중"으로 오인하게 됩니다.

## 영향 범위

문서 10파일(ko 5 / en 5)뿐이며 런타임 동작 변경은 없습니다.

## 확인 방법

```bash
# 1. 미존재 심볼이 남아 있지 않은지
grep -rn "EntityType\|InferSelectModel" modules/docs/ko modules/docs/en

# 2. 수정된 entity.json 예제가 실제 스키마를 만족하는지 (EntityJsonSchema.safeParse)
#    → 아래 3번의 타입체크와 함께, 작업 중 스크립트로 전수 통과를 확인했습니다.

# 3. Puri 예제 컴파일 검증 (작업 중 수행한 절차)
#    examples/miomock/api 에 동일 패턴의 임시 파일을 두고
pnpm --filter sonamu build   # build:sonamu 까지
pnpm --filter miomock-api typecheck

# 4. 포맷/린트
pnpm check
```

`pnpm check`는 통과합니다. Puri 예제는 miomock에 임시 파일로 옮겨 `typecheck` 통과를 확인한 뒤 제거했습니다(leftJoin 인자 순서 오류를 이 과정에서 발견했습니다).

## 사람의 확인이 필요한 부분

1. **`entity-management.mdx`의 en 문서에만 있는 Index `Where` 행** — 부분 인덱스용 UI 필드로 서술되어 있는데, `_entity_index_modal.tsx`에서 `where` 관련 코드를 찾지 못했습니다. entity.json 스키마에는 `where`가 존재하므로 UI 미지원일 가능성이 있습니다. 제 변경 범위 밖이라 **그대로 두었습니다.** 확인 부탁드립니다. (ko 문서에는 이 행이 없어 ko/en 불일치도 남아 있습니다.)
2. **`stub.mdx`의 en 문서 생성 예제에 한국어 `desc`가 남아 있는 점** — 템플릿이 실제로 "등록일시"를 넣기 때문에 사실대로 적고 주석을 달았습니다. 영어 문서 정책상 번역하는 편이 낫다면 알려주세요.
3. **`faq/database.mdx`의 `.select("user_id", { count: Puri.count() })` 패턴** — Puri의 `select`는 객체 인자 하나만 받습니다(`puri.ts:489`). 이전 Nightly PR(#198)에서 들어온 것으로 보이며 별도 건이라 이번 PR에서는 **손대지 않았습니다.** 필요하시면 다음 Nightly에서 다루겠습니다.
4. `scaffold.mdx`의 model 예제는 지면상 메서드 본문을 생략했습니다. 생략 사실은 Note로 명시했습니다.
