### PR TITLE
[Nightly 2026-08-14] 문서의 미존재 Puri API(paginate·explain) 및 바인딩 인자를 받지 않는 raw() 호출 정정, 벡터 검색 예제를 vectorSimilarity()로 전환 (ko/en 8파일)

### DIFF
--- a/modules/docs/en/advanced-features/vector-search/vector-search.mdx
+++ b/modules/docs/en/advanced-features/vector-search/vector-search.mdx
@@ -65,23 +65,12 @@ class DocumentModelClass extends BaseModelClass {
       "query", // for search
     );
 
-    // 2. Write vector search SQL with Puri
-    const results = await this.getPuri("r").raw(
-      `
-      SELECT
-        id,
-        title,
-        content,
-        1 - (embedding <=> ?) AS similarity
-      FROM documents
-      WHERE embedding IS NOT NULL
-      ORDER BY embedding <=> ?
-      LIMIT ?
-    `,
-      [JSON.stringify(embedding.embedding), JSON.stringify(embedding.embedding), limit],
-    );
-
-    return results.rows;
+    // 2. Run the vector search with Puri's vectorSimilarity()
+    return this.getPuri("r")
+      .table("documents")
+      .select({ id: "id", title: "title", content: "content" })
+      .vectorSimilarity("embedding", embedding.embedding)
+      .limit(limit);
   }
 }
 ```
@@ -93,26 +82,33 @@ class DocumentModelClass extends BaseModelClass {
 3. Calculate similarity in PostgreSQL (pgvector)
 4. Return top N results
 
-### Why Use Puri's raw()?
+### Why Use vectorSimilarity()?
 
-Knex doesn't directly support pgvector's special operators (`<=>`):
+pgvector's special operators (`<=>`) cannot be expressed with ordinary `where` conditions:
 
 ```typescript
-// Hard with Knex
+// Cannot be expressed with findMany's wq
 await this.findMany({
   wq: [
     /* how to use pgvector operators? */
   ],
 });
 
-// Write SQL directly with Puri.raw()
-await this.getPuri("r").raw(`
-  SELECT * FROM docs
-  WHERE embedding <=> ? < 0.5
-`);
+// Puri's vectorSimilarity()
+await this.getPuri("r")
+  .table("documents")
+  .select({ id: "id" })
+  .vectorSimilarity("embedding", embedding.embedding, { threshold: 0.5 });
 ```
 
-Sonamu's `Puri` wraps Knex and provides the `raw()` method.
+`vectorSimilarity()` handles all of the following at once:
+
+- Adds a `similarity` column to the SELECT clause
+- Adds `WHERE {column} IS NOT NULL`
+- Adds a similarity filter when `threshold` is given
+- Sets `ORDER BY` on the distance operator (so the HNSW index is used)
+
+The embedding is bound internally, so you never need to concatenate the vector into SQL yourself.
 
 ## Understanding Similarity Functions
 
@@ -176,20 +172,21 @@ ORDER BY embedding <#> ?;
 
 ### Use Cosine Similarity in Sonamu
 
+All three methods are selected via the `method` option of `vectorSimilarity()`. The default is `"cosine"`.
+
+| method               | Operator | similarity value           |
+| -------------------- | -------- | -------------------------- |
+| `"cosine"` (default) | `<=>`    | `1 - distance`             |
+| `"l2"`               | `<->`    | distance (lower is closer) |
+| `"inner_product"`    | `<#>`    | `-distance`                |
+
 ```typescript
-// Recommended: Cosine similarity
-const results = await this.getPuri("r").raw(
-  `
-  SELECT
-    id, title, content,
-    1 - (embedding <=> ?) AS similarity
-  FROM documents
-  WHERE embedding IS NOT NULL
-  ORDER BY embedding <=> ?
-  LIMIT ?
-`,
-  [JSON.stringify(embedding.embedding), JSON.stringify(embedding.embedding), limit],
-);
+// Recommended: Cosine similarity (the default when method is omitted)
+const results = await this.getPuri("r")
+  .table("documents")
+  .select({ id: "id", title: "title", content: "content" })
+  .vectorSimilarity("embedding", embedding.embedding, { method: "cosine" })
+  .limit(limit);
 ```
 
 ## Threshold Filtering
@@ -205,25 +202,11 @@ async searchWithThreshold(
 ) {
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
-  const results = await this.getPuri("r").raw(`
-    SELECT
-      id, title, content,
-      1 - (embedding <=> ?) AS similarity
-    FROM documents
-    WHERE
-      embedding IS NOT NULL
-      AND 1 - (embedding <=> ?) > ?
-    ORDER BY embedding <=> ?
-    LIMIT ?
-  `, [
-    JSON.stringify(embedding.embedding),
-    JSON.stringify(embedding.embedding),
-    threshold,
-    JSON.stringify(embedding.embedding),
-    limit,
-  ]);
-
-  return results.rows;
+  return this.getPuri("r")
+    .table("documents")
+    .select({ id: "id", title: "title", content: "content" })
+    .vectorSimilarity("embedding", embedding.embedding, { threshold })
+    .limit(limit);
 }
 ```
 
@@ -244,32 +227,26 @@ class KnowledgeBaseModelClass extends BaseModelClass {
   async searchKnowledge(query: string, category?: string, limit: number = 5) {
     const embedding = await Embedding.embedOne(query, "voyage", "query");
 
-    // Category filter (optional)
-    const categoryFilter = category ? `AND category = '${category}'` : "";
+    const qb = this.getPuri("r")
+      .table("knowledge_base")
+      .select({
+        id: "id",
+        title: "title",
+        content: "content",
+        category: "category",
+        createdAt: "created_at",
+      });
 
-    const results = await this.getPuri("r").raw(
-      `
-      SELECT
-        id, title, content, category,
-        1 - (embedding <=> ?) AS similarity,
-        created_at
-      FROM knowledge_base
-      WHERE
-        embedding IS NOT NULL
-        ${categoryFilter}
-      ORDER BY embedding <=> ?
-      LIMIT ?
-    `,
-      [JSON.stringify(embedding.embedding), JSON.stringify(embedding.embedding), limit],
-    );
+    // Category filter (optional) — the value is bound, so no string concatenation is needed
+    if (category) {
+      qb.where("category", category);
+    }
 
-    return results.rows.map((row) => ({
-      id: row.id,
-      title: row.title,
-      content: row.content,
-      category: row.category,
+    const rows = await qb.vectorSimilarity("embedding", embedding.embedding).limit(limit);
+
+    return rows.map((row) => ({
+      ...row,
       similarity: parseFloat(row.similarity.toFixed(3)),
-      createdAt: row.created_at,
     }));
   }
 }
@@ -301,27 +278,12 @@ class ProductModelClass extends BaseModelClass {
     }
 
     // Search similar products (exclude self)
-    const results = await this.getPuri("r").raw(
-      `
-      SELECT
-        id, name, description, price,
-        1 - (embedding <=> ?) AS similarity
-      FROM products
-      WHERE
-        embedding IS NOT NULL
-        AND id != ?
-      ORDER BY embedding <=> ?
-      LIMIT ?
-    `,
-      [
-        JSON.stringify(baseProduct.embedding),
-        productId,
-        JSON.stringify(baseProduct.embedding),
-        limit,
-      ],
-    );
-
-    return results.rows;
+    return this.getPuri("r")
+      .table("products")
+      .select({ id: "id", name: "name", description: "description", price: "price" })
+      .where("id", "!=", productId)
+      .vectorSimilarity("embedding", baseProduct.embedding)
+      .limit(limit);
   }
 }
 ```
@@ -359,49 +321,34 @@ async advancedSearch(
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
   // Dynamic WHERE conditions
-  const conditions = ['embedding IS NOT NULL'];
-  const params: any[] = [
-    JSON.stringify(embedding.embedding),
-    JSON.stringify(embedding.embedding),
-  ];
+  const qb = this.getPuri("r")
+    .table("documents")
+    .select({
+      id: "id",
+      title: "title",
+      content: "content",
+      category: "category",
+      createdAt: "created_at",
+    });
 
   if (filters.category) {
-    conditions.push(`category = ?`);
-    params.push(filters.category);
-  }
-
-  if (filters.minSimilarity) {
-    conditions.push(`1 - (embedding <=> ?) > ?`);
-    params.push(
-      JSON.stringify(embedding.embedding),
-      filters.minSimilarity
-    );
+    qb.where("category", filters.category);
   }
 
   if (filters.dateFrom) {
-    conditions.push(`created_at >= ?`);
-    params.push(filters.dateFrom);
+    qb.where("created_at", ">=", filters.dateFrom);
   }
 
   if (filters.dateTo) {
-    conditions.push(`created_at <= ?`);
-    params.push(filters.dateTo);
+    qb.where("created_at", "<=", filters.dateTo);
   }
 
-  params.push(limit);
-
-  const results = await this.getPuri("r").raw(`
-    SELECT
-      id, title, content, category,
-      1 - (embedding <=> ?) AS similarity,
-      created_at
-    FROM documents
-    WHERE ${conditions.join(' AND ')}
-    ORDER BY embedding <=> ?
-    LIMIT ?
-  `, params);
-
-  return results.rows;
+  // Pass the similarity cutoff through vectorSimilarity's threshold option
+  return qb
+    .vectorSimilarity("embedding", embedding.embedding, {
+      threshold: filters.minSimilarity,
+    })
+    .limit(limit);
 }
 ```
 
@@ -418,24 +365,22 @@ async searchDocumentChunks(
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
   // Search by chunk (fetch more)
-  const chunks = await this.getPuri("r").raw(`
-    SELECT
-      id, parent_id, title, content, chunk_index,
-      1 - (embedding <=> ?) AS similarity
-    FROM document_chunks
-    WHERE embedding IS NOT NULL
-    ORDER BY embedding <=> ?
-    LIMIT ?
-  `, [
-    JSON.stringify(embedding.embedding),
-    JSON.stringify(embedding.embedding),
-    limit * 3,
-  ]);
+  const chunks = await this.getPuri("r")
+    .table("document_chunks")
+    .select({
+      id: "id",
+      parent_id: "parent_id",
+      title: "title",
+      content: "content",
+      chunk_index: "chunk_index",
+    })
+    .vectorSimilarity("embedding", embedding.embedding)
+    .limit(limit * 3);
 
   // Group by parent document
   const grouped = new Map();
 
-  for (const chunk of chunks.rows) {
+  for (const chunk of chunks) {
     const parentId = chunk.parent_id;
 
     if (!grouped.has(parentId)) {
@@ -486,17 +431,16 @@ USING hnsw (embedding vector_cosine_ops);
 ### Verify with EXPLAIN ANALYZE
 
 ```typescript
-const explain = await this.getPuri("r").raw(
-  `
-  EXPLAIN ANALYZE
-  SELECT id, title, 1 - (embedding <=> ?) AS similarity
-  FROM documents
-  WHERE embedding IS NOT NULL
-  ORDER BY embedding <=> ?
-  LIMIT 10
-`,
-  [JSON.stringify(embedding.embedding), JSON.stringify(embedding.embedding)],
-);
+const rdb = this.getPuri("r");
+
+const query = rdb
+  .table("documents")
+  .select({ id: "id", title: "title" })
+  .vectorSimilarity("embedding", embedding.embedding)
+  .limit(10);
+
+// Build the finished SQL with toQuery() and pass it to EXPLAIN
+const explain = await rdb.raw(`EXPLAIN ANALYZE ${query.toQuery()}`);
 
 console.log(explain.rows);
 ```
@@ -521,8 +465,16 @@ SET LOCAL hnsw.ef_search = 100;  -- default: 40
 In Sonamu:
 
 ```typescript
-await this.getPuri("r").raw("SET LOCAL hnsw.ef_search = 100");
-const results = await this.getPuri("r").raw(`SELECT ...`);
+const rdb = this.getPuri("r");
+
+// SET LOCAL only applies within a transaction, so run it inside @transactional
+await rdb.raw("SET LOCAL hnsw.ef_search = 100");
+
+const results = await rdb
+  .table("documents")
+  .select({ id: "id", title: "title" })
+  .vectorSimilarity("embedding", embedding.embedding)
+  .limit(10);
 ```
 
 ## Benchmarks
@@ -543,11 +495,7 @@ const results = await this.getPuri("r").raw(`SELECT ...`);
 <Warning>
 **Cautions for vector search in Sonamu**:
 
-1. **NULL check required**: Exclude documents without embeddings
-
-   ```sql
-   WHERE embedding IS NOT NULL
-   ```
+1. **NULL check**: `vectorSimilarity()` adds `WHERE {column} IS NOT NULL` automatically, so you don't need to write it
 
 2. **Dimension match**: Query and DB vector dimensions must match
 
@@ -561,23 +509,22 @@ const results = await this.getPuri("r").raw(`SELECT ...`);
    // Query: Voyage (1024)
    ```
 
-3. **JSON.stringify required**: Convert array to JSON string
+3. **Pass the embedding as a plain number[]**: `vectorSimilarity()` handles the vector literal conversion
 
    ```typescript
-   JSON.stringify(embedding.embedding);
+   qb.vectorSimilarity("embedding", embedding.embedding);
    ```
 
-4. **Operator used twice**: In WHERE and ORDER BY
-
-   ```sql
-   WHERE 1 - (embedding <=> ?) > 0.5
-   ORDER BY embedding <=> ?
-   ```
-
-5. **Use Puri.raw()**: Cannot use Knex's wq
+4. **Use the threshold option for cutoffs**: no need to write WHERE/ORDER BY yourself
 
    ```typescript
-   await this.getPuri("r").raw(`SELECT ...`);
+   qb.vectorSimilarity("embedding", embedding.embedding, { threshold: 0.5 });
+   ```
+
+5. **Cannot use findMany's wq**: use `vectorSimilarity()` for vector search
+
+   ```typescript
+   await this.getPuri("r").table("documents").vectorSimilarity("embedding", vector);
    ```
 
 6. **Index creation timing**: After data

--- a/modules/docs/en/api-reference/decorators/api.mdx
+++ b/modules/docs/en/api-reference/decorators/api.mdx
@@ -527,10 +527,12 @@ Logs are recorded through LogTape, with categories in `[model:user]` or `[frame:
     class UserModelClass extends BaseModelClass {
       @api({ httpMethod: "GET" })
       async list(params: UserListParams) {
+        const { num = 20, page = 1 } = params;
         const rdb = this.getPuri("r");
         return rdb.table("users")
           .where("deleted_at", null)
-          .paginate(params);
+          .limit(num)
+          .offset(num * (page - 1));
       }
 
       @api({ httpMethod: "GET" })

--- a/modules/docs/en/api-reference/decorators/cache.mdx
+++ b/modules/docs/en/api-reference/decorators/cache.mdx
@@ -487,10 +487,12 @@ export default defineConfig({
       @api({ httpMethod: "GET" })
       @cache({ ttl: "5m", tags: ["products"] })
       async list(params: ProductListParams) {
+        const { num = 20, page = 1 } = params;
         const rdb = this.getPuri("r");
         return rdb.table("products")
           .where("active", true)
-          .paginate(params);
+          .limit(num)
+          .offset(num * (page - 1));
       }
 
       @api({ httpMethod: "GET" })

--- a/modules/docs/en/database/puri/raw-queries.mdx
+++ b/modules/docs/en/database/puri/raw-queries.mdx
@@ -488,14 +488,12 @@ const results = await db
 
 ```typescript
 // Check query execution plan
-const plan = await db
-  .table("employees")
-  .select({ id: "id" })
-  .where("department_id", 1)
-  .rawQuery()
-  .explain();
+// Puri has no explain(), so build the SQL with toQuery() and pass it to EXPLAIN.
+const query = db.table("employees").select({ id: "id" }).where("department_id", 1);
 
-console.log(plan);
+const plan = await db.raw(`EXPLAIN ANALYZE ${query.toQuery()}`);
+
+console.log(plan.rows);
 ```
 
 ### Index Hints (Not supported in PostgreSQL)

--- a/modules/docs/ko/advanced-features/vector-search/vector-search.mdx
+++ b/modules/docs/ko/advanced-features/vector-search/vector-search.mdx
@@ -65,23 +65,12 @@ class DocumentModelClass extends BaseModelClass {
       "query", // 검색용
     );
 
-    // 2. Puri로 벡터 검색 SQL 작성
-    const results = await this.getPuri("r").raw(
-      `
-      SELECT 
-        id,
-        title,
-        content,
-        1 - (embedding <=> ?) AS similarity
-      FROM documents
-      WHERE embedding IS NOT NULL
-      ORDER BY embedding <=> ?
-      LIMIT ?
-    `,
-      [JSON.stringify(embedding.embedding), JSON.stringify(embedding.embedding), limit],
-    );
-
-    return results.rows;
+    // 2. Puri의 vectorSimilarity()로 벡터 검색
+    return this.getPuri("r")
+      .table("documents")
+      .select({ id: "id", title: "title", content: "content" })
+      .vectorSimilarity("embedding", embedding.embedding)
+      .limit(limit);
   }
 }
 ```
@@ -93,26 +82,33 @@ class DocumentModelClass extends BaseModelClass {
 3. PostgreSQL에서 유사도 계산 (pgvector)
 4. 상위 N개 반환
 
-### 왜 Puri의 raw()를 쓰나요?
+### 왜 vectorSimilarity()를 쓰나요?
 
-pgvector의 특수 연산자(`<=>`)는 Knex가 직접 지원하지 않습니다:
+pgvector의 특수 연산자(`<=>`)는 일반 `where` 조건으로 표현할 수 없습니다:
 
 ```typescript
-// ❌ Knex로는 어려움
+// ❌ findMany의 wq로는 표현 불가
 await this.findMany({
   wq: [
     /* pgvector 연산자 어떻게? */
   ],
 });
 
-// ✅ Puri.raw()로 SQL 직접 작성
-await this.getPuri("r").raw(`
-  SELECT * FROM docs
-  WHERE embedding <=> ? < 0.5
-`);
+// ✅ Puri의 vectorSimilarity()
+await this.getPuri("r")
+  .table("documents")
+  .select({ id: "id" })
+  .vectorSimilarity("embedding", embedding.embedding, { threshold: 0.5 });
 ```
 
-Sonamu의 `Puri`는 Knex를 감싸므로 `raw()` 메서드를 제공합니다.
+`vectorSimilarity()`는 다음을 한 번에 처리합니다:
+
+- `similarity` 컬럼을 SELECT에 추가
+- `WHERE {컬럼} IS NOT NULL` 추가
+- `threshold`가 주어지면 유사도 필터 추가
+- 거리 연산자 기준 `ORDER BY` 설정 (HNSW 인덱스를 타도록)
+
+임베딩 값은 내부에서 바인딩되므로, 벡터를 직접 문자열로 이어붙일 필요가 없습니다.
 
 ## 유사도 함수 이해하기
 
@@ -176,20 +172,21 @@ ORDER BY embedding <#> ?;
 
 ### Sonamu에서는 코사인 유사도 사용
 
+세 방식 모두 `vectorSimilarity()`의 `method` 옵션으로 선택합니다. 기본값은 `"cosine"`입니다.
+
+| method            | 연산자 | similarity 값       |
+| ----------------- | ------ | ------------------- |
+| `"cosine"` (기본) | `<=>`  | `1 - distance`      |
+| `"l2"`            | `<->`  | 거리 (낮을수록 유사) |
+| `"inner_product"` | `<#>`  | `-distance`         |
+
 ```typescript
-// ✅ 권장: 코사인 유사도
-const results = await this.getPuri("r").raw(
-  `
-  SELECT 
-    id, title, content,
-    1 - (embedding <=> ?) AS similarity
-  FROM documents
-  WHERE embedding IS NOT NULL
-  ORDER BY embedding <=> ?
-  LIMIT ?
-`,
-  [JSON.stringify(embedding.embedding), JSON.stringify(embedding.embedding), limit],
-);
+// ✅ 권장: 코사인 유사도 (method 생략 시 기본값)
+const results = await this.getPuri("r")
+  .table("documents")
+  .select({ id: "id", title: "title", content: "content" })
+  .vectorSimilarity("embedding", embedding.embedding, { method: "cosine" })
+  .limit(limit);
 ```
 
 ## 임계값 필터링
@@ -205,25 +202,11 @@ async searchWithThreshold(
 ) {
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
-  const results = await this.getPuri("r").raw(`
-    SELECT
-      id, title, content,
-      1 - (embedding <=> ?) AS similarity
-    FROM documents
-    WHERE
-      embedding IS NOT NULL
-      AND 1 - (embedding <=> ?) > ?
-    ORDER BY embedding <=> ?
-    LIMIT ?
-  `, [
-    JSON.stringify(embedding.embedding),
-    JSON.stringify(embedding.embedding),
-    threshold,
-    JSON.stringify(embedding.embedding),
-    limit,
-  ]);
-
-  return results.rows;
+  return this.getPuri("r")
+    .table("documents")
+    .select({ id: "id", title: "title", content: "content" })
+    .vectorSimilarity("embedding", embedding.embedding, { threshold })
+    .limit(limit);
 }
 ```
 
@@ -244,32 +227,26 @@ class KnowledgeBaseModelClass extends BaseModelClass {
   async searchKnowledge(query: string, category?: string, limit: number = 5) {
     const embedding = await Embedding.embedOne(query, "voyage", "query");
 
-    // 카테고리 필터 (선택)
-    const categoryFilter = category ? `AND category = '${category}'` : "";
+    const qb = this.getPuri("r")
+      .table("knowledge_base")
+      .select({
+        id: "id",
+        title: "title",
+        content: "content",
+        category: "category",
+        createdAt: "created_at",
+      });
 
-    const results = await this.getPuri("r").raw(
-      `
-      SELECT 
-        id, title, content, category,
-        1 - (embedding <=> ?) AS similarity,
-        created_at
-      FROM knowledge_base
-      WHERE 
-        embedding IS NOT NULL
-        ${categoryFilter}
-      ORDER BY embedding <=> ?
-      LIMIT ?
-    `,
-      [JSON.stringify(embedding.embedding), JSON.stringify(embedding.embedding), limit],
-    );
+    // 카테고리 필터 (선택) — 값은 바인딩되므로 문자열 이어붙이기가 필요 없습니다
+    if (category) {
+      qb.where("category", category);
+    }
 
-    return results.rows.map((row) => ({
-      id: row.id,
-      title: row.title,
-      content: row.content,
-      category: row.category,
+    const rows = await qb.vectorSimilarity("embedding", embedding.embedding).limit(limit);
+
+    return rows.map((row) => ({
+      ...row,
       similarity: parseFloat(row.similarity.toFixed(3)),
-      createdAt: row.created_at,
     }));
   }
 }
@@ -301,27 +278,12 @@ class ProductModelClass extends BaseModelClass {
     }
 
     // 유사 상품 검색 (자기 자신 제외)
-    const results = await this.getPuri("r").raw(
-      `
-      SELECT 
-        id, name, description, price,
-        1 - (embedding <=> ?) AS similarity
-      FROM products
-      WHERE 
-        embedding IS NOT NULL
-        AND id != ?
-      ORDER BY embedding <=> ?
-      LIMIT ?
-    `,
-      [
-        JSON.stringify(baseProduct.embedding),
-        productId,
-        JSON.stringify(baseProduct.embedding),
-        limit,
-      ],
-    );
-
-    return results.rows;
+    return this.getPuri("r")
+      .table("products")
+      .select({ id: "id", name: "name", description: "description", price: "price" })
+      .where("id", "!=", productId)
+      .vectorSimilarity("embedding", baseProduct.embedding)
+      .limit(limit);
   }
 }
 ```
@@ -359,49 +321,34 @@ async advancedSearch(
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
   // WHERE 조건 동적 생성
-  const conditions = ['embedding IS NOT NULL'];
-  const params: any[] = [
-    JSON.stringify(embedding.embedding),
-    JSON.stringify(embedding.embedding),
-  ];
+  const qb = this.getPuri("r")
+    .table("documents")
+    .select({
+      id: "id",
+      title: "title",
+      content: "content",
+      category: "category",
+      createdAt: "created_at",
+    });
 
   if (filters.category) {
-    conditions.push(`category = ?`);
-    params.push(filters.category);
-  }
-
-  if (filters.minSimilarity) {
-    conditions.push(`1 - (embedding <=> ?) > ?`);
-    params.push(
-      JSON.stringify(embedding.embedding),
-      filters.minSimilarity
-    );
+    qb.where("category", filters.category);
   }
 
   if (filters.dateFrom) {
-    conditions.push(`created_at >= ?`);
-    params.push(filters.dateFrom);
+    qb.where("created_at", ">=", filters.dateFrom);
   }
 
   if (filters.dateTo) {
-    conditions.push(`created_at <= ?`);
-    params.push(filters.dateTo);
+    qb.where("created_at", "<=", filters.dateTo);
   }
 
-  params.push(limit);
-
-  const results = await this.getPuri("r").raw(`
-    SELECT
-      id, title, content, category,
-      1 - (embedding <=> ?) AS similarity,
-      created_at
-    FROM documents
-    WHERE ${conditions.join(' AND ')}
-    ORDER BY embedding <=> ?
-    LIMIT ?
-  `, params);
-
-  return results.rows;
+  // 유사도 임계값은 vectorSimilarity의 threshold 옵션으로 전달합니다
+  return qb
+    .vectorSimilarity("embedding", embedding.embedding, {
+      threshold: filters.minSimilarity,
+    })
+    .limit(limit);
 }
 ```
 
@@ -418,24 +365,22 @@ async searchDocumentChunks(
   const embedding = await Embedding.embedOne(query, 'voyage', 'query');
 
   // 청크별 검색 (더 많이 가져옴)
-  const chunks = await this.getPuri("r").raw(`
-    SELECT
-      id, parent_id, title, content, chunk_index,
-      1 - (embedding <=> ?) AS similarity
-    FROM document_chunks
-    WHERE embedding IS NOT NULL
-    ORDER BY embedding <=> ?
-    LIMIT ?
-  `, [
-    JSON.stringify(embedding.embedding),
-    JSON.stringify(embedding.embedding),
-    limit * 3,
-  ]);
+  const chunks = await this.getPuri("r")
+    .table("document_chunks")
+    .select({
+      id: "id",
+      parent_id: "parent_id",
+      title: "title",
+      content: "content",
+      chunk_index: "chunk_index",
+    })
+    .vectorSimilarity("embedding", embedding.embedding)
+    .limit(limit * 3);
 
   // 부모 문서별로 그룹화
   const grouped = new Map();
 
-  for (const chunk of chunks.rows) {
+  for (const chunk of chunks) {
     const parentId = chunk.parent_id;
 
     if (!grouped.has(parentId)) {
@@ -486,17 +431,16 @@ USING hnsw (embedding vector_cosine_ops);
 ### EXPLAIN ANALYZE로 확인
 
 ```typescript
-const explain = await this.getPuri("r").raw(
-  `
-  EXPLAIN ANALYZE
-  SELECT id, title, 1 - (embedding <=> ?) AS similarity
-  FROM documents
-  WHERE embedding IS NOT NULL
-  ORDER BY embedding <=> ?
-  LIMIT 10
-`,
-  [JSON.stringify(embedding.embedding), JSON.stringify(embedding.embedding)],
-);
+const rdb = this.getPuri("r");
+
+const query = rdb
+  .table("documents")
+  .select({ id: "id", title: "title" })
+  .vectorSimilarity("embedding", embedding.embedding)
+  .limit(10);
+
+// toQuery()로 완성된 SQL을 뽑아 EXPLAIN에 넘깁니다
+const explain = await rdb.raw(`EXPLAIN ANALYZE ${query.toQuery()}`);
 
 console.log(explain.rows);
 ```
@@ -521,8 +465,16 @@ SET LOCAL hnsw.ef_search = 100;  -- 기본: 40
 Sonamu에서:
 
 ```typescript
-await this.getPuri("r").raw("SET LOCAL hnsw.ef_search = 100");
-const results = await this.getPuri("r").raw(`SELECT ...`);
+const rdb = this.getPuri("r");
+
+// SET LOCAL은 트랜잭션 범위에서만 유효하므로 @transactional 안에서 실행합니다
+await rdb.raw("SET LOCAL hnsw.ef_search = 100");
+
+const results = await rdb
+  .table("documents")
+  .select({ id: "id", title: "title" })
+  .vectorSimilarity("embedding", embedding.embedding)
+  .limit(10);
 ```
 
 ## 벤치마크
@@ -543,11 +495,7 @@ const results = await this.getPuri("r").raw(`SELECT ...`);
 <Warning>
 **Sonamu에서 벡터 검색 시 주의사항**:
 
-1. **NULL 체크 필수**: 임베딩 없는 문서 제외
-
-   ```sql
-   WHERE embedding IS NOT NULL
-   ```
+1. **NULL 체크**: `vectorSimilarity()`가 `WHERE {컬럼} IS NOT NULL`을 자동으로 추가하므로 직접 쓸 필요 없음
 
 2. **차원 일치**: 쿼리와 DB 벡터 차원 같아야 함
 
@@ -561,23 +509,22 @@ const results = await this.getPuri("r").raw(`SELECT ...`);
    // 쿼리: Voyage (1024)
    ```
 
-3. **JSON.stringify 필수**: 배열을 JSON 문자열로
+3. **임베딩은 number[] 그대로 전달**: 벡터 리터럴 변환은 `vectorSimilarity()`가 처리
 
    ```typescript
-   JSON.stringify(embedding.embedding);
+   qb.vectorSimilarity("embedding", embedding.embedding);
    ```
 
-4. **연산자 두 번 사용**: WHERE와 ORDER BY
-
-   ```sql
-   WHERE 1 - (embedding <=> ?) > 0.5
-   ORDER BY embedding <=> ?
-   ```
-
-5. **Puri.raw() 사용**: Knex의 wq로는 안 됨
+4. **임계값은 threshold 옵션으로**: WHERE/ORDER BY를 직접 쓰지 않아도 됨
 
    ```typescript
-   await this.getPuri("r").raw(`SELECT ...`);
+   qb.vectorSimilarity("embedding", embedding.embedding, { threshold: 0.5 });
+   ```
+
+5. **findMany의 wq로는 불가**: 벡터 검색은 `vectorSimilarity()`를 사용
+
+   ```typescript
+   await this.getPuri("r").table("documents").vectorSimilarity("embedding", vector);
    ```
 
 6. **인덱스 생성 시점**: 데이터 후

--- a/modules/docs/ko/api-reference/decorators/api.mdx
+++ b/modules/docs/ko/api-reference/decorators/api.mdx
@@ -527,10 +527,12 @@ async findById(id: number) {
     class UserModelClass extends BaseModelClass {
       @api({ httpMethod: "GET" })
       async list(params: UserListParams) {
+        const { num = 20, page = 1 } = params;
         const rdb = this.getPuri("r");
         return rdb.table("users")
           .where("deleted_at", null)
-          .paginate(params);
+          .limit(num)
+          .offset(num * (page - 1));
       }
 
       @api({ httpMethod: "GET" })

--- a/modules/docs/ko/api-reference/decorators/cache.mdx
+++ b/modules/docs/ko/api-reference/decorators/cache.mdx
@@ -485,10 +485,12 @@ export default defineConfig({
       @api({ httpMethod: "GET" })
       @cache({ ttl: "5m", tags: ["products"] })
       async list(params: ProductListParams) {
+        const { num = 20, page = 1 } = params;
         const rdb = this.getPuri("r");
         return rdb.table("products")
           .where("active", true)
-          .paginate(params);
+          .limit(num)
+          .offset(num * (page - 1));
       }
 
       @api({ httpMethod: "GET" })

--- a/modules/docs/ko/database/puri/raw-queries.mdx
+++ b/modules/docs/ko/database/puri/raw-queries.mdx
@@ -488,14 +488,12 @@ const results = await db
 
 ```typescript
 // 쿼리 실행 계획 확인
-const plan = await db
-  .table("employees")
-  .select({ id: "id" })
-  .where("department_id", 1)
-  .rawQuery()
-  .explain();
+// Puri에는 explain()이 없으므로, toQuery()로 SQL을 만들어 EXPLAIN에 넘깁니다.
+const query = db.table("employees").select({ id: "id" }).where("department_id", 1);
 
-console.log(plan);
+const plan = await db.raw(`EXPLAIN ANALYZE ${query.toQuery()}`);
+
+console.log(plan.rows);
 ```
 
 ### 인덱스 힌트 (PostgreSQL은 지원 안함)


### PR DESCRIPTION
## 이 PR은 무엇인가요?

**AI(Claude)가 자동으로 생성한 Nightly PR**입니다. [#43 Nightly PR Directions](https://github.com/cartanova-ai/sonamu/issues/43)의 지침에 따라, 작업 범위는 [#44](https://github.com/cartanova-ai/sonamu/issues/44)와 그 서브이슈인 [#189](https://github.com/cartanova-ai/sonamu/issues/189), [#197](https://github.com/cartanova-ai/sonamu/issues/197)의 description에서 가져왔습니다.

코드베이스의 소유권은 전적으로 메인테이너에게 있습니다. **문서만 수정했고 프레임워크 소스는 한 줄도 건드리지 않았습니다.** 판단이 틀렸다고 보이는 부분은 부담 없이 닫거나 일부만 골라 가져가 주세요.

## 왜 이 작업을 선정했나요?

#44는 "문서와 주석이 코드와 어긋나는 경우 설명을 업데이트해야 한다"고 지시합니다. #189가 요구하는 열린 Nightly PR(#226, #228, #229, #230)의 codex 코멘트 확인도 먼저 수행했으나, **네 PR 모두 issue comment·review comment가 하나도 달려 있지 않아 반영할 피드백이 없었습니다.**

그래서 이번에는 **"문서가 호출하는 메서드가 실제로 존재하는가"**를 기준으로 훑었습니다. `Puri`/`PuriWrapper`의 실제 메서드 목록을 추출해 문서의 호출부와 대조한 결과, 아래 두 종류의 문제가 나왔습니다. 둘 다 **예제를 그대로 복사하면 컴파일이 막히는** 수준이라 우선순위를 높게 봤습니다.

지적을 무비판적으로 늘리지 않기 위해, 소스에 실제로 없는 것만 손댔습니다. 예컨대 `type-safety.mdx`의 `this.paginate(...)`는 같은 예제 안에서 사용자가 직접 정의한 헬퍼이므로 **의도적으로 건드리지 않았습니다.**

## 무엇이 문제였나요?

### 1. 존재하지 않는 `paginate()` / `explain()` (커밋 1)

| 위치 | 호출 | 실제 |
| --- | --- | --- |
| `decorators/api.mdx`, `decorators/cache.mdx` | `rdb.table("users").where(...).paginate(params)` | `Puri`에 `paginate` 없음 |
| `puri/raw-queries.mdx` | `...rawQuery().explain()` | Knex `QueryBuilder`에 `explain` 없음 |

두 이름 모두 `modules/sonamu/src` 전체에 정의가 없습니다. 그대로 복사하면 TS2339로 바로 막힙니다.

### 2. `PuriWrapper.raw()`에 바인딩 인자를 넘기는 예제 (커밋 2)

`PuriWrapper.raw()`의 시그니처는 `raw(sql: string)` 하나뿐입니다(`puri-wrapper.ts:36`). 그런데 `vector-search.mdx`의 벡터 검색 예제 **8곳 전부**가 아래 형태였습니다.

```typescript
await this.getPuri("r").raw(
  `... WHERE embedding <=> ? ... LIMIT ?`,
  [JSON.stringify(embedding.embedding), ..., limit],   // ← 받지 않는 두 번째 인자
);
```

인자 개수 초과로 컴파일이 막히고, 억지로 우회하더라도 `?` 플레이스홀더가 바인딩되지 않아 knex가 `Undefined binding(s) detected`로 실패합니다. **이 문서의 벡터 검색 예제는 현재 하나도 동작하지 않습니다.**

더 중요한 점은, Puri에 **이 용도의 전용 API인 `vectorSimilarity()`가 이미 있는데(`puri.ts:1232`) 문서 어디에도 언급이 없었다**는 것입니다. 이 메서드는 `similarity` 컬럼 추가, `WHERE {컬럼} IS NOT NULL`, `threshold` 필터, 거리 연산자 기준 `ORDER BY`(HNSW 인덱스 유도)를 한 번에 처리하고 임베딩도 내부에서 바인딩합니다.

부수적으로, 지식 베이스 검색 예제는 사용자 입력을 SQL에 그대로 이어붙이고 있었습니다.

```typescript
const categoryFilter = category ? `AND category = '${category}'` : "";
```

## 어떤 접근을 채택했고, 왜인가요?

- **`paginate` → `limit(num).offset(num * (page - 1))`.** 새 API를 제안하는 대신, `BaseModelClass.executeListQuery`가 실제로 쓰는 계산식(`base-model.ts:469`)을 그대로 가져왔습니다. 생성된 `ListParams`의 `num`/`page`는 `.partial()`이라 optional이므로 기본값(`num = 20, page = 1`)을 명시했습니다.
- **`explain` → `toQuery()` + `raw()`.** `Puri.toQuery()`는 완성된 SQL 문자열을 돌려주므로, 바인딩 인자 없이 `EXPLAIN ANALYZE ${query.toQuery()}` 한 줄로 처리됩니다. 이 형태는 `raw(sql: string)` 시그니처와도 맞습니다.
- **벡터 검색 예제 전부를 `vectorSimilarity()`로 교체.** raw SQL의 바인딩만 고쳐도 되지만, 그러면 이미 존재하는 전용 API를 계속 감춰두게 됩니다. #197이 말하는 "raw 대신 Puri API 우선" 방향과도 일치합니다. 카테고리 필터는 `where()`로 바뀌면서 위의 문자열 보간 경로가 함께 사라집니다.
- **문서의 서술도 함께 갱신.** "왜 Puri의 raw()를 쓰나요?" 절 제목/본문과 주의사항 3~5번(`JSON.stringify 필수`, `연산자 두 번 사용`, `Puri.raw() 사용`)은 `vectorSimilarity()` 기준으로는 더 이상 맞지 않아 다시 썼습니다. `method` 옵션(cosine/l2/inner_product) 대응표도 추가했습니다.
- **`SET LOCAL hnsw.ef_search` 예제**는 `raw()`가 그대로 적절해서 유지하되, 트랜잭션 범위에서만 유효하다는 주석을 덧붙였습니다.

## 이렇게 하지 않으면

벡터 검색은 이 문서가 사실상 유일한 진입점입니다. 지금 상태로는 신규 사용자가 문서를 따라 했을 때 **처음부터 끝까지 하나도 동작하지 않고**, 프레임워크가 이미 제공하는 `vectorSimilarity()`를 못 보고 직접 raw SQL을 짜게 됩니다. `@api`/`@cache` 문서의 `paginate` 역시 "예제 코드가 컴파일되지 않는다"는 첫인상을 남깁니다.

## 영향 범위

- 변경 대상: `modules/docs` **문서 8파일(ko 4 / en 4)** 뿐입니다.
- 프레임워크 런타임 동작 변경 없음. 생성 코드·템플릿·마이그레이션 무관.
- 검증: 루트 `pnpm check`(oxlint + oxfmt) 통과. (`.mdx`는 lint/format 대상이 아니므로, 예제는 `Puri`/`PuriWrapper`/`BaseModelClass`의 실제 시그니처와 수동 대조했습니다.)

## 확인 방법

```bash
# 1. 미존재 메서드가 문서에서 사라졌는지
rg '\.paginate\(|\.explain\(' modules/docs/ | rg -v 'type-safety'   # 결과 없음

# 2. raw()에 바인딩 인자를 넘기는 예제가 남아 있는지
rg -U 'getPuri\("r"\)\.raw\(\s*`[^`]*`\s*,' modules/docs/            # 결과 없음

# 3. 근거가 되는 실제 시그니처
rg -n 'raw\(sql: string\)' modules/sonamu/src/database/puri-wrapper.ts
rg -n 'vectorSimilarity\(' modules/sonamu/src/database/puri.ts
rg -n 'limit\(num\)\.offset' modules/sonamu/src/database/base-model.ts
```

## 사람의 확인이 필요한 부분

- **`.mdx` 예제는 타입 체크가 걸리지 않습니다.** 예제 속 테이블(`documents`, `knowledge_base`, `document_chunks`)은 가상의 스키마라 `vectorSimilarity()`의 `VectorColumns<TTables>` 제약을 실제로 통과시켜 볼 수 없었습니다. 시그니처 대조까지만 했고, 실행 검증은 하지 못했습니다.
- **`type-safety.mdx`의 사용자 정의 `paginate` 헬퍼**는 그대로 두었습니다. 다만 그 안의 `const { total } = await countQuery.select(...).first()`는 `first()`가 `undefined`일 때 구조 분해에서 터질 수 있어 보입니다. 이번 PR의 주제와 달라 손대지 않았으니, 별도로 볼지 판단해 주세요.
- **`method: "l2"`의 `threshold` 의미**가 다른 두 방식과 반대(낮을수록 유사)입니다. 표에는 적어두었지만, 문서 톤상 더 강조가 필요할지는 메인테이너 판단에 맡깁니다.
- 남은 #197 과제인 **`knex.raw()` → `upsertBuilder()` 교체**는 이번 범위에 넣지 않았습니다. 예제마다 마이그레이션인지 비즈니스 로직인지 개별 판단이 필요해, 한 PR에 섞으면 리뷰 부담이 커진다고 봤습니다.
