### PR TITLE
[Nightly 2026-08-17] 인증·스토리지 문서의 존재하지 않는 서브패스 import(sonamu/auth·sonamu/decorators)와 CLI 명령(sonamu better-auth) 정정, 세션 정리 예제를 실제 workflow API로 교체 (ko/en 6파일)

### DIFF
--- a/modules/docs/en/api-development/authentication/session-management.mdx
+++ b/modules/docs/en/api-development/authentication/session-management.mdx
@@ -624,23 +624,28 @@ class AuthModel extends BaseModelClass {
 Periodically delete expired Refresh Tokens to manage database size.
 
 ```typescript
-// tasks/cleanup-tokens.ts
-import { task } from "sonamu";
+// src/workflows/cleanup-tokens.workflow.ts
+import { BaseModel, workflow } from "sonamu";
 
 /**
  * Delete expired Refresh Tokens at midnight every day
  */
-@task({ cron: "0 0 * * *" })
-export async function cleanupExpiredTokens() {
-  const db = getDatabase();
+export const cleanupExpiredTokens = workflow(
+  {
+    name: "cleanup_expired_tokens",
+    schedules: [{ expression: "0 0 * * *" }],
+  },
+  async ({ logger }) => {
+    const wdb = BaseModel.getPuri("w");
 
-  const result = await db
-    .table("refresh_tokens")
-    .where("expires_at", "<", new Date())
-    .delete();
+    const deleted = await wdb
+      .table("refresh_tokens")
+      .where("expires_at", "<", new Date())
+      .delete();
 
-  console.log(`Deleted ${result} expired refresh tokens`);
-}
+    logger.info(`Deleted ${deleted} expired refresh tokens`);
+  },
+);
 ```
 
 ## Cautions

--- a/modules/docs/en/configuration/sonamu-config/auth.mdx
+++ b/modules/docs/en/configuration/sonamu-config/auth.mdx
@@ -130,7 +130,7 @@ You need to generate the required entities before using better-auth.
 ### Generate Entities via CLI
 
 ```bash
-pnpm sonamu better-auth
+pnpm sonamu auth generate
 ```
 
 This command generates the following entities:
@@ -152,10 +152,10 @@ To use better-auth plugins, specify the required plugins with the `--plugins` op
 
 ```bash
 # Single plugin
-pnpm sonamu better-auth --plugins=2fa
+pnpm sonamu auth generate --plugins=2fa
 
 # Multiple plugins (comma-separated)
-pnpm sonamu better-auth --plugins=2fa,admin,username
+pnpm sonamu auth generate --plugins=2fa,admin,username
 ```
 
 Supported plugins:
@@ -408,7 +408,7 @@ To use better-auth plugins, add them to the `auth.plugins` array in `sonamu.conf
 
 <Warning>
   Before configuring plugins, you must first generate the required entities and fields using `pnpm
-  sonamu better-auth --plugins=...`.
+  sonamu auth generate --plugins=...`.
 </Warning>
 
 ### Two-Factor Authentication (2FA)
@@ -807,7 +807,7 @@ export default defineConfig({
 
 ```bash
 # Generate entities before auth configuration
-pnpm sonamu better-auth
+pnpm sonamu auth generate
 
 # Run migrations
 pnpm sonamu migrate run
@@ -846,7 +846,7 @@ export default defineConfig({
 
 ### 4. Compatibility with Existing User Entity
 
-If a User entity already exists, running `pnpm sonamu better-auth` will only add missing fields. Existing data is preserved.
+If a User entity already exists, running `pnpm sonamu auth generate` will only add missing fields. Existing data is preserved.
 
 ## Next Steps
 

--- a/modules/docs/en/configuration/sonamu-config/auth.mdx
+++ b/modules/docs/en/configuration/sonamu-config/auth.mdx
@@ -416,8 +416,7 @@ To use better-auth plugins, add them to the `auth.plugins` array in `sonamu.conf
 Enable TOTP-based two-factor authentication:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { twoFactor, TWO_FACTOR_SCHEMA } from "sonamu/auth";
+import { defineConfig, twoFactor, TWO_FACTOR_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -445,8 +444,7 @@ export default defineConfig({
 Supports user roles, banning, and impersonation:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { admin, ADMIN_SCHEMA } from "sonamu/auth";
+import { defineConfig, admin, ADMIN_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -474,8 +472,7 @@ Fields added to User table by Admin plugin:
 Allows login with username instead of email:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { username, USERNAME_SCHEMA } from "sonamu/auth";
+import { defineConfig, username, USERNAME_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -500,8 +497,7 @@ Fields added to User table by Username plugin:
 Supports phone number verification:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { phoneNumber, PHONE_NUMBER_SCHEMA } from "sonamu/auth";
+import { defineConfig, phoneNumber, PHONE_NUMBER_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -526,8 +522,7 @@ Fields added to User table by Phone Number plugin:
 Supports WebAuthn/FIDO2 based passkey authentication:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { passkey, PASSKEY_SCHEMA } from "sonamu/auth";
+import { defineConfig, passkey, PASSKEY_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -561,8 +556,7 @@ Passkey-related APIs:
 Supports SSO login through external IdPs (OIDC, SAML):
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { sso, SSO_SCHEMA } from "sonamu/auth";
+import { defineConfig, sso, SSO_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -588,8 +582,7 @@ Tables created by SSO plugin:
 Supports API key based authentication:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { apiKey, API_KEY_SCHEMA } from "sonamu/auth";
+import { defineConfig, apiKey, API_KEY_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -619,8 +612,7 @@ API Key-related APIs:
 Supports JWT token issuance and JWKS key management:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { jwt, JWT_SCHEMA } from "sonamu/auth";
+import { defineConfig, jwt, JWT_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -649,8 +641,7 @@ JWT-related APIs:
 Supports organization, member, invitation, and team management:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { organization, ORGANIZATION_SCHEMA } from "sonamu/auth";
+import { defineConfig, organization, ORGANIZATION_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -690,8 +681,7 @@ Organization-related APIs:
 Supports anonymous user authentication. Allows creating temporary users without sign-up:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { anonymous, ANONYMOUS_SCHEMA } from "sonamu/auth";
+import { defineConfig, anonymous, ANONYMOUS_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -718,8 +708,8 @@ Anonymous-related APIs:
 ### Using Multiple Plugins Together
 
 ```typescript
-import { defineConfig } from "sonamu";
 import {
+  defineConfig,
   admin,
   ADMIN_SCHEMA,
   twoFactor,
@@ -730,7 +720,7 @@ import {
   PASSKEY_SCHEMA,
   organization,
   ORGANIZATION_SCHEMA,
-} from "sonamu/auth";
+} from "sonamu";
 
 export default defineConfig({
   server: {

--- a/modules/docs/en/configuration/sonamu-config/storage.mdx
+++ b/modules/docs/en/configuration/sonamu-config/storage.mdx
@@ -389,10 +389,8 @@ AWS_SECRET_ACCESS_KEY=your_secret_key_here
 After storage configuration, you can upload files using the `@upload` decorator and `BufferedFile.saveToDisk()`.
 
 ```typescript
+import { BaseModelClass, Sonamu, upload } from "sonamu";
 import { type DriverKey } from "sonamu/storage";
-import { Sonamu } from "sonamu";
-import { upload } from "sonamu/decorators";
-import { BaseModelClass } from "sonamu";
 
 export class FileModel extends BaseModelClass {
   @upload()

--- a/modules/docs/ko/api-development/authentication/session-management.mdx
+++ b/modules/docs/ko/api-development/authentication/session-management.mdx
@@ -623,23 +623,28 @@ class AuthModel extends BaseModelClass {
 주기적으로 만료된 Refresh Token을 삭제하여 데이터베이스 크기를 관리합니다.
 
 ```typescript
-// tasks/cleanup-tokens.ts
-import { task } from "sonamu";
+// src/workflows/cleanup-tokens.workflow.ts
+import { BaseModel, workflow } from "sonamu";
 
 /**
  * 매일 자정에 만료된 Refresh Token 삭제
  */
-@task({ cron: "0 0 * * *" })
-export async function cleanupExpiredTokens() {
-  const db = getDatabase();
+export const cleanupExpiredTokens = workflow(
+  {
+    name: "cleanup_expired_tokens",
+    schedules: [{ expression: "0 0 * * *" }],
+  },
+  async ({ logger }) => {
+    const wdb = BaseModel.getPuri("w");
 
-  const result = await db
-    .table("refresh_tokens")
-    .where("expires_at", "<", new Date())
-    .delete();
+    const deleted = await wdb
+      .table("refresh_tokens")
+      .where("expires_at", "<", new Date())
+      .delete();
 
-  console.log(`Deleted ${result} expired refresh tokens`);
-}
+    logger.info(`Deleted ${deleted} expired refresh tokens`);
+  },
+);
 ```
 
 ## 주의사항

--- a/modules/docs/ko/configuration/sonamu-config/auth.mdx
+++ b/modules/docs/ko/configuration/sonamu-config/auth.mdx
@@ -413,8 +413,7 @@ better-auth 플러그인을 사용하려면 `sonamu.config.ts`의 `auth.plugins`
 TOTP 기반 2단계 인증을 활성화합니다:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { twoFactor, TWO_FACTOR_SCHEMA } from "sonamu/auth";
+import { defineConfig, twoFactor, TWO_FACTOR_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -442,8 +441,7 @@ export default defineConfig({
 사용자 역할, 차단 기능, 대리 로그인(impersonation)을 지원합니다:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { admin, ADMIN_SCHEMA } from "sonamu/auth";
+import { defineConfig, admin, ADMIN_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -471,8 +469,7 @@ Admin 플러그인이 User 테이블에 추가하는 필드:
 이메일 대신 사용자명으로 로그인할 수 있습니다:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { username, USERNAME_SCHEMA } from "sonamu/auth";
+import { defineConfig, username, USERNAME_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -497,8 +494,7 @@ Username 플러그인이 User 테이블에 추가하는 필드:
 전화번호 인증을 지원합니다:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { phoneNumber, PHONE_NUMBER_SCHEMA } from "sonamu/auth";
+import { defineConfig, phoneNumber, PHONE_NUMBER_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -523,8 +519,7 @@ Phone Number 플러그인이 User 테이블에 추가하는 필드:
 WebAuthn/FIDO2 기반 패스키 인증을 지원합니다:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { passkey, PASSKEY_SCHEMA } from "sonamu/auth";
+import { defineConfig, passkey, PASSKEY_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -558,8 +553,7 @@ Passkey 관련 API:
 외부 IdP(OIDC, SAML)를 통한 SSO 로그인을 지원합니다:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { sso, SSO_SCHEMA } from "sonamu/auth";
+import { defineConfig, sso, SSO_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -585,8 +579,7 @@ SSO 플러그인이 생성하는 테이블:
 API 키 기반 인증을 지원합니다:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { apiKey, API_KEY_SCHEMA } from "sonamu/auth";
+import { defineConfig, apiKey, API_KEY_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -616,8 +609,7 @@ API Key 관련 API:
 JWT 토큰 발급 및 JWKS 키 관리를 지원합니다:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { jwt, JWT_SCHEMA } from "sonamu/auth";
+import { defineConfig, jwt, JWT_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -646,8 +638,7 @@ JWT 관련 API:
 조직, 멤버, 초대, 팀 관리를 지원합니다:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { organization, ORGANIZATION_SCHEMA } from "sonamu/auth";
+import { defineConfig, organization, ORGANIZATION_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -687,8 +678,7 @@ Organization 관련 API:
 익명 사용자 인증을 지원합니다. 회원가입 없이 임시 사용자를 생성할 수 있습니다:
 
 ```typescript
-import { defineConfig } from "sonamu";
-import { anonymous, ANONYMOUS_SCHEMA } from "sonamu/auth";
+import { defineConfig, anonymous, ANONYMOUS_SCHEMA } from "sonamu";
 
 export default defineConfig({
   server: {
@@ -715,8 +705,8 @@ Anonymous 관련 API:
 ### 여러 플러그인 함께 사용
 
 ```typescript
-import { defineConfig } from "sonamu";
 import {
+  defineConfig,
   admin,
   ADMIN_SCHEMA,
   twoFactor,
@@ -727,7 +717,7 @@ import {
   PASSKEY_SCHEMA,
   organization,
   ORGANIZATION_SCHEMA,
-} from "sonamu/auth";
+} from "sonamu";
 
 export default defineConfig({
   server: {

--- a/modules/docs/ko/configuration/sonamu-config/auth.mdx
+++ b/modules/docs/ko/configuration/sonamu-config/auth.mdx
@@ -130,7 +130,7 @@ better-auth를 사용하려면 먼저 필요한 엔티티들을 생성해야 합
 ### CLI로 엔티티 생성
 
 ```bash
-pnpm sonamu better-auth
+pnpm sonamu auth generate
 ```
 
 이 명령은 다음 엔티티들을 생성합니다:
@@ -150,10 +150,10 @@ better-auth 플러그인을 사용하려면 `--plugins` 옵션으로 필요한 �
 
 ```bash
 # 단일 플러그인
-pnpm sonamu better-auth --plugins=2fa
+pnpm sonamu auth generate --plugins=2fa
 
 # 여러 플러그인 (쉼표로 구분)
-pnpm sonamu better-auth --plugins=2fa,admin,username
+pnpm sonamu auth generate --plugins=2fa,admin,username
 ```
 
 지원하는 플러그인:
@@ -404,7 +404,7 @@ export function GoogleLoginButton() {
 better-auth 플러그인을 사용하려면 `sonamu.config.ts`의 `auth.plugins` 배열에 플러그인을 추가합니다.
 
 <Warning>
-  플러그인을 설정하기 전에 먼저 `pnpm sonamu better-auth --plugins=...` 명령으로 필요한 엔티티와
+  플러그인을 설정하기 전에 먼저 `pnpm sonamu auth generate --plugins=...` 명령으로 필요한 엔티티와
   필드를 생성해야 합니다.
 </Warning>
 
@@ -804,7 +804,7 @@ export default defineConfig({
 
 ```bash
 # auth 설정 전에 먼저 엔티티 생성
-pnpm sonamu better-auth
+pnpm sonamu auth generate
 
 # 마이그레이션 실행
 pnpm sonamu migrate run
@@ -843,7 +843,7 @@ export default defineConfig({
 
 ### 4. 기존 User 엔티티와의 호환성
 
-이미 User 엔티티가 있는 경우, `pnpm sonamu better-auth` 실행 시 누락된 필드만 추가됩니다. 기존 데이터는 유지됩니다.
+이미 User 엔티티가 있는 경우, `pnpm sonamu auth generate` 실행 시 누락된 필드만 추가됩니다. 기존 데이터는 유지됩니다.
 
 ## 다음 단계
 

--- a/modules/docs/ko/configuration/sonamu-config/storage.mdx
+++ b/modules/docs/ko/configuration/sonamu-config/storage.mdx
@@ -387,10 +387,8 @@ AWS_SECRET_ACCESS_KEY=your_secret_key_here
 스토리지 설정 후 `@upload` 데코레이터와 `BufferedFile.saveToDisk()`를 사용하여 파일을 업로드할 수 있습니다.
 
 ```typescript
+import { BaseModelClass, Sonamu, upload } from "sonamu";
 import { type DriverKey } from "sonamu/storage";
-import { Sonamu } from "sonamu";
-import { upload } from "sonamu/decorators";
-import { BaseModelClass } from "sonamu";
 
 export class FileModel extends BaseModelClass {
   @upload()


### PR DESCRIPTION
## 이 PR은 무엇인가요?

Nightly PR Directions(#43)에 따라 **AI(Claude Code)가 자동으로 생성**한 문서 정정 PR입니다. 작업 범위는 #44의 지침(“문서와 주석이 코드와 어긋나는 경우 설명을 업데이트”, “`/modules/docs/ko` 수정 시 `/modules/docs/en` 동기화”)을 따랐습니다.

소스 동작은 **전혀 바꾸지 않았고**, 문서 4개 파일(ko 3 + en 3, 실제로는 auth·storage·session-management의 ko/en 6파일)만 수정했습니다. 판단이 틀렸다고 보시면 그대로 닫으셔도 됩니다.

## 왜 이 작업을 골랐나요?

문서의 `import` 경로와 CLI 명령을 실제 `modules/sonamu` 소스와 대조한 결과, **복사해서 실행하면 즉시 실패하는** 세 가지 사실 오류를 찾았습니다. 추측이나 스타일 취향이 아니라 소스에서 확인 가능한 불일치만 담았습니다.

### 1. 존재하지 않는 서브패스 import (`e6a5cfee`)

`modules/sonamu/package.json`의 `exports` 맵에는 `"./auth"`와 `"./decorators"` 항목이 **없습니다**. (있는 것은 `"./auth/plugins"`, `"./cache"`, `"./storage"` 등)

- `configuration/sonamu-config/auth.mdx`: 11곳이 `import { admin, ADMIN_SCHEMA } from "sonamu/auth";`
- `configuration/sonamu-config/storage.mdx`: 1곳이 `import { upload } from "sonamu/decorators";`

두 심볼 모두 루트에서 노출됩니다.
- `src/index.ts` → `export * from "./auth"` → `src/auth/index.ts` → `export * from "./plugins"` → `wrappers/index.ts`가 `admin`/`twoFactor`/`*_SCHEMA` 등을 export
- `src/index.ts` → `export * from "./api/decorators"` → `upload` (`src/api/decorators.ts:448`)

문서대로 실행하면 Node가 `ERR_PACKAGE_PATH_NOT_EXPORTED`로 죽습니다. **루트 `"sonamu"`로 합치는 방식**을 택했는데, 이는 `sonamu/auth/plugins`로 고치는 것보다 실제 코드(`examples/miomock/api/src/sonamu.config.ts:5`가 `import { admin, ..., passkey, ..., twoFactor } from "sonamu"`)의 관용구와 일치하기 때문입니다.

### 2. 존재하지 않는 CLI 명령 `sonamu better-auth` (`1be68782`)

`src/bin/cli.ts`의 tsicli `args`에 등록된 인증 명령은 `["auth", "generate"]`와 `["auth", "add-companions"]` 뿐이고, `--plugins` 옵션을 파싱하는 것도 `auth_generate()`입니다. `better-auth`라는 명령은 없습니다.

auth.mdx는 “엔티티 생성” 절 전체를 `pnpm sonamu better-auth`로 안내하고 있어, 인증을 처음 붙이는 사용자가 **첫 단계에서 막힙니다**. 명령 표기 6곳만 `pnpm sonamu auth generate`로 바꿨고, better-auth 라이브러리 자체를 가리키는 설명 문장은 손대지 않았습니다. 플러그인 ID(`2fa,admin,username`)는 `SUPPORTED_PLUGIN_IDS`와 일치함을 확인해 그대로 두었습니다.

### 3. 존재하지 않는 `@task` 데코레이터 예제 (`d11f3f80`)

`api-development/authentication/session-management.mdx`의 “만료된 세션 정리” 예제:

```ts
import { task } from "sonamu";      // sonamu는 task를 export하지 않음
@task({ cron: "0 0 * * *" })        // 데코레이터 문법도 아님
export async function cleanupExpiredTokens() {
  const db = getDatabase();         // 정의되지 않은 함수
```

실제 스케줄 API는 `src/tasks/decorator.ts`의 `workflow(options, fn)` 팩토리이며, 주기 실행은 `options.schedules[].expression`으로 표현합니다. 같은 저장소의 `advanced-features/workflows/workflow-decorator.mdx`(cleanupOldData 예제)와 동일한 형태로 맞췄고, 모델 클래스 밖에서의 DB 접근은 `worker-setup.mdx`가 쓰는 `BaseModel.getPuri()`로, 로그는 workflow 컨텍스트가 넘겨주는 `logger`(`workflow-manager.ts:45`)로 통일했습니다.

## 영향 범위

- 런타임 영향 **없음**. `modules/docs`의 mdx 본문만 변경했습니다.
- 영향을 받는 독자 경로: 인증 설정(`/configuration/sonamu-config/auth`), 스토리지 업로드 예제(`/configuration/sonamu-config/storage`), 세션 관리(`/api-development/authentication/session-management`). ko/en 모두 동일하게 반영했습니다.

## 확인 방법

```bash
# 1. 잘못된 서브패스가 문서에 남아있지 않은지
grep -rn 'from "sonamu/auth"\|from "sonamu/decorators"' modules/docs   # 결과 없음

# 2. 해당 서브패스가 실제로 없다는 근거
node -e 'console.log(Object.keys(require("./modules/sonamu/package.json").exports))'

# 3. CLI 명령 목록 확인
grep -n '\["auth"' modules/sonamu/src/bin/cli.ts

# 4. 포맷/린트
pnpm check
```

`pnpm check`(oxlint --type-aware + oxfmt) 통과를 확인했습니다.

## 사람의 확인이 필요한 부분

- **import 경로 선택**: `"sonamu"`(루트) 대신 `"sonamu/auth/plugins"`를 정식 경로로 안내하고 싶으시다면 그쪽이 맞습니다. miomock의 실사용 코드를 근거로 루트를 골랐을 뿐, 패키지 설계 의도는 확인하지 못했습니다.
- **문서 예제 타입 검증 부재**: mdx 코드 블록은 CI에서 타입 체크되지 않습니다. 새로 쓴 workflow 예제는 `workflow()` 오버로드와 `PuriWrapper.table()` 시그니처를 소스에서 눈으로 대조했을 뿐, 실제 컴파일로 검증하지는 못했습니다. 특히 `wdb.table("refresh_tokens")`는 프로젝트 스키마 타입에 해당 테이블이 있어야 통과합니다(주변 예제들도 같은 전제).
- **`sonamu better-auth`의 과거 존재 여부**: 이 명령이 예전에 있다가 `auth generate`로 개명된 것인지, 처음부터 오기였는지는 히스토리에서 확정하지 못했습니다. 어느 쪽이든 현재 코드 기준으로는 동작하지 않습니다.
