### PR TITLE
[Nightly 2026-08-18] 마이그레이션 문서의 미존재 CLI 명령(migrate rollback·down·up·latest, sonamu ui·validate) 정정 및 롤백 안내를 Sonamu UI·Migrator API 기준으로 재작성 (ko/en 6파일)

### DIFF
--- a/modules/docs/en/database/migrations/creating-migrations.mdx
+++ b/modules/docs/en/database/migrations/creating-migrations.mdx
@@ -44,8 +44,13 @@ First, modify the Entity JSON file:
 
 ### 2. Open Sonamu UI
 
+Start the API dev server and open it in a browser. Sonamu UI is served from the API server's
+`/sonamu-ui` path, without a separate port.
+
 ```bash
-pnpm sonamu ui
+pnpm dev
+
+# http://localhost:34900/sonamu-ui
 ```
 
 <Frame>
@@ -359,11 +364,11 @@ psql -U postgres -h localhost -p 5432 -d mydb
 pnpm sonamu migrate status
 ```
 
-### 3. Validate Entity
+### 3. Sync Entities
 
 ```bash
-# Validate Entity syntax
-pnpm sonamu validate
+# Read Entity definitions and regenerate types/schemas (fails on invalid definitions)
+pnpm sonamu sync
 ```
 
 ## Manual Modification

--- a/modules/docs/en/database/migrations/rolling-back.mdx
+++ b/modules/docs/en/database/migrations/rolling-back.mdx
@@ -1,43 +1,60 @@
 ---
 title: "Rolling Back"
-description: "Undo changes with migrate rollback"
+description: "Undo changes from Sonamu UI"
 ---
 
 Rollback migrations to restore the database to a previous state.
 
-## Rollback Commands
+## Rollback Methods
 
 <CardGroup cols={2}>
-  <Card title="rollback" icon="rotate-left">
-    Rollback recent batch Multiple at once
+  <Card title="Sonamu UI" icon="rotate-left">
+    Rollback button on the Migrations tab Rolls back the most recent batch
   </Card>
-  <Card title="rollback --all" icon="arrows-rotate">
-    Rollback all migrations Return to initial state
+  <Card title="runAction()" icon="code">
+    Call the Migrator API directly For scripts and automation
   </Card>
-  <Card title="down" icon="arrow-down">
-    One at a time Step-by-step rollback
-  </Card>
-  <Card title="status" icon="list-check">
+  <Card title="migrate status" icon="list-check">
     Check status before rollback Verify batches
+  </Card>
+  <Card title="down function" icon="arrow-down">
+    Reverse operation in the migration file Determines the rollback result
   </Card>
 </CardGroup>
 
+<Warning>
+  **There is no rollback CLI command.** `sonamu migrate` provides exactly four subcommands: `run`,
+  `apply`, `generate`, and `status`. Rollback is performed only from Sonamu UI or via
+  `Migrator.runAction("rollback", ...)`.
+</Warning>
+
 ## Basic Rollback
 
-### Rollback Recent Batch
+### Rollback from Sonamu UI
+
+1. Start the API dev server (`pnpm dev`).
+2. Open the **Migrations** tab at `http://localhost:34900/sonamu-ui`.
+3. Select the database connections to roll back.
+4. Click **Rollback** and confirm in the modal.
+
+<Info>A rollback reverts **every migration in the most recent batch** of the selected database.</Info>
+
+### Rollback from a Script
+
+For CI or operational scripts, call `Migrator` directly.
+
+```typescript title="src/scripts/rollback-migration.ts"
+import { Migrator, Sonamu } from "sonamu";
+
+Sonamu.runScript(async () => {
+  const migrator = new Migrator();
+  await migrator.runAction("rollback", ["development"]);
+});
+```
 
 ```bash
-pnpm sonamu migrate rollback
+pnpm tsx src/scripts/rollback-migration.ts
 ```
-
-**Execution Result**:
-
-```
-Batch 2 rolled back: 1 migration
-✅ 20251220143200_alter_users_add1.ts
-```
-
-<Info>`migrate rollback` rolls back all migrations in the most recent batch.</Info>
 
 ### Check Current Status
 
@@ -59,70 +76,32 @@ Pending migrations:
   ⏳ 20251220143300_alter_posts_add1.ts
 ```
 
-## Rollback Methods
+## Rollback Granularity
 
 ### Batch-based Rollback
 
-```bash
-# Check status
-pnpm sonamu migrate status
-
-# Batch 3 (most recent)
-✅ 20251220150000_alter_users_add2.ts
-✅ 20251220150100_alter_posts_add2.ts
-
-# Batch 2
-✅ 20251220143200_alter_users_add1.ts
-
-# Rollback (Batch 3 only)
-pnpm sonamu migrate rollback
-
-# Result: 2 migrations in Batch 3 rolled back
-Batch 3 rolled back: 2 migrations
-✅ 20251220150000_alter_users_add2.ts
-✅ 20251220150100_alter_posts_add2.ts
-```
-
-### One at a Time
-
-```bash
-pnpm sonamu migrate down
-```
-
-**First Run**:
+The unit of a rollback is a **batch**. A single rollback reverts every migration in the most recent
+batch.
 
 ```
-Batch 2 rolled back: 1 migration
-✅ 20251220143200_alter_users_add1.ts
+# Before rollback
+Batch 3 (most recent): 20251220150000_alter_users_add2.ts
+                       20251220150100_alter_posts_add2.ts
+Batch 2:               20251220143200_alter_users_add1.ts
+
+# One rollback → both migrations in Batch 3 are rolled back together
+Batch 2:               20251220143200_alter_users_add1.ts  ← kept
 ```
 
-**Second Run**:
+### Reverting Multiple Batches
 
-```
-Batch 1 rolled back: 1 migration
-✅ 20251220143100_create__posts.ts
-```
+There is no way to roll back a single selected migration or several batches at once. To go further
+back, **run the rollback once per batch**, checking `pnpm sonamu migrate status` between runs.
 
-### Full Rollback
-
-```bash
-pnpm sonamu migrate rollback --all
-```
-
-**Execution Result**:
-
-```
-Batch 2 rolled back: 1 migration
-✅ 20251220143200_alter_users_add1.ts
-
-Batch 1 rolled back: 2 migrations
-✅ 20251220143100_create__posts.ts
-✅ 20251220143022_create__users.ts
-
-All migrations rolled back successfully
-```
-
-<Warning>`rollback --all` deletes all tables! Never use in production.</Warning>
+<Warning>
+  Repeating rollbacks eventually returns the database to its initial schema (all tables dropped).
+  Verify the impact of each run in production.
+</Warning>
 
 ## The down Function
 
@@ -198,8 +177,7 @@ pnpm sonamu migrate run
 
 # 2. Discover problem (wrong column type)
 
-# 3. Rollback
-pnpm sonamu migrate rollback
+# 3. Roll back from the Migrations tab in Sonamu UI
 
 # 4. Fix migration file
 vim src/migrations/20251220143200_alter_users_add1.ts
@@ -210,27 +188,34 @@ pnpm sonamu migrate run
 
 ### Scenario 2: Production Emergency Rollback
 
+The production database is often unreachable from wherever Sonamu UI runs, so run the rollback
+script with production environment variables.
+
 ```bash
 # 1. Problem discovered after production deployment
 
-# 2. Immediate rollback
-NODE_ENV=production pnpm sonamu migrate rollback
+# 2. Immediate rollback (script calling runAction("rollback", ["production"]))
+NODE_ENV=production pnpm tsx src/scripts/rollback-migration.ts
 
 # 3. Deploy previous application version
 
 # 4. Fix problem and redeploy
 ```
 
+<Info>
+  When `NODE_ENV` is not `local`, only the connection whose name matches the environment is allowed
+  as a target. Any other target is rejected with an error.
+</Info>
+
 ### Scenario 3: Partial Rollback
 
-```bash
+```
 # Current status
 Batch 3: alter_users_add2.ts, alter_posts_add2.ts
 Batch 2: alter_users_add1.ts
 Batch 1: create__users.ts, create__posts.ts
 
-# Rollback only Batch 3 (keep Batch 2, 1)
-pnpm sonamu migrate rollback
+# One rollback → only Batch 3 is rolled back (Batch 2, 1 kept)
 
 # Result
 Batch 2: alter_users_add1.ts  ← Retained
@@ -239,7 +224,7 @@ Batch 1: create__users.ts, create__posts.ts  ← Retained
 
 ```mermaid
 flowchart TD
-    A[Batch 3<br/>alter_users_add2<br/>alter_posts_add2] --> B[rollback command]
+    A[Batch 3<br/>alter_users_add2<br/>alter_posts_add2] --> B[one rollback run]
     C[Batch 2<br/>alter_users_add1] --> D[Continue retained]
     E[Batch 1<br/>create__users<br/>create__posts] --> D
 
@@ -346,8 +331,7 @@ export async function down(knex: Knex): Promise<void> {
 # PostgreSQL backup
 pg_dump -U postgres -d mydb > backup_before_rollback.sql
 
-# Rollback
-pnpm sonamu migrate rollback
+# Rollback (Sonamu UI or the rollback script)
 
 # Restore if issues occur
 psql -U postgres -d mydb < backup_before_rollback.sql
@@ -357,34 +341,30 @@ psql -U postgres -d mydb < backup_before_rollback.sql
 
 ```bash
 # Test rollback in staging
-NODE_ENV=staging pnpm sonamu migrate rollback
+NODE_ENV=staging pnpm tsx src/scripts/rollback-migration.ts
 
 # If no issues, production
-NODE_ENV=production pnpm sonamu migrate rollback
+NODE_ENV=production pnpm tsx src/scripts/rollback-migration.ts
 ```
 
 ### 3. Incremental Rollback
 
 ```bash
-# Rollback one at a time
-pnpm sonamu migrate down
+# Roll back once (most recent batch)
 
 # Check status
 pnpm sonamu migrate status
 
 # Test application
 
-# Next rollback
-pnpm sonamu migrate down
+# If everything looks fine, roll back the next batch
 ```
 
 ## Error Handling
 
 ### Rollback Failure
 
-```bash
-pnpm sonamu migrate rollback
-```
+When a down function fails during rollback, an error like the following is raised.
 
 **Error**:
 
@@ -418,21 +398,18 @@ ALTER TABLE users DROP COLUMN phone;
 
 ## Rollback Logs
 
-### Verbose Logs
+### Checking the Result
 
-```bash
-pnpm sonamu migrate rollback --verbose
+`runAction("rollback", ...)` returns the batch number and the list of rolled back files per target
+connection.
+
+```typescript
+const results = await migrator.runAction("rollback", ["development"]);
+console.log(results);
+// [{ connKey: "development", batchNo: 2, applied: ["20251220143200_alter_users_add1.ts"] }]
 ```
 
-**Output**:
-
-```
-Rolling back migration: 20251220143200_alter_users_add1.ts
-SQL: ALTER TABLE "users" DROP COLUMN "phone"
-✅ Completed in 23ms
-
-Batch 2 rolled back: 1 migration
-```
+Sonamu UI shows the same information in the result modal.
 
 ### Querying Rollback History
 
@@ -474,7 +451,7 @@ test("migration reversibility", async () => {
 
 ### Rollback Steps
 
-1. `pnpm sonamu migrate rollback`
+1. Roll back from the Migrations tab in Sonamu UI (or run the rollback script)
 2. Deploy previous app version
 3. Verify phone field not used
 ```
@@ -489,7 +466,7 @@ echo "Creating backup..."
 pg_dump -U postgres -d mydb > backup.sql
 
 echo "Rolling back..."
-pnpm sonamu migrate rollback
+pnpm tsx src/scripts/rollback-migration.ts
 
 if [ $? -eq 0 ]; then
   echo "✅ Rollback successful"

--- a/modules/docs/en/database/migrations/running-migrations.mdx
+++ b/modules/docs/en/database/migrations/running-migrations.mdx
@@ -14,13 +14,18 @@ How to apply generated Migration files to the database.
   <Card title="migrate status" icon="list-check">
     Check execution status Pending list
   </Card>
-  <Card title="migrate latest" icon="forward">
-    Run to latest Same as run
+  <Card title="migrate apply" icon="database">
+    Run against selected databases
   </Card>
-  <Card title="migrate up" icon="arrow-up">
-    One at a time Step-by-step execution
+  <Card title="migrate generate" icon="plus">
+    Generate prepared migration files
   </Card>
 </CardGroup>
+
+<Info>
+  `sonamu migrate` has exactly four subcommands: `run`, `apply`, `generate`, and `status`. Rollback
+  is not a CLI command — see [Rolling Back](/en/database/migrations/rolling-back).
+</Info>
 
 ## Basic Execution
 
@@ -85,29 +90,34 @@ flowchart TD
     style E fill:#fff3e0
 ```
 
-## Step-by-step Execution
+## Targeting Specific Databases
 
-### One at a Time
+### migrate apply
+
+`migrate run` applies migrations only to the database matching the current `NODE_ENV` (`test` and
+`fixture` when `NODE_ENV=test`). To choose the targets yourself, use `migrate apply`.
 
 ```bash
-pnpm sonamu migrate up
+pnpm sonamu migrate apply
 ```
 
-**First Run**:
+A target selection prompt appears.
 
 ```
-Batch 1 run: 1 migration
-✅ 20251220143022_create__users.ts
+? Please input #targets ›
+◯ Development
+◯ Staging
+◯ Production
+◯ Fixture
+◯ Test
 ```
 
-**Second Run**:
+<Warning>
+  When `NODE_ENV` is not `local`, only the connection whose name matches the environment is allowed.
+  Choosing any other target fails with `Migration targets are not allowed in NODE_ENV=...`.
+</Warning>
 
-```
-Batch 2 run: 1 migration
-✅ 20251220143100_create__posts.ts
-```
-
-<Info>`migrate up` executes only the oldest pending migration.</Info>
+<Info>There is no command to run a single migration at a time. The execution unit is always all pending migrations.</Info>
 
 ## Batch System
 
@@ -249,31 +259,11 @@ Batch 1 run: 2 migrations (1 successful, 1 failed)
 
 ## Checking Execution Logs
 
-### Verbose Logs
+### Execution Result
 
-```bash
-pnpm sonamu migrate run --verbose
-```
-
-**Output**:
-
-```
-Running migration: 20251220143022_create__users.ts
-SQL: CREATE TABLE "users" (
-  "id" serial primary key,
-  "email" varchar(255) not null
-)
-✅ Completed in 45ms
-
-Running migration: 20251220143100_create__posts.ts
-SQL: CREATE TABLE "posts" (
-  "id" serial primary key,
-  "title" varchar(200) not null
-)
-✅ Completed in 32ms
-
-Total time: 77ms
-```
+`migrate run` prints the batch number and the list of applied files per target connection. There is
+no option for SQL-level verbose logging, so use the `knex_migrations` queries below or your database
+server logs to inspect the executed SQL.
 
 ### Querying Execution History
 
@@ -422,7 +412,7 @@ console.log(`Migration completed in ${duration}ms`);
 
 <CardGroup cols={2}>
   <Card title="Rolling Back" icon="rotate-left" href="/en/database/migrations/rolling-back">
-    Undo with migrate rollback
+    Undo from Sonamu UI
   </Card>
   <Card title="Strategies" icon="chess" href="/en/database/migrations/migration-strategies">
     Safe migration practices

--- a/modules/docs/ko/database/migrations/creating-migrations.mdx
+++ b/modules/docs/ko/database/migrations/creating-migrations.mdx
@@ -44,8 +44,13 @@ Sonamu는 Entity 변경 사항을 감지하여 자동으로 Migration 파일을 
 
 ### 2. Sonamu UI 열기
 
+API 개발 서버를 실행한 뒤 브라우저에서 접속합니다. Sonamu UI는 별도 포트 없이 API 서버의
+`/sonamu-ui` 경로에서 제공됩니다.
+
 ```bash
-pnpm sonamu ui
+pnpm dev
+
+# http://localhost:34900/sonamu-ui
 ```
 
 ### 3. Generate 버튼 클릭
@@ -361,11 +366,11 @@ psql -U postgres -h localhost -p 5432 -d mydb
 pnpm sonamu migrate status
 ```
 
-### 3. Entity 검증
+### 3. Entity 동기화
 
 ```bash
-# Entity 문법 검증
-pnpm sonamu validate
+# Entity 정의를 읽어 타입/스키마를 재생성 (정의 오류가 있으면 여기서 실패)
+pnpm sonamu sync
 ```
 
 ## 수동 수정

--- a/modules/docs/ko/database/migrations/rolling-back.mdx
+++ b/modules/docs/ko/database/migrations/rolling-back.mdx
@@ -1,43 +1,60 @@
 ---
 title: "롤백하기"
-description: "migrate rollback으로 변경 사항 되돌리기"
+description: "Sonamu UI에서 변경 사항 되돌리기"
 ---
 
 Migration을 롤백하여 데이터베이스를 이전 상태로 되돌릴 수 있습니다.
 
-## 롤백 명령어
+## 롤백 수단
 
 <CardGroup cols={2}>
-  <Card title="rollback" icon="rotate-left">
-    최근 batch 롤백 한 번에 여러 개
+  <Card title="Sonamu UI" icon="rotate-left">
+    Migrations 탭의 롤백 버튼 최근 batch 롤백
   </Card>
-  <Card title="rollback --all" icon="arrows-rotate">
-    모든 Migration 롤백 초기 상태로
+  <Card title="runAction()" icon="code">
+    Migrator API 직접 호출 스크립트/자동화용
   </Card>
-  <Card title="down" icon="arrow-down">
-    한 번에 하나씩 단계별 롤백
-  </Card>
-  <Card title="status" icon="list-check">
+  <Card title="migrate status" icon="list-check">
     롤백 전 상태 확인 batch 확인
+  </Card>
+  <Card title="down 함수" icon="arrow-down">
+    Migration 파일의 역작업 롤백 결과를 결정
   </Card>
 </CardGroup>
 
+<Warning>
+  **롤백 전용 CLI 명령은 없습니다.** `sonamu migrate`가 제공하는 서브커맨드는 `run`, `apply`,
+  `generate`, `status` 네 가지뿐입니다. 롤백은 Sonamu UI 또는 `Migrator.runAction("rollback", ...)`
+  으로만 수행합니다.
+</Warning>
+
 ## 기본 롤백
 
-### 최근 batch 롤백
+### Sonamu UI에서 롤백
+
+1. API 개발 서버를 실행합니다(`pnpm dev`).
+2. `http://localhost:34900/sonamu-ui`의 **Migrations** 탭을 엽니다.
+3. 롤백할 DB 커넥션을 선택합니다.
+4. **롤백** 버튼을 클릭하고 확인 모달에서 실행합니다.
+
+<Info>롤백은 선택한 DB의 **가장 최근 batch에 속한 모든 Migration**을 되돌립니다.</Info>
+
+### 스크립트에서 롤백
+
+CI나 운영 스크립트에서는 `Migrator`를 직접 호출합니다.
+
+```typescript title="src/scripts/rollback-migration.ts"
+import { Migrator, Sonamu } from "sonamu";
+
+Sonamu.runScript(async () => {
+  const migrator = new Migrator();
+  await migrator.runAction("rollback", ["development"]);
+});
+```
 
 ```bash
-pnpm sonamu migrate rollback
+pnpm tsx src/scripts/rollback-migration.ts
 ```
-
-**실행 결과**:
-
-```
-Batch 2 rolled back: 1 migration
-✅ 20251220143200_alter_users_add1.ts
-```
-
-<Info>`migrate rollback`은 가장 최근 batch의 모든 Migration을 롤백합니다.</Info>
 
 ### 현재 상태 확인
 
@@ -63,66 +80,28 @@ Pending migrations:
 
 ### Batch 단위 롤백
 
-```bash
-# 상태 확인
-pnpm sonamu migrate status
-
-# Batch 3 (가장 최근)
-✅ 20251220150000_alter_users_add2.ts
-✅ 20251220150100_alter_posts_add2.ts
-
-# Batch 2
-✅ 20251220143200_alter_users_add1.ts
-
-# 롤백 (Batch 3만)
-pnpm sonamu migrate rollback
-
-# 결과: Batch 3의 2개 Migration 롤백
-Batch 3 rolled back: 2 migrations
-✅ 20251220150000_alter_users_add2.ts
-✅ 20251220150100_alter_posts_add2.ts
-```
-
-### 한 번에 하나씩
-
-```bash
-pnpm sonamu migrate down
-```
-
-**첫 번째 실행**:
+롤백의 단위는 **batch**입니다. 한 번의 롤백은 가장 최근 batch에 속한 Migration을 모두 되돌립니다.
 
 ```
-Batch 2 rolled back: 1 migration
-✅ 20251220143200_alter_users_add1.ts
+# 롤백 전
+Batch 3 (가장 최근): 20251220150000_alter_users_add2.ts
+                     20251220150100_alter_posts_add2.ts
+Batch 2:             20251220143200_alter_users_add1.ts
+
+# 롤백 1회 실행 → Batch 3의 2개 Migration이 함께 롤백됨
+Batch 2:             20251220143200_alter_users_add1.ts  ← 유지
 ```
 
-**두 번째 실행**:
+### 여러 batch 되돌리기
 
-```
-Batch 1 rolled back: 1 migration
-✅ 20251220143100_create__posts.ts
-```
+Migration 하나만 골라서 되돌리거나, 여러 batch를 한 번에 되돌리는 기능은 제공되지 않습니다.
+더 과거로 되돌리려면 **롤백을 batch 수만큼 반복 실행**하고, 각 회차 사이에
+`pnpm sonamu migrate status`로 상태를 확인하세요.
 
-### 전체 롤백
-
-```bash
-pnpm sonamu migrate rollback --all
-```
-
-**실행 결과**:
-
-```
-Batch 2 rolled back: 1 migration
-✅ 20251220143200_alter_users_add1.ts
-
-Batch 1 rolled back: 2 migrations
-✅ 20251220143100_create__posts.ts
-✅ 20251220143022_create__users.ts
-
-All migrations rolled back successfully
-```
-
-<Warning>`rollback --all`은 모든 테이블을 삭제합니다! 프로덕션에서는 절대 사용하지 마세요.</Warning>
+<Warning>
+  롤백을 반복하면 결국 초기 스키마(모든 테이블 삭제)까지 되돌아갑니다. 프로덕션에서는 각 회차마다
+  영향 범위를 확인하세요.
+</Warning>
 
 ## down 함수
 
@@ -198,8 +177,7 @@ pnpm sonamu migrate run
 
 # 2. 문제 발견 (잘못된 컬럼 타입)
 
-# 3. 롤백
-pnpm sonamu migrate rollback
+# 3. Sonamu UI의 Migrations 탭에서 롤백
 
 # 4. Migration 파일 수정
 vim src/migrations/20251220143200_alter_users_add1.ts
@@ -210,27 +188,34 @@ pnpm sonamu migrate run
 
 ### 시나리오 2: 프로덕션 긴급 롤백
 
+프로덕션 DB는 Sonamu UI가 실행되는 환경에서 접근할 수 없는 경우가 많으므로,
+롤백 스크립트를 프로덕션 환경 변수로 실행합니다.
+
 ```bash
 # 1. 프로덕션 배포 후 문제 발견
 
-# 2. 즉시 롤백
-NODE_ENV=production pnpm sonamu migrate rollback
+# 2. 즉시 롤백 (runAction("rollback", ["production"]) 스크립트)
+NODE_ENV=production pnpm tsx src/scripts/rollback-migration.ts
 
 # 3. 이전 버전 애플리케이션 배포
 
 # 4. 문제 수정 후 재배포
 ```
 
+<Info>
+  `NODE_ENV`가 `local`이 아니면 해당 환경과 이름이 같은 DB 커넥션만 작업 대상으로 허용됩니다. 다른
+  대상을 넘기면 에러로 차단됩니다.
+</Info>
+
 ### 시나리오 3: 부분 롤백
 
-```bash
+```
 # 현재 상태
 Batch 3: alter_users_add2.ts, alter_posts_add2.ts
 Batch 2: alter_users_add1.ts
 Batch 1: create__users.ts, create__posts.ts
 
-# Batch 3만 롤백 (Batch 2, 1은 유지)
-pnpm sonamu migrate rollback
+# 롤백 1회 → Batch 3만 롤백 (Batch 2, 1은 유지)
 
 # 결과
 Batch 2: alter_users_add1.ts  ← 유지
@@ -239,7 +224,7 @@ Batch 1: create__users.ts, create__posts.ts  ← 유지
 
 ```mermaid
 flowchart TD
-    A[Batch 3<br/>alter_users_add2<br/>alter_posts_add2] --> B[rollback 명령어]
+    A[Batch 3<br/>alter_users_add2<br/>alter_posts_add2] --> B[롤백 1회 실행]
     C[Batch 2<br/>alter_users_add1] --> D[계속 유지]
     E[Batch 1<br/>create__users<br/>create__posts] --> D
 
@@ -346,8 +331,7 @@ export async function down(knex: Knex): Promise<void> {
 # PostgreSQL 백업
 pg_dump -U postgres -d mydb > backup_before_rollback.sql
 
-# 롤백
-pnpm sonamu migrate rollback
+# 롤백 (Sonamu UI 또는 롤백 스크립트)
 
 # 문제 발생 시 복원
 psql -U postgres -d mydb < backup_before_rollback.sql
@@ -357,34 +341,30 @@ psql -U postgres -d mydb < backup_before_rollback.sql
 
 ```bash
 # 스테이징에서 롤백 테스트
-NODE_ENV=staging pnpm sonamu migrate rollback
+NODE_ENV=staging pnpm tsx src/scripts/rollback-migration.ts
 
 # 문제 없으면 프로덕션
-NODE_ENV=production pnpm sonamu migrate rollback
+NODE_ENV=production pnpm tsx src/scripts/rollback-migration.ts
 ```
 
 ### 3. 점진적 롤백
 
 ```bash
-# 한 번에 하나씩 롤백
-pnpm sonamu migrate down
+# 롤백 1회 실행 (최근 batch)
 
 # 상태 확인
 pnpm sonamu migrate status
 
 # 애플리케이션 테스트
 
-# 다음 롤백
-pnpm sonamu migrate down
+# 이상 없으면 다음 batch 롤백
 ```
 
 ## 에러 처리
 
 ### 롤백 실패
 
-```bash
-pnpm sonamu migrate rollback
-```
+롤백 중 down 함수가 실패하면 다음과 같은 에러가 발생합니다.
 
 **에러**:
 
@@ -418,21 +398,17 @@ ALTER TABLE users DROP COLUMN phone;
 
 ## 롤백 로그
 
-### 상세 로그
+### 실행 결과 확인
 
-```bash
-pnpm sonamu migrate rollback --verbose
+`runAction("rollback", ...)`은 대상 커넥션별로 batch 번호와 롤백된 파일 목록을 반환합니다.
+
+```typescript
+const results = await migrator.runAction("rollback", ["development"]);
+console.log(results);
+// [{ connKey: "development", batchNo: 2, applied: ["20251220143200_alter_users_add1.ts"] }]
 ```
 
-**출력**:
-
-```
-Rolling back migration: 20251220143200_alter_users_add1.ts
-SQL: ALTER TABLE "users" DROP COLUMN "phone"
-✅ Completed in 23ms
-
-Batch 2 rolled back: 1 migration
-```
+Sonamu UI에서 실행한 경우 같은 내용이 결과 모달에 표시됩니다.
 
 ### 롤백 기록 조회
 
@@ -474,7 +450,7 @@ test("migration reversibility", async () => {
 
 ### Rollback Steps
 
-1. `pnpm sonamu migrate rollback`
+1. Sonamu UI Migrations 탭에서 롤백 (또는 롤백 스크립트 실행)
 2. Deploy previous app version
 3. Verify phone field not used
 ```
@@ -489,7 +465,7 @@ echo "Creating backup..."
 pg_dump -U postgres -d mydb > backup.sql
 
 echo "Rolling back..."
-pnpm sonamu migrate rollback
+pnpm tsx src/scripts/rollback-migration.ts
 
 if [ $? -eq 0 ]; then
   echo "✅ Rollback successful"

--- a/modules/docs/ko/database/migrations/running-migrations.mdx
+++ b/modules/docs/ko/database/migrations/running-migrations.mdx
@@ -14,13 +14,18 @@ description: "pnpm sonamu migrate로 데이터베이스 적용하기"
   <Card title="migrate status" icon="list-check">
     실행 상태 확인 pending 목록
   </Card>
-  <Card title="migrate latest" icon="forward">
-    최신까지 실행 run과 동일
+  <Card title="migrate apply" icon="database">
+    대상 DB를 골라서 실행
   </Card>
-  <Card title="migrate up" icon="arrow-up">
-    한 번에 하나씩 단계별 실행
+  <Card title="migrate generate" icon="plus">
+    준비된 Migration 파일 생성
   </Card>
 </CardGroup>
+
+<Info>
+  `sonamu migrate`의 서브커맨드는 `run`, `apply`, `generate`, `status` 네 가지입니다. 롤백은 CLI가
+  아닌 Sonamu UI에서 수행합니다. [롤백하기](/ko/database/migrations/rolling-back) 문서를 참고하세요.
+</Info>
 
 ## 기본 실행
 
@@ -85,29 +90,34 @@ flowchart TD
     style E fill:#fff3e0
 ```
 
-## 단계별 실행
+## 대상 DB 지정 실행
 
-### 한 번에 하나씩
+### migrate apply
+
+`migrate run`은 현재 `NODE_ENV`에 해당하는 DB에만 적용합니다(`NODE_ENV=test`인 경우 `test`와
+`fixture`). 대상 DB를 직접 고르려면 `migrate apply`를 사용합니다.
 
 ```bash
-pnpm sonamu migrate up
+pnpm sonamu migrate apply
 ```
 
-**첫 번째 실행**:
+실행하면 대상 선택 프롬프트가 나타납니다.
 
 ```
-Batch 1 run: 1 migration
-✅ 20251220143022_create__users.ts
+? Please input #targets ›
+◯ Development
+◯ Staging
+◯ Production
+◯ Fixture
+◯ Test
 ```
 
-**두 번째 실행**:
+<Warning>
+  `NODE_ENV`가 `local`이 아니면 해당 환경과 이름이 같은 커넥션만 허용됩니다. 그 외 대상을 고르면
+  `Migration targets are not allowed in NODE_ENV=...` 에러로 차단됩니다.
+</Warning>
 
-```
-Batch 2 run: 1 migration
-✅ 20251220143100_create__posts.ts
-```
-
-<Info>`migrate up`은 pending 중 가장 오래된 Migration 하나만 실행합니다.</Info>
+<Info>Migration 하나씩만 골라서 실행하는 명령은 제공되지 않습니다. 실행 단위는 항상 pending 전체입니다.</Info>
 
 ## Batch 시스템
 
@@ -249,31 +259,11 @@ Batch 1 run: 2 migrations (1 successful, 1 failed)
 
 ## 실행 로그 확인
 
-### 상세 로그
+### 실행 결과
 
-```bash
-pnpm sonamu migrate run --verbose
-```
-
-**출력**:
-
-```
-Running migration: 20251220143022_create__users.ts
-SQL: CREATE TABLE "users" (
-  "id" serial primary key,
-  "email" varchar(255) not null
-)
-✅ Completed in 45ms
-
-Running migration: 20251220143100_create__posts.ts
-SQL: CREATE TABLE "posts" (
-  "id" serial primary key,
-  "title" varchar(200) not null
-)
-✅ Completed in 32ms
-
-Total time: 77ms
-```
+`migrate run`은 대상 커넥션별로 batch 번호와 적용된 파일 목록을 출력합니다. SQL 단위의 상세 로그를
+남기는 옵션은 제공되지 않으므로, 실제 실행된 SQL을 확인하려면 아래 `knex_migrations` 조회나 DB
+서버 로그를 사용하세요.
 
 ### 실행 기록 조회
 
@@ -422,7 +412,7 @@ console.log(`Migration completed in ${duration}ms`);
 
 <CardGroup cols={2}>
   <Card title="롤백하기" icon="rotate-left" href="/ko/database/migrations/rolling-back">
-    migrate rollback으로 되돌리기
+    Sonamu UI에서 되돌리기
   </Card>
   <Card title="전략" icon="chess" href="/ko/database/migrations/migration-strategies">
     안전한 마이그레이션


### PR DESCRIPTION
> 🤖 **이 PR은 AI(Claude Code)가 Nightly 작업으로 자동 생성했습니다.**
> [#43 Nightly PR Directions](https://github.com/cartanova-ai/sonamu/issues/43)의 지침과 [#44](https://github.com/cartanova-ai/sonamu/issues/44)의 작업 범위를 따랐습니다.
> 문서만 수정했고 프레임워크 소스는 건드리지 않았습니다. 판단이 틀렸다고 보이시면 부담 없이 닫아주세요.

## 무엇을, 왜

`modules/docs`의 **마이그레이션 문서 3종(ko/en)**이 실제로 존재하지 않는 CLI 명령을 안내하고 있어 이를 실제 API에 맞게 정정했습니다.

#44에서 지정하신 범위 중 **"문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트"**에 해당합니다. 여러 후보 중 이 건을 고른 이유는:

- 단순한 표기 차이가 아니라 **문서대로 따라 하면 반드시 실패하는 명령**입니다.
- 특히 `rolling-back.mdx`는 **문서 전체가 존재하지 않는 명령을 전제**로 쓰여 있어, "프로덕션 긴급 롤백" 절차를 그대로 믿고 장애 상황에서 실행하면 롤백 수단을 못 찾는 상황이 됩니다.
- 검증이 명확합니다. `sonamu migrate`의 서브커맨드는 `modules/sonamu/src/bin/cli.ts`의 `args` 배열에 전부 열거되어 있습니다.

## 근거

`modules/sonamu/src/bin/cli.ts:166-181`에 등록된 migrate 관련 인자는 아래 네 가지뿐입니다.

```ts
["migrate", "run"],
["migrate", "apply", "#targets"],
["migrate", "generate"],
["migrate", "status"],
```

이 사실을 기준으로 정정한 항목입니다.

| 문서의 서술 | 실제 |
| --- | --- |
| `sonamu migrate rollback` (11곳) | 존재하지 않음. 롤백은 Sonamu UI Migrations 탭 또는 `Migrator.runAction("rollback", targets)` |
| `sonamu migrate rollback --all` / `--verbose` | 존재하지 않음 (옵션 파싱 대상 아님) |
| `sonamu migrate down` (3곳) | 존재하지 않음. 롤백 단위는 항상 batch |
| `sonamu migrate up` / `migrate latest` | 존재하지 않음. 실행 단위는 항상 pending 전체 |
| `sonamu migrate run --verbose` | 존재하지 않음 |
| `pnpm sonamu ui` | 존재하지 않음. UI는 API 서버의 `/sonamu-ui` 경로 (`src/api/sonamu.ts:445`, `src/ui/api.ts:1479`) |
| `pnpm sonamu validate` | 존재하지 않음 |

롤백 기능 자체는 실재합니다. `ui-web/src/routes/migrations.tsx:298`의 롤백 버튼 → `POST /api/migrations/runAction` (`src/ui/api.ts:731`) → `Migrator.runAction("rollback", ...)` (`src/migration/migrator.ts:300`) 경로이며, 내부적으로 `knex.migrate.rollback()`이므로 **최근 batch 하나**만 되돌립니다. 문서가 안내하던 "한 번에 하나씩", "전체 롤백"은 구현상 불가능한 동작이었습니다.

## 접근 방식

**명령을 지어내지 않고, 실제 존재하는 경로로 대체**했습니다.

- 롤백 → Sonamu UI 절차 + `Sonamu.runScript` 기반 스크립트 예제. 스크립트 예제는 이미 `tools-and-cli/sonamu-cli/migrate.mdx`에 있는 형식을 그대로 따랐습니다(문서 간 일관성).
- `migrate up`/`latest` 카드 → 실제 존재하는 `migrate apply`/`migrate generate`로 교체하고, `apply`의 대상 선택 프롬프트(`cli.ts:143-149`의 choices)를 실제 값으로 기재.
- 없는 기능은 "없다"고 명시. 지어낸 대체 명령을 넣는 것보다, 제약을 알려주는 편이 사용자가 다른 수단을 찾는 데 낫다고 판단했습니다.
- 검증 불가능한 가짜 터미널 출력(`✅ Completed in 23ms` 등)은 새로 만들지 않았고, 명령이 사라진 자리의 것만 제거했습니다.

기존 문서의 구조·톤·`<Info>`/`<Warning>` 사용 패턴은 그대로 유지했으며, `down()` 함수 작성법·데이터 보존 전략 등 **여전히 유효한 내용은 손대지 않았습니다.**

## 영향 범위

- 문서 6개 파일(ko/en 각 3개). **프레임워크 동작 변경 없음, 코드 변경 없음.**
- 문서 추가/삭제가 없어 `docs.json` 내비게이션 영향 없음. 삭제된 섹션을 가리키는 앵커 링크가 없음을 확인했습니다.

## 확인 방법

```bash
# 1. 롤백 CLI가 없음을 확인 (usage 에러)
pnpm sonamu migrate rollback

# 2. 실제 서브커맨드 확인
grep -A 4 '\["migrate", "run"\]' modules/sonamu/src/bin/cli.ts

# 3. 문서 렌더링 확인
pnpm --filter sonamu-docs dev
#   /ko/database/migrations/rolling-back
#   /ko/database/migrations/running-migrations
#   /ko/database/migrations/creating-migrations
```

검증: 루트 `pnpm check`(oxlint + oxfmt) 통과. `.mdx`는 포맷터 대상이 아니라 별도 도구 검증은 없습니다.

## 사람의 확인이 필요한 부분

1. **`pnpm sonamu validate` → `pnpm sonamu sync` 대체가 의도에 맞는지.** 원문 맥락은 "Generate 전 Entity 검증"이었는데, 전용 검증 명령이 없어 Entity 정의를 읽어 재생성하며 오류가 드러나는 `sync`로 바꿨습니다. 의도상 다른 것을 가리키셨던 거라면 알려주세요.
2. **프로덕션 긴급 롤백 시나리오.** UI 접근이 어려운 환경을 가정해 `NODE_ENV=production`으로 롤백 스크립트를 실행하는 형태로 바꿨습니다. 실제 운영 절차(승인 플로우 등)와 다르다면 조정이 필요합니다.
3. **손대지 않은 인접 문제들** — 이번 PR 범위를 넘어선다고 판단해 남겨두었습니다.
   - `migrate status`의 출력 예시가 실제 출력(`console.log(status)`의 객체 덤프)과 다릅니다. 3개 파일에 걸쳐 있어 별도 건으로 보는 편이 낫다고 봤습니다.
   - `tools-and-cli/sonamu-cli/migrate.mdx`는 `pnpm migrate run` 형태를 쓰는데, 템플릿 `package.json`에 `migrate` 스크립트가 없어 `pnpm sonamu migrate run`이 맞아 보입니다.
   - `running-migrations.mdx`의 "트랜잭션 비활성화" 절이 `knexfile.ts` 설정을 안내하는데, Sonamu는 `knexfile.ts`를 쓰지 않습니다.
   - 이 외에도 `faq/`, `troubleshooting/`, `core-concepts/model/` 등에 `sonamu generate model`, `sonamu migrate shadow-test` 등 같은 유형의 미존재 명령이 남아 있습니다. 이번 PR의 방향이 괜찮다면 다음 Nightly에서 이어서 진행하겠습니다.
