### PR TITLE
[sonamu] feat(SON-533): findMany가 활성 트랜잭션을 재사용하도록 개선

### DIFF
--- a/examples/miomock/api/src/sonamu-test/base-model.transaction.test.ts
+++ b/examples/miomock/api/src/sonamu-test/base-model.transaction.test.ts
@@ -1,0 +1,765 @@
+import {
+  BaseModelClass,
+  DB,
+  type DBPreset,
+  PuriWrapper,
+  transactional,
+  UpsertBuilder,
+} from "sonamu";
+import { bootstrap, test } from "sonamu/test";
+import { describe, expect, vi } from "vitest";
+
+import { DepartmentModel } from "../application/department/department.model";
+import { EmployeeModel } from "../application/employee/employee.model";
+import {
+  departmentLoaderQueries,
+  employeeLoaderQueries,
+  employeeSubsetQueries,
+} from "../application/sonamu.generated.sso";
+
+class ExpectedRollback<T> extends Error {
+  constructor(readonly result: T) {
+    super("테스트 트랜잭션 롤백");
+  }
+}
+
+class TransactionOwnerModelClass extends BaseModelClass {
+  override getPuri(which: DBPreset): PuriWrapper {
+    const activeTransaction = DB.getTransactionContext().getTransaction(which);
+    if (activeTransaction) {
+      return activeTransaction;
+    }
+
+    // 워커 DB의 r/w 별칭과 다른 연결에서 트랜잭션을 열어 전파 누락을 식별한다.
+    return new PuriWrapper(DB.getDB("test"), new UpsertBuilder());
+  }
+
+  @transactional()
+  async rollbackAfter<T>(callback: (trx: PuriWrapper) => Promise<T>): Promise<never> {
+    const result = await callback(this.getPuri("w"));
+    throw new ExpectedRollback(result);
+  }
+}
+
+const TransactionOwnerModel = new TransactionOwnerModelClass();
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function runInRollbackTransaction<T>(callback: (trx: PuriWrapper) => Promise<T>): Promise<T> {
+  try {
+    await TransactionOwnerModel.rollbackAfter(callback);
+  } catch (error) {
+    if (error instanceof ExpectedRollback) {
+      return error.result as T;
+    }
+    throw error;
+  }
+
+  throw new Error("테스트 트랜잭션이 롤백되지 않았습니다");
+}
+
+bootstrap(vi);
+
+describe("BaseModel 트랜잭션 전파", () => {
+  test("다른 모델의 findMany가 활성 트랜잭션에서 count/list/both와 연속 변경을 조회한다", async () => {
+    const initialName = "SON-533 트랜잭션 부서";
+    const lockedName = "SON-533 잠금 이후 부서";
+    const sequentialName = "SON-533 연속 조회 부서";
+
+    const result = await runInRollbackTransaction(async (trx) => {
+      const company = await trx
+        .table("companies")
+        .select({ id: "companies.id" })
+        .orderBy("companies.id", "asc")
+        .first();
+      if (!company) {
+        throw new Error("테스트할 회사가 없습니다");
+      }
+
+      const [inserted] = await trx
+        .table("departments")
+        .insert({
+          name: initialName,
+          company_id: company.id,
+          parent_id: null,
+          created_at: new Date(),
+        })
+        .returning("id");
+      if (!inserted) {
+        throw new Error("테스트 부서를 생성하지 못했습니다");
+      }
+
+      const countResult = await DepartmentModel.findMany("P2", {
+        id: inserted.id,
+        num: 1,
+        page: 1,
+        queryMode: "count",
+      });
+      const listResult = await DepartmentModel.findMany("P2", {
+        id: inserted.id,
+        num: 1,
+        page: 1,
+        queryMode: "list",
+      });
+
+      await trx
+        .table("departments")
+        .where("departments.id", inserted.id)
+        .select({ id: "departments.id" })
+        .forUpdate()
+        .first();
+      await trx
+        .table("departments")
+        .where("departments.id", inserted.id)
+        .update({ name: lockedName });
+
+      const bothResult = await DepartmentModel.findMany("P2", {
+        id: inserted.id,
+        num: 1,
+        page: 1,
+        queryMode: "both",
+      });
+      const transactionAfterFindMany = DB.getTransactionContext().getTransaction("w");
+
+      await trx
+        .table("departments")
+        .where("departments.id", inserted.id)
+        .update({ name: sequentialName });
+      const sequentialResult = await DepartmentModel.findMany("P2", {
+        id: inserted.id,
+        num: 1,
+        page: 1,
+        queryMode: "list",
+      });
+
+      return {
+        insertedId: inserted.id,
+        countResult,
+        listResult,
+        bothResult,
+        sequentialResult,
+        reusedTransaction: transactionAfterFindMany === trx,
+        distinctFromConfiguredReadDB: trx.knex !== DB.getDB("r"),
+      };
+    });
+
+    expect(result.countResult).toEqual({ total: 1 });
+    expect(result.listResult).toEqual({
+      rows: [expect.objectContaining({ id: result.insertedId, name: initialName })],
+    });
+    expect(result.bothResult).toEqual({
+      rows: [expect.objectContaining({ id: result.insertedId, name: lockedName })],
+      total: 1,
+    });
+    expect(result.sequentialResult).toEqual({
+      rows: [expect.objectContaining({ id: result.insertedId, name: sequentialName })],
+    });
+    expect(result.reusedTransaction).toBe(true);
+    expect(result.distinctFromConfiguredReadDB).toBe(true);
+
+    const rolledBack = await DB.getDB("test")("departments").where("id", result.insertedId).first();
+    expect(rolledBack).toBeUndefined();
+  });
+
+  test("서로 다른 preset이 중첩되면 가장 안쪽 트랜잭션을 사용하고 종료 후 바깥 트랜잭션을 복원한다", async () => {
+    const outerName = "SON-533 바깥 트랜잭션 부서";
+    const innerName = "SON-533 안쪽 트랜잭션 부서";
+
+    const result = await runInRollbackTransaction(async (outerTrx) => {
+      const outerDepartment = await outerTrx
+        .table("departments")
+        .select({ id: "departments.id", name: "departments.name" })
+        .orderBy("departments.id", "asc")
+        .first();
+      if (!outerDepartment) {
+        throw new Error("바깥 트랜잭션을 검증할 부서가 없습니다");
+      }
+
+      await outerTrx
+        .table("departments")
+        .where("departments.id", outerDepartment.id)
+        .update({ name: outerName });
+
+      const fixturePuri = new PuriWrapper(DB.getDB("fixture"), new UpsertBuilder());
+      const innerDepartment = await fixturePuri
+        .table("departments")
+        .select({ id: "departments.id", name: "departments.name" })
+        .orderBy("departments.id", "asc")
+        .first();
+      if (!innerDepartment) {
+        throw new Error("안쪽 트랜잭션을 검증할 부서가 없습니다");
+      }
+
+      let innerReadName: string | undefined;
+      try {
+        await fixturePuri.transaction(
+          async (innerTrx) => {
+            await innerTrx
+              .table("departments")
+              .where("departments.id", innerDepartment.id)
+              .update({ name: innerName });
+
+            const innerResult = await DepartmentModel.findMany("P2", {
+              id: innerDepartment.id,
+              num: 1,
+              page: 1,
+              queryMode: "list",
+            });
+            throw new ExpectedRollback(innerResult.rows[0]?.name);
+          },
+          { dbPreset: "fixture" },
+        );
+      } catch (error) {
+        if (!(error instanceof ExpectedRollback)) {
+          throw error;
+        }
+        innerReadName = error.result as string | undefined;
+      }
+
+      const outerResult = await DepartmentModel.findMany("P2", {
+        id: outerDepartment.id,
+        num: 1,
+        page: 1,
+        queryMode: "list",
+      });
+
+      return {
+        outerDepartment,
+        innerDepartment,
+        innerReadName,
+        outerReadName: outerResult.rows[0]?.name,
+        outerTransactionRestored: DB.getTransactionContext().getActiveTransaction() === outerTrx,
+      };
+    });
+
+    expect(result.innerReadName).toBe(innerName);
+    expect(result.outerReadName).toBe(outerName);
+    expect(result.outerTransactionRestored).toBe(true);
+
+    const [outerRolledBack, innerRolledBack] = await Promise.all([
+      DB.getDB("test")("departments").select("name").where("id", result.outerDepartment.id).first(),
+      DB.getDB("fixture")("departments")
+        .select("name")
+        .where("id", result.innerDepartment.id)
+        .first(),
+    ]);
+    expect(outerRolledBack?.name).toBe(result.outerDepartment.name);
+    expect(innerRolledBack?.name).toBe(result.innerDepartment.name);
+  });
+
+  test("@transactional이 다른 preset 안에서 기존 같은 preset을 재사용하고 주변 scope를 복원한다", async () => {
+    const result = await runInRollbackTransaction(async (outerTrx) => {
+      const fixturePuri = new PuriWrapper(DB.getDB("fixture"), new UpsertBuilder());
+      const fixtureResult = await fixturePuri.transaction(
+        async (fixtureTrx) => {
+          const getPuriSpy = vi.spyOn(TransactionOwnerModel, "getPuri");
+
+          try {
+            let reusedResult:
+              | {
+                  reusedExactWrapper: boolean;
+                  reusedAsNearestActive: boolean;
+                  inheritedFixture: boolean;
+                }
+              | undefined;
+
+            try {
+              await TransactionOwnerModel.rollbackAfter(async (reusedTrx) => ({
+                reusedExactWrapper: reusedTrx === outerTrx,
+                reusedAsNearestActive:
+                  DB.getTransactionContext().getActiveTransaction() === outerTrx,
+                inheritedFixture:
+                  DB.getTransactionContext().getTransaction("fixture") === fixtureTrx,
+              }));
+            } catch (error) {
+              if (!(error instanceof ExpectedRollback)) {
+                throw error;
+              }
+              reusedResult = error.result as typeof reusedResult;
+            }
+
+            if (!reusedResult) {
+              throw new Error("재사용한 트랜잭션 결과를 확인하지 못했습니다");
+            }
+
+            return {
+              ...reusedResult,
+              getPuriCalls: getPuriSpy.mock.calls.length,
+              fixtureRestored: DB.getTransactionContext().getActiveTransaction() === fixtureTrx,
+            };
+          } finally {
+            getPuriSpy.mockRestore();
+          }
+        },
+        { dbPreset: "fixture" },
+      );
+
+      return {
+        ...fixtureResult,
+        outerRestored: DB.getTransactionContext().getActiveTransaction() === outerTrx,
+      };
+    });
+
+    expect.soft(result.reusedExactWrapper).toBe(true);
+    expect.soft(result.reusedAsNearestActive).toBe(true);
+    expect.soft(result.inheritedFixture).toBe(true);
+    expect.soft(result.getPuriCalls).toBe(1);
+    expect.soft(result.fixtureRestored).toBe(true);
+    expect.soft(result.outerRestored).toBe(true);
+  });
+
+  test("같은 preset의 중첩 Puri 트랜잭션이 savepoint만 롤백하고 바깥 scope를 복원한다", async () => {
+    const outerName = "SON-533 savepoint 바깥 부서";
+    const innerName = "SON-533 savepoint 안쪽 부서";
+    const subsequentName = "SON-533 savepoint 후속 부서";
+    const savepointFailure = new Error("의도한 savepoint 롤백");
+
+    const result = await runInRollbackTransaction(async (outerTrx) => {
+      const department = await outerTrx
+        .table("departments")
+        .select({ id: "departments.id", name: "departments.name" })
+        .orderBy("departments.id", "asc")
+        .first();
+      if (!department) {
+        throw new Error("savepoint를 검증할 부서가 없습니다");
+      }
+
+      await outerTrx
+        .table("departments")
+        .where("departments.id", department.id)
+        .update({ name: outerName });
+
+      const outerContext = DB.getTransactionContext();
+      let innerUsedDistinctWrapper = false;
+      let innerWasNearestActive = false;
+      let innerContextWasChild = false;
+      let caughtSameFailure = false;
+
+      try {
+        await outerTrx.transaction(
+          async (innerTrx) => {
+            innerUsedDistinctWrapper = innerTrx !== outerTrx;
+            innerWasNearestActive =
+              DB.getTransactionContext().getActiveTransaction() === innerTrx &&
+              DB.getTransactionContext().getTransaction("w") === innerTrx;
+            innerContextWasChild = DB.getTransactionContext() !== outerContext;
+
+            await innerTrx
+              .table("departments")
+              .where("departments.id", department.id)
+              .update({ name: innerName });
+            const innerVisible = await innerTrx
+              .table("departments")
+              .select({ name: "departments.name" })
+              .where("departments.id", department.id)
+              .first();
+            expect(innerVisible?.name).toBe(innerName);
+
+            throw savepointFailure;
+          },
+          { dbPreset: "w" },
+        );
+      } catch (error) {
+        caughtSameFailure = error === savepointFailure;
+        if (!caughtSameFailure) {
+          throw error;
+        }
+      }
+
+      const afterSavepointRollback = await outerTrx
+        .table("departments")
+        .select({ name: "departments.name" })
+        .where("departments.id", department.id)
+        .first();
+      const outerContextRestored =
+        DB.getTransactionContext() === outerContext &&
+        DB.getTransactionContext().getActiveTransaction() === outerTrx &&
+        DB.getTransactionContext().getTransaction("w") === outerTrx;
+
+      await outerTrx
+        .table("departments")
+        .where("departments.id", department.id)
+        .update({ name: subsequentName });
+      const subsequentVisible = await outerTrx
+        .table("departments")
+        .select({ name: "departments.name" })
+        .where("departments.id", department.id)
+        .first();
+
+      return {
+        department,
+        innerUsedDistinctWrapper,
+        innerWasNearestActive,
+        innerContextWasChild,
+        caughtSameFailure,
+        outerContextRestored,
+        nameAfterSavepointRollback: afterSavepointRollback?.name,
+        subsequentVisibleName: subsequentVisible?.name,
+      };
+    });
+
+    expect.soft(result.innerUsedDistinctWrapper).toBe(true);
+    expect.soft(result.innerWasNearestActive).toBe(true);
+    expect.soft(result.innerContextWasChild).toBe(true);
+    expect.soft(result.caughtSameFailure).toBe(true);
+    expect.soft(result.outerContextRestored).toBe(true);
+    expect.soft(result.nameAfterSavepointRollback).toBe(outerName);
+    expect.soft(result.subsequentVisibleName).toBe(subsequentName);
+    expect.soft(DB.getTransactionContext().getTransaction("w")).toBeUndefined();
+
+    const persisted = await DB.getDB("test")("departments")
+      .select("name")
+      .where("id", result.department.id)
+      .first();
+    expect(persisted?.name).toBe(result.department.name);
+  });
+
+  test("같은 parent scope에서 겹쳐 실행되는 sibling 트랜잭션은 각자의 활성 범위를 유지한다", async () => {
+    const firstName = "SON-533 첫 번째 sibling 부서";
+    const secondName = "SON-533 두 번째 sibling 부서";
+    const testPuri = new PuriWrapper(DB.getDB("test"), new UpsertBuilder());
+    const fixturePuri = new PuriWrapper(DB.getDB("fixture"), new UpsertBuilder());
+
+    const firstDepartment = await testPuri
+      .table("departments")
+      .select({ id: "departments.id", name: "departments.name" })
+      .orderBy("departments.id", "asc")
+      .first();
+    const secondDepartment = await fixturePuri
+      .table("departments")
+      .select({ id: "departments.id", name: "departments.name" })
+      .orderBy("departments.id", "asc")
+      .first();
+    if (!firstDepartment || !secondDepartment) {
+      throw new Error("sibling 트랜잭션을 검증할 부서가 없습니다");
+    }
+
+    const firstReady = createDeferred();
+    const secondReady = createDeferred();
+    const firstExited = createDeferred();
+
+    let siblingResult:
+      | {
+          firstResult: {
+            activeWasOwn: boolean;
+            inheritedParent: boolean;
+            readName: string | undefined;
+            error: unknown;
+          };
+          secondResult: {
+            activeWasOwn: boolean;
+            inheritedParent: boolean;
+            readName: string | undefined;
+            error: unknown;
+          };
+          outerRestored: boolean;
+        }
+      | undefined;
+
+    try {
+      await testPuri.transaction(
+        async (outerTrx) => {
+          const firstBranch = (async () => {
+            let activeWasOwn = false;
+            let inheritedParent = false;
+            try {
+              await testPuri.transaction(
+                async (firstTrx) => {
+                  await firstTrx
+                    .table("departments")
+                    .where("departments.id", firstDepartment.id)
+                    .update({ name: firstName });
+                  firstReady.resolve();
+                  await secondReady.promise;
+
+                  activeWasOwn =
+                    DB.getTransactionContext().getActiveTransaction() === firstTrx &&
+                    DB.getTransactionContext().getTransaction("w") === firstTrx;
+                  inheritedParent = DB.getTransactionContext().getTransaction("r") === outerTrx;
+                  const result = await DepartmentModel.findMany("P2", {
+                    id: firstDepartment.id,
+                    num: 1,
+                    page: 1,
+                    queryMode: "list",
+                  });
+                  throw new ExpectedRollback(result.rows[0]?.name);
+                },
+                { dbPreset: "w" },
+              );
+            } catch (error) {
+              if (error instanceof ExpectedRollback) {
+                return {
+                  activeWasOwn,
+                  inheritedParent,
+                  readName: error.result as string | undefined,
+                  error: undefined,
+                };
+              }
+              return { activeWasOwn, inheritedParent, readName: undefined, error };
+            } finally {
+              firstExited.resolve();
+            }
+
+            throw new Error("첫 번째 sibling 트랜잭션이 롤백되지 않았습니다");
+          })();
+
+          await firstReady.promise;
+          const secondBranch = (async () => {
+            let activeWasOwn = false;
+            let inheritedParent = false;
+            try {
+              await fixturePuri.transaction(
+                async (secondTrx) => {
+                  await secondTrx
+                    .table("departments")
+                    .where("departments.id", secondDepartment.id)
+                    .update({ name: secondName });
+                  secondReady.resolve();
+                  await firstExited.promise;
+
+                  activeWasOwn =
+                    DB.getTransactionContext().getActiveTransaction() === secondTrx &&
+                    DB.getTransactionContext().getTransaction("w") === secondTrx;
+                  inheritedParent = DB.getTransactionContext().getTransaction("r") === outerTrx;
+                  const result = await DepartmentModel.findMany("P2", {
+                    id: secondDepartment.id,
+                    num: 1,
+                    page: 1,
+                    queryMode: "list",
+                  });
+                  throw new ExpectedRollback(result.rows[0]?.name);
+                },
+                { dbPreset: "w" },
+              );
+            } catch (error) {
+              if (error instanceof ExpectedRollback) {
+                return {
+                  activeWasOwn,
+                  inheritedParent,
+                  readName: error.result as string | undefined,
+                  error: undefined,
+                };
+              }
+              return { activeWasOwn, inheritedParent, readName: undefined, error };
+            }
+
+            throw new Error("두 번째 sibling 트랜잭션이 롤백되지 않았습니다");
+          })();
+
+          const [firstResult, secondResult] = await Promise.all([firstBranch, secondBranch]);
+          throw new ExpectedRollback({
+            firstResult,
+            secondResult,
+            outerRestored: DB.getTransactionContext().getActiveTransaction() === outerTrx,
+          });
+        },
+        { dbPreset: "r" },
+      );
+    } catch (error) {
+      if (!(error instanceof ExpectedRollback)) {
+        throw error;
+      }
+      siblingResult = error.result as typeof siblingResult;
+    }
+
+    if (!siblingResult) {
+      throw new Error("sibling 트랜잭션 결과를 확인하지 못했습니다");
+    }
+
+    const { firstResult, secondResult, outerRestored } = siblingResult;
+
+    expect.soft(firstResult.activeWasOwn).toBe(true);
+    expect.soft(firstResult.inheritedParent).toBe(true);
+    expect.soft(firstResult.readName).toBe(firstName);
+    expect.soft(firstResult.error).toBeUndefined();
+    expect.soft(secondResult.activeWasOwn).toBe(true);
+    expect.soft(secondResult.inheritedParent).toBe(true);
+    expect.soft(secondResult.readName).toBe(secondName);
+    expect.soft(secondResult.error).toBeUndefined();
+    expect.soft(outerRestored).toBe(true);
+    expect.soft(DB.getTransactionContext().getActiveTransaction()).toBeUndefined();
+
+    const [firstRolledBack, secondRolledBack] = await Promise.all([
+      DB.getDB("test")("departments").select("name").where("id", firstDepartment.id).first(),
+      DB.getDB("fixture")("departments").select("name").where("id", secondDepartment.id).first(),
+    ]);
+    expect(firstRolledBack?.name).toBe(firstDepartment.name);
+    expect(secondRolledBack?.name).toBe(secondDepartment.name);
+  });
+
+  test("관계 로더와 중첩 로더가 활성 트랜잭션의 변경을 함께 조회한다", async () => {
+    const updatedSalary = "123456.78";
+    const updatedProjectName = "SON-533 트랜잭션 프로젝트";
+
+    const result = await runInRollbackTransaction(async (trx) => {
+      const seed = await trx
+        .table({ link: "projects__employees" })
+        .join({ employee: "employees" }, "link.employee_id", "employee.id")
+        .where("employee.department_id", "!=", null)
+        .select({
+          employeeId: "employee.id",
+          departmentId: "employee.department_id",
+          projectId: "link.project_id",
+        })
+        .orderBy("link.id", "asc")
+        .first();
+      if (!seed || seed.departmentId === null) {
+        throw new Error("관계 로더를 검증할 직원이 없습니다");
+      }
+
+      await trx
+        .table("employees")
+        .where("employees.id", seed.employeeId)
+        .update({ salary: updatedSalary });
+      await trx
+        .table("projects")
+        .where("projects.id", seed.projectId)
+        .update({ name: updatedProjectName });
+
+      const departmentResult = await DepartmentModel.findMany("A", {
+        id: seed.departmentId,
+        num: 1,
+        page: 1,
+        queryMode: "list",
+      });
+      const rootSubsetSpy = vi.spyOn(employeeSubsetQueries, "P");
+      const departmentEmployeesLoaderSpy = vi.spyOn(employeeLoaderQueries.P[0], "qb");
+      const nestedProjectsLoaderSpy = vi.spyOn(employeeLoaderQueries.P[0].loaders[0], "qb");
+      const directProjectsLoaderSpy = vi.spyOn(employeeLoaderQueries.P[1], "qb");
+
+      try {
+        const employeeResult = await EmployeeModel.findMany("P", {
+          id: seed.employeeId,
+          num: 1,
+          page: 1,
+          queryMode: "list",
+        });
+        const rootWrapper = rootSubsetSpy.mock.calls.at(-1)?.[0];
+        const departmentEmployeesWrapper = departmentEmployeesLoaderSpy.mock.calls.at(-1)?.[0];
+        const nestedProjectsWrapper = nestedProjectsLoaderSpy.mock.calls.at(-1)?.[0];
+        const directProjectsWrapper = directProjectsLoaderSpy.mock.calls.at(-1)?.[0];
+
+        return {
+          seed,
+          departmentResult,
+          employeeResult,
+          rootUsesTransactionConnection: rootWrapper?.knex === trx.knex,
+          loadersUseRootConnection:
+            departmentEmployeesWrapper?.knex === rootWrapper?.knex &&
+            nestedProjectsWrapper?.knex === rootWrapper?.knex &&
+            directProjectsWrapper?.knex === rootWrapper?.knex,
+          loadersShareDerivedWrapper:
+            departmentEmployeesWrapper === nestedProjectsWrapper &&
+            nestedProjectsWrapper === directProjectsWrapper &&
+            directProjectsWrapper !== rootWrapper,
+        };
+      } finally {
+        rootSubsetSpy.mockRestore();
+        departmentEmployeesLoaderSpy.mockRestore();
+        nestedProjectsLoaderSpy.mockRestore();
+        directProjectsLoaderSpy.mockRestore();
+      }
+    });
+
+    const departmentEmployee = result.departmentResult.rows[0]?.employees.find(
+      ({ id }) => id === result.seed.employeeId,
+    );
+    const employee = result.employeeResult.rows[0];
+    const directProject = employee?.projs.find(({ id }) => id === result.seed.projectId);
+    const nestedProject = employee?.department?.employees
+      .find(({ id }) => id === result.seed.employeeId)
+      ?.projs.find(({ id }) => id === result.seed.projectId);
+
+    expect.soft(departmentEmployee?.salary).toBe(updatedSalary);
+    expect.soft(directProject?.name).toBe(updatedProjectName);
+    expect.soft(nestedProject?.name).toBe(updatedProjectName);
+    expect.soft(result.rootUsesTransactionConnection).toBe(true);
+    expect.soft(result.loadersUseRootConnection).toBe(true);
+    expect.soft(result.loadersShareDerivedWrapper).toBe(true);
+  });
+
+  test("로더 실패를 그대로 전파하고 바깥 트랜잭션을 롤백한 뒤 컨텍스트를 제거한다", async () => {
+    const baseDB = DB.getDB("test");
+    const originalDepartment = await baseDB("departments").select("id", "name").first();
+    if (!originalDepartment) {
+      throw new Error("롤백을 검증할 부서가 없습니다");
+    }
+
+    const loaderFailure = new Error("의도한 로더 실패");
+    vi.spyOn(departmentLoaderQueries.A[0], "qb").mockImplementationOnce(() => {
+      throw loaderFailure;
+    });
+
+    const operation = TransactionOwnerModel.rollbackAfter(async (trx) => {
+      await trx
+        .table("departments")
+        .where("departments.id", originalDepartment.id)
+        .update({ name: "SON-533 롤백 대상 부서" });
+
+      return DepartmentModel.findMany("A", {
+        id: originalDepartment.id,
+        num: 1,
+        page: 1,
+        queryMode: "list",
+      });
+    });
+
+    await expect(operation).rejects.toBe(loaderFailure);
+    expect(DB.getTransactionContext().getTransaction("w")).toBeUndefined();
+
+    const rolledBack = await baseDB("departments")
+      .select("name")
+      .where("id", originalDepartment.id)
+      .first();
+    expect(rolledBack?.name).toBe(originalDepartment.name);
+  });
+
+  test("활성 트랜잭션이 없으면 설정된 읽기 DB를 사용한다", async () => {
+    expect(DB.getTransactionContext().getTransaction("w")).toBeUndefined();
+
+    const configuredWriteDB = DB.getDB("w");
+    const configuredReadTransaction = await DB.getDB("fixture").transaction();
+    try {
+      const department = await configuredReadTransaction("departments")
+        .select("id")
+        .orderBy("id", "asc")
+        .first();
+      if (!department) {
+        throw new Error("설정된 읽기 DB를 검증할 부서가 없습니다");
+      }
+
+      const readMarker = "SON-533 설정된 읽기 DB 부서";
+      await configuredReadTransaction("departments")
+        .where("id", department.id)
+        .update({ name: readMarker });
+
+      const getDBSpy = vi.spyOn(DepartmentModel, "getDB").mockImplementation((preset) => {
+        return preset === "r" ? configuredReadTransaction : configuredWriteDB;
+      });
+      try {
+        const result = await DepartmentModel.findMany("P2", {
+          id: department.id,
+          num: 1,
+          page: 1,
+          queryMode: "both",
+        });
+
+        expect(result).toEqual({
+          rows: [expect.objectContaining({ id: department.id, name: readMarker })],
+          total: 1,
+        });
+        expect(getDBSpy.mock.calls.map(([preset]) => preset)).toEqual(["r"]);
+      } finally {
+        getDBSpy.mockRestore();
+      }
+    } finally {
+      await configuredReadTransaction.rollback();
+    }
+  });
+});

--- a/modules/docs/en/api-reference/base-model/get-puri.mdx
+++ b/modules/docs/en/api-reference/base-model/get-puri.mdx
@@ -213,34 +213,10 @@ async transferPoints(fromUserId: number, toUserId: number, points: number) {
 }
 ```
 
-## Automatic Transaction Context Detection
+## Transaction Integration
 
-`getPuri` automatically detects and reuses transaction contexts. This is an important feature when used with the `@transactional` decorator.
-
-### How It Works
-
-The `getPuri` method works internally as follows:
-
-1. Check for an active transaction via `DB.getTransactionContext()`
-2. If a transaction exists, reuse it
-3. If no transaction exists, create a new PuriWrapper
-
-```typescript
-// Internal logic of getPuri (for reference)
-getPuri(which: DBPreset): PuriWrapper {
-  // 1. Attempt to get transaction from transaction context
-  const trx = DB.getTransactionContext().getTransaction(which);
-
-  if (trx) {
-    // 2. If transaction exists, reuse it
-    return trx;
-  }
-
-  // 3. If no transaction, return a new PuriWrapper
-  const db = this.getDB(which);
-  return new PuriWrapper(db, new UpsertBuilder());
-}
-```
+When a transaction is already active for the requested preset, `getPuri` participates in that DB
+transaction. Otherwise, it accesses the DB configured for the preset.
 
 ### Using Within @transactional
 
@@ -276,7 +252,8 @@ class UserModelClass extends BaseModelClass {
 
 ### Nested Method Call Safety
 
-Thanks to this feature, it's safe to call other methods within a transaction. All `getPuri` calls use the same transaction.
+Methods called inside a transaction participate in the same DB transaction when they request the
+same preset.
 
 ```typescript
 class UserModelClass extends BaseModelClass {
@@ -306,14 +283,17 @@ class UserModelClass extends BaseModelClass {
 ```
 
 <Info>
-  The transaction context set by the `@transactional` decorator is automatically shared across all
-  sub-method calls. This is implemented via AsyncLocalStorage.
+  Within `@transactional`, calls to `getPuri` with the same dbPreset participate in the same DB
+  transaction. The outermost decorated call owns commit and rollback.
 </Info>
 
 <Warning>
-  A PuriWrapper obtained via `getPuri` within a transaction and a new transaction started with
-  `wdb.transaction()` are **different transactions**. If you need nested transactions, you must
-  manage them explicitly.
+  When a transaction for the same dbPreset is already active, nested `.transaction()` creates a
+  savepoint. Await nested calls sequentially; do not run sibling savepoints in parallel with
+  `Promise.all`. Use a distinct dbPreset consistently for each configured DB; do not reuse one
+  preset name for different DB connections. This partial-rollback guidance is for direct DB
+  queries. For a shared UpsertBuilder batch or graph, propagate failures to the outermost
+  transaction and roll back the whole unit instead of catching and continuing.
 </Warning>
 
 ## Practical Examples
@@ -632,7 +612,7 @@ const wdb = this.getPuri("w");
 await wdb.table("users").insert({ ... });
 ```
 
-### 2. Transaction Context
+### 2. Using @transactional
 
 Within `@transactional`, transactions are automatically managed.
 

--- a/modules/docs/en/api-reference/decorators/transactional.mdx
+++ b/modules/docs/en/api-reference/decorators/transactional.mdx
@@ -188,7 +188,8 @@ async transfer(fromId: number, toId: number, amount: number) {
 
 ### Transaction Nesting
 
-Transactions with the same dbPreset are **reused**:
+Nested `@transactional` calls with the same dbPreset participate in the **same DB transaction**. The
+outermost call owns commit and rollback:
 
 ```typescript
 class UserModelClass extends BaseModelClass {
@@ -220,7 +221,6 @@ class UserModelClass extends BaseModelClass {
 [DEBUG] new transaction context: w
 [DEBUG] transactional: UserModel.createProfile
 [DEBUG] reuse transaction context: w
-[DEBUG] delete transaction context: w
 ```
 
 ### Different Preset Transactions
@@ -293,39 +293,6 @@ async uploadAvatar() {
     .update({ avatar_url: url });
 
   return { url };
-}
-```
-
-## AsyncLocalStorage
-
-`@transactional` uses Node.js's AsyncLocalStorage to manage transaction context.
-
-### Context Creation
-
-```typescript
-// When no transaction exists
-@transactional()
-async save() {
-  // 1. Create new AsyncLocalStorage context
-  // 2. Start transaction
-  // 3. Execute method
-  // 4. Commit/rollback
-  // 5. Clean up context
-}
-```
-
-### Context Reuse
-
-```typescript
-@transactional()
-async parent() {
-  // Creates context
-  await this.child();  // Uses same context
-}
-
-@transactional()
-async child() {
-  // Reuses parent's context
 }
 ```
 
@@ -480,7 +447,6 @@ async save() {
   // Automatic logs:
   // [DEBUG] transactional: UserModel.save
   // [DEBUG] new transaction context: w
-  // [DEBUG] delete transaction context: w
 }
 ```
 

--- a/modules/docs/en/database/transactions/transactional-decorator.mdx
+++ b/modules/docs/en/database/transactions/transactional-decorator.mdx
@@ -18,7 +18,7 @@ The `@transactional` decorator automatically wraps methods in transactions, redu
     Configure transaction isolation level Concurrency control
   </Card>
   <Card title="Nested Transactions" icon="layer-group">
-    Automatic context sharing Savepoint support
+    Same-preset DB transaction No automatic savepoint
   </Card>
 </CardGroup>
 
@@ -286,7 +286,10 @@ class UserModel extends BaseModelClass {
 
 ## Nested Transactions
 
-### Automatic Context Sharing
+### Automatic Transaction Reuse
+
+Same-preset nested `@transactional` calls participate in one DB transaction. The outermost
+same-preset call owns commit and rollback.
 
 ```typescript
 class UserModel extends BaseModelClass {
@@ -298,7 +301,7 @@ class UserModel extends BaseModelClass {
     const [userId] = await wdb.table("users").insert(userData).returning("id");
 
     // Call another @transactional method
-    // Shares same transaction context
+    // Participates in the same DB transaction
     await this.updateBio(userId, bio);
 
     return userId;
@@ -320,12 +323,12 @@ flowchart TD
     C --> D[User INSERT]
     D --> E[Call updateBio]
     E --> F[@transactional 2]
-    F --> G{Existing Transaction?}
+    F --> G{Existing Same-preset Transaction?}
     G -->|Yes| H[Reuse Same Transaction]
     G -->|No| I[Create New Transaction]
     H --> J[Bio UPDATE]
     J --> K[Method End]
-    K --> L[COMMIT]
+    K --> L[Outermost Same-preset Call COMMIT]
 
     style C fill:#e8f5e9
     style H fill:#c8e6c9
@@ -335,6 +338,50 @@ flowchart TD
 <Info>
   **Benefits of Nested Transactions**: - Improved code reusability - Freedom to combine methods -
   Automatic transaction boundary management
+</Info>
+
+### Error and Savepoint Semantics
+
+A same-preset nested `@transactional` call participates in the outer DB transaction. It does not
+create a new database transaction or savepoint, and the outermost call owns commit and rollback.
+
+```typescript
+@transactional()
+async outerMethod() {
+  const wdb = this.getPuri("w");
+  await wdb.table("users").insert({ id: 1 });
+
+  try {
+    await this.innerMethod();
+  } catch (error) {
+    // Catching this application-level error lets the outer transaction continue.
+    console.error(error);
+  }
+
+  // Runs normally and may commit with earlier successful writes.
+  await wdb.table("logs").insert({ action: "user_created" });
+}
+
+@transactional()
+async innerMethod() {
+  const wdb = this.getPuri("w");
+  await wdb.table("profiles").insert({ user_id: 1 });
+  throw new Error("Application validation failed");
+}
+```
+
+<Warning>
+  This example catches an application-level error thrown after the DB statements succeeded. The
+  outer transaction may continue and commit those writes. A PostgreSQL statement error, such as a
+  constraint or SQL failure, aborts the current PostgreSQL transaction; catching it alone does not
+  make that transaction usable again.
+</Warning>
+
+<Info>
+  If a direct DB query may fail and the outer transaction must recover, run that query in a nested
+  `getPuri("w").transaction(...)` savepoint. If the whole composition must remain atomic, let an
+  application-level error propagate out of the outermost `@transactional` call to roll everything
+  back.
 </Info>
 
 ## Using with @api
@@ -447,7 +494,8 @@ async createUserComplex(data: UserSaveParams): Promise<number> {
 
 <Warning>
   **Must Follow**: 1. Method must be `async` function 2. Access DB with `this.getPuri("r" or "w")` 3.
-  Propagate errors with throw (auto rollback) 4. Nested transactions share same context
+  Propagate application-level errors with throw (auto rollback) 4. Same-preset nested calls
+  participate in the same DB transaction, and the outermost call owns commit/rollback
 </Warning>
 
 ### Common Mistakes
@@ -457,17 +505,17 @@ class UserModel extends BaseModelClass {
   // ❌ Wrong usage
   @transactional()
   async wrongUsage1(data: UserSaveParams): Promise<number> {
-    // Don't store getPuri in different variable
-    const db = this.getPuri("w");
+    const wdb = this.getPuri("w");
 
-    // Hiding errors with catch prevents rollback
+    wdb.ubRegister("users", data);
+    const [id] = await wdb.ubUpsert("users");
+
+    // Hiding an application-level error after a successful DB write may commit that write.
     try {
-      db.ubRegister("users", data);
-      const [id] = await db.ubUpsert("users");
-      return id;
+      throw new Error("Application validation failed");
     } catch (error) {
       console.error(error);
-      return 0; // ❌ Hiding error → no rollback
+      return id;
     }
   }
 

--- a/modules/docs/ko/api-reference/base-model/get-puri.mdx
+++ b/modules/docs/ko/api-reference/base-model/get-puri.mdx
@@ -213,34 +213,10 @@ async transferPoints(fromUserId: number, toUserId: number, points: number) {
 }
 ```
 
-## 트랜잭션 컨텍스트 자동 감지
+## 트랜잭션 연동
 
-`getPuri`는 트랜잭션 컨텍스트를 자동으로 감지하고 재사용합니다. 이는 `@transactional` 데코레이터와 함께 사용할 때 중요한 기능입니다.
-
-### 동작 원리
-
-`getPuri` 메서드는 내부적으로 다음과 같이 동작합니다:
-
-1. `DB.getTransactionContext()`를 통해 현재 실행 중인 트랜잭션 확인
-2. 트랜잭션이 있으면 해당 트랜잭션을 재사용
-3. 트랜잭션이 없으면 새로운 PuriWrapper 생성
-
-```typescript
-// getPuri 내부 로직 (참고용)
-getPuri(which: DBPreset): PuriWrapper {
-  // 1. 트랜잭션 컨텍스트에서 트랜잭션 획득 시도
-  const trx = DB.getTransactionContext().getTransaction(which);
-
-  if (trx) {
-    // 2. 트랜잭션이 있으면 재사용
-    return trx;
-  }
-
-  // 3. 트랜잭션이 없으면 새로운 PuriWrapper 반환
-  const db = this.getDB(which);
-  return new PuriWrapper(db, new UpsertBuilder());
-}
-```
+요청한 preset에 이미 활성 트랜잭션이 있으면 `getPuri`는 해당 DB 트랜잭션에 참여합니다. 활성
+트랜잭션이 없으면 preset에 설정된 DB에 접근합니다.
 
 ### @transactional 내에서 사용
 
@@ -276,7 +252,7 @@ class UserModelClass extends BaseModelClass {
 
 ### 중첩 메서드 호출 안전성
 
-이 기능 덕분에 트랜잭션 내에서 다른 메서드를 호출해도 안전합니다. 모든 `getPuri` 호출이 동일한 트랜잭션을 사용합니다.
+트랜잭션 안에서 호출한 메서드가 같은 preset을 요청하면 동일한 DB 트랜잭션에 참여합니다.
 
 ```typescript
 class UserModelClass extends BaseModelClass {
@@ -306,13 +282,17 @@ class UserModelClass extends BaseModelClass {
 ```
 
 <Info>
-  `@transactional` 데코레이터가 설정한 트랜잭션 컨텍스트는 모든 하위 메서드 호출에서 자동으로
-  공유됩니다. 이는 AsyncLocalStorage를 통해 구현됩니다.
+  `@transactional` 안에서 같은 dbPreset으로 호출한 `getPuri`는 동일한 DB 트랜잭션에 참여합니다.
+  가장 바깥 데코레이터 호출이 커밋과 롤백을 담당합니다.
 </Info>
 
 <Warning>
-  트랜잭션 내에서 `getPuri`로 얻은 PuriWrapper와 `wdb.transaction()`으로 시작한 새로운 트랜잭션은
-  **서로 다른 트랜잭션**입니다. 중첩 트랜잭션이 필요한 경우 명시적으로 관리해야 합니다.
+  같은 dbPreset의 트랜잭션이 이미 활성 상태라면 중첩 `.transaction()`은 Savepoint를 생성합니다.
+  중첩 호출은 하나씩 순차적으로 `await`하고 sibling Savepoint를 `Promise.all`로 병렬 실행하지 마세요.
+  설정된 DB마다 고유한 dbPreset을 일관되게 사용하고, 서로 다른 DB 연결에 같은 preset 이름을
+  재사용하지 마세요. 이 부분 롤백 안내는 직접 DB 쿼리에 적용됩니다. 하나의 UpsertBuilder batch나
+  graph를 공유한다면 실패를 잡고 계속하지 말고 가장 바깥 트랜잭션까지 전파해 전체 작업을
+  롤백하세요.
 </Warning>
 
 ## 실전 예시
@@ -630,7 +610,7 @@ const wdb = this.getPuri("w");
 await wdb.table("users").insert({ ... });
 ```
 
-### 2. 트랜잭션 컨텍스트
+### 2. @transactional 내에서 사용
 
 `@transactional` 내에서는 트랜잭션이 자동으로 관리됩니다.
 

--- a/modules/docs/ko/api-reference/decorators/transactional.mdx
+++ b/modules/docs/ko/api-reference/decorators/transactional.mdx
@@ -185,7 +185,8 @@ async transfer(fromId: number, toId: number, amount: number) {
 
 ### 트랜잭션 중첩
 
-같은 dbPreset의 트랜잭션은 **재사용**됩니다:
+같은 dbPreset의 중첩 `@transactional` 호출은 **같은 DB 트랜잭션에 참여**합니다. 가장 바깥 호출이
+커밋과 롤백을 담당합니다:
 
 ```typescript
 class UserModelClass extends BaseModelClass {
@@ -217,7 +218,6 @@ class UserModelClass extends BaseModelClass {
 [DEBUG] new transaction context: w
 [DEBUG] transactional: UserModel.createProfile
 [DEBUG] reuse transaction context: w
-[DEBUG] delete transaction context: w
 ```
 
 ### 다른 Preset의 트랜잭션
@@ -290,39 +290,6 @@ async uploadAvatar() {
     .update({ avatar_url: url });
 
   return { url };
-}
-```
-
-## AsyncLocalStorage
-
-`@transactional`은 Node.js의 AsyncLocalStorage를 사용하여 트랜잭션 컨텍스트를 관리합니다.
-
-### 컨텍스트 생성
-
-```typescript
-// 트랜잭션이 없을 때
-@transactional()
-async save() {
-  // 1. 새 AsyncLocalStorage 컨텍스트 생성
-  // 2. 트랜잭션 시작
-  // 3. 메서드 실행
-  // 4. 커밋/롤백
-  // 5. 컨텍스트 정리
-}
-```
-
-### 컨텍스트 재사용
-
-```typescript
-@transactional()
-async parent() {
-  // 컨텍스트 생성
-  await this.child();  // 같은 컨텍스트 사용
-}
-
-@transactional()
-async child() {
-  // 부모의 컨텍스트 재사용
 }
 ```
 
@@ -477,7 +444,6 @@ async save() {
   // 자동 로그:
   // [DEBUG] transactional: UserModel.save
   // [DEBUG] new transaction context: w
-  // [DEBUG] delete transaction context: w
 }
 ```
 

--- a/modules/docs/ko/database/transactions/transactional-decorator.mdx
+++ b/modules/docs/ko/database/transactions/transactional-decorator.mdx
@@ -18,7 +18,7 @@ description: "메서드를 자동으로 트랜잭션으로 감싸기"
     트랜잭션 격리 수준 설정 동시성 제어
   </Card>
   <Card title="중첩 트랜잭션" icon="layer-group">
-    자동 컨텍스트 공유 Savepoint 지원
+    같은 preset의 DB 트랜잭션 Savepoint 자동 생성 안 함
   </Card>
 </CardGroup>
 
@@ -286,7 +286,10 @@ class UserModel extends BaseModelClass {
 
 ## 중첩 트랜잭션
 
-### 자동 컨텍스트 공유
+### 자동 트랜잭션 재사용
+
+같은 preset의 중첩 `@transactional` 호출은 하나의 DB 트랜잭션에 참여합니다. 같은 preset의 가장
+바깥 호출이 커밋과 롤백을 담당합니다.
 
 ```typescript
 class UserModel extends BaseModelClass {
@@ -298,7 +301,7 @@ class UserModel extends BaseModelClass {
     const [userId] = await wdb.table("users").insert(userData).returning("id");
 
     // 다른 @transactional 메서드 호출
-    // 같은 트랜잭션 컨텍스트 공유
+    // 같은 DB 트랜잭션에 참여
     await this.updateBio(userId, bio);
 
     return userId;
@@ -320,12 +323,12 @@ flowchart TD
     C --> D[User INSERT]
     D --> E[updateBio 호출]
     E --> F[@transactional 2]
-    F --> G{기존 트랜잭션?}
+    F --> G{같은 preset의 기존 트랜잭션?}
     G -->|Yes| H[같은 트랜잭션 재사용]
     G -->|No| I[새 트랜잭션 생성]
     H --> J[Bio UPDATE]
     J --> K[메서드 종료]
-    K --> L[COMMIT]
+    K --> L[같은 preset의 가장 바깥 호출 COMMIT]
 
     style C fill:#e8f5e9
     style H fill:#c8e6c9
@@ -336,221 +339,47 @@ flowchart TD
   **중첩 트랜잭션의 이점**: - 코드 재사용성 향상 - 메서드 조합 자유로움 - 트랜잭션 경계 자동 관리
 </Info>
 
-### 중첩 트랜잭션 메커니즘 상세
+### 에러와 Savepoint 의미
 
-Sonamu의 중첩 트랜잭션은 **트랜잭션 컨텍스트 공유** 방식으로 동작합니다.
-
-#### 트랜잭션 컨텍스트 공유
+같은 preset의 중첩 `@transactional` 호출은 바깥 DB 트랜잭션에 참여합니다. 새 트랜잭션이나
+Savepoint를 만들지 않으며, 같은 preset의 가장 바깥 호출이 커밋과 롤백을 담당합니다.
 
 ```typescript
-// 외부 트랜잭션
 @transactional()
 async outerMethod() {
   const wdb = this.getPuri("w");
+  await wdb.table("users").insert({ id: 1 });
 
-  // 여기서 트랜잭션 A가 시작됨
-  await wdb.table("users").insert({ ... });
+  try {
+    await this.innerMethod();
+  } catch (error) {
+    // 이 애플리케이션 에러를 잡으면 바깥 트랜잭션은 계속된다.
+    console.error(error);
+  }
 
-  // 내부 메서드 호출
-  await this.innerMethod();  // ← 트랜잭션 A를 공유
-
-  await wdb.table("logs").insert({ ... });
-
-  // 여기서 트랜잭션 A가 커밋됨
+  // 앞에서 성공한 작업과 함께 커밋될 수 있다.
+  await wdb.table("logs").insert({ action: "user_created" });
 }
 
 @transactional()
 async innerMethod() {
   const wdb = this.getPuri("w");
-
-  // 새 트랜잭션을 시작하지 않고, 외부 트랜잭션 A를 재사용
-  await wdb.table("profiles").insert({ ... });
-
-  // 여기서 커밋하지 않음 (외부 트랜잭션이 커밋)
+  await wdb.table("profiles").insert({ user_id: 1 });
+  throw new Error("Application validation failed");
 }
 ```
-
-**동작 원리**:
-
-1. `outerMethod` 실행 → 트랜잭션 A 시작
-2. `innerMethod` 호출 → 기존 트랜잭션 A 감지
-3. `innerMethod`는 새 트랜잭션을 시작하지 않고 A를 재사용
-4. `innerMethod` 종료 → 커밋하지 않음
-5. `outerMethod` 종료 → 트랜잭션 A 커밋
-
-#### Savepoint는 생성되지 않음
-
-Sonamu는 **Savepoint를 자동으로 생성하지 않습니다**. 모든 중첩된 메서드가 같은 트랜잭션을 공유하므로:
-
-```typescript
-@transactional()
-async methodA() {
-  const wdb = this.getPuri("w");
-
-  await wdb.table("users").insert({ id: 1 });
-
-  try {
-    await this.methodB();  // ← 실패하면?
-  } catch (error) {
-    // ⚠️ methodB가 실패해도 이미 전체 트랜잭션이 롤백됨
-    // Savepoint가 없으므로 users INSERT도 함께 롤백
-    console.error("Failed:", error);
-  }
-
-  // ❌ 여기는 실행되지 않음 (트랜잭션이 이미 롤백됨)
-  await wdb.table("logs").insert({ ... });
-}
-
-@transactional()
-async methodB() {
-  const wdb = this.getPuri("w");
-
-  throw new Error("Failed!");  // ← 전체 트랜잭션 롤백
-}
-```
-
-**결과**:
-
-- `methodB`에서 에러 발생 → 전체 트랜잭션 롤백
-- `methodA`의 users INSERT도 롤백됨
-- Savepoint가 없으므로 부분 롤백 불가
-
-#### Savepoint가 필요한 경우
-
-부분 롤백이 필요하면 **수동으로 Savepoint를 관리**해야 합니다:
-
-```typescript
-@transactional()
-async methodWithSavepoint() {
-  const wdb = this.getPuri("w");
-
-  // 기본 데이터 삽입
-  await wdb.table("users").insert({ id: 1, name: "John" });
-
-  // Savepoint 생성
-  await wdb.raw("SAVEPOINT sp1");
-
-  try {
-    // 위험한 작업
-    await wdb.table("profiles").insert({ user_id: 1, bio: "..." });
-
-    // 성공 시 Savepoint 해제
-    await wdb.raw("RELEASE SAVEPOINT sp1");
-  } catch (error) {
-    // 실패 시 Savepoint까지만 롤백
-    await wdb.raw("ROLLBACK TO SAVEPOINT sp1");
-    console.error("Profile creation failed, but user is saved");
-  }
-
-  // 로그는 항상 삽입
-  await wdb.table("logs").insert({ action: "user_created" });
-
-  // 전체 커밋
-}
-```
-
-**Savepoint 사용 시나리오**:
-
-- 선택적 작업이 실패해도 메인 작업은 성공시켜야 할 때
-- 여러 단계의 작업 중 일부만 롤백하고 싶을 때
-- 복잡한 비즈니스 로직에서 부분 실패 처리가 필요할 때
-
-#### 트랜잭션 컨텍스트 확인
-
-현재 실행 중인 트랜잭션이 있는지 확인하는 방법:
-
-```typescript
-import { DB } from "sonamu";
-
-@transactional()
-async checkContext() {
-  const wdb = this.getPuri("w");
-
-  // 트랜잭션 컨텍스트 가져오기
-  const txContext = DB.getTransactionContext();
-  const transaction = txContext.getTransaction("w");
-
-  if (transaction) {
-    console.log("현재 트랜잭션이 활성화되어 있습니다.");
-  } else {
-    console.log("트랜잭션이 없습니다.");
-  }
-}
-```
-
-#### 중첩 레벨 제한 없음
-
-Sonamu는 중첩 레벨에 제한이 없습니다:
-
-```typescript
-@transactional()
-async level1() {
-  await this.level2();  // OK
-}
-
-@transactional()
-async level2() {
-  await this.level3();  // OK
-}
-
-@transactional()
-async level3() {
-  await this.level4();  // OK
-}
-
-// 모두 같은 트랜잭션 컨텍스트 공유
-```
-
-#### 커밋 시점
-
-**오직 최상위 트랜잭션만** 커밋합니다:
-
-```typescript
-@transactional()
-async topLevel() {
-  // 트랜잭션 시작
-
-  await this.middleLevel();
-
-  // ✅ 여기서 커밋 (최상위)
-}
-
-@transactional()
-async middleLevel() {
-  await this.bottomLevel();
-
-  // ❌ 여기서 커밋하지 않음 (중첩)
-}
-
-@transactional()
-async bottomLevel() {
-  // 작업 수행
-
-  // ❌ 여기서도 커밋하지 않음 (중첩)
-}
-```
-
-**정리**:
-
-| 항목              | 동작                            |
-| ----------------- | ------------------------------- |
-| **트랜잭션 생성** | 최상위 메서드만 생성            |
-| **트랜잭션 공유** | 모든 중첩 메서드가 공유         |
-| **Savepoint**     | 자동 생성 안됨 (수동 관리 필요) |
-| **커밋**          | 최상위 메서드만 커밋            |
-| **롤백**          | 어디서든 에러 발생 시 전체 롤백 |
-| **중첩 레벨**     | 제한 없음                       |
 
 <Warning>
-  **중첩 트랜잭션 주의사항**: 1. **전체 롤백**: 중첩된 메서드에서 에러 발생 시 전체 트랜잭션이
-  롤백됨 2. **Savepoint 없음**: 부분 롤백이 필요하면 수동으로 Savepoint 관리 3. **커밋 시점**:
-  중첩된 메서드 종료 시 커밋되지 않음 (최상위만 커밋) 4. **에러 처리**: try-catch로 잡아도
-  트랜잭션은 이미 롤백된 상태
+  이 예시는 DB 문장이 성공한 뒤 발생한 애플리케이션 에러를 잡습니다. 바깥 트랜잭션은 계속되어
+  앞선 작업을 커밋할 수 있습니다. 반면 제약조건이나 SQL 실패 같은 PostgreSQL 문장 오류는 현재
+  트랜잭션을 중단하므로 catch만으로 다시 사용할 수 없습니다.
 </Warning>
 
 <Info>
-  **권장 사항**: - 간단한 중첩: `@transactional` 자동 공유 사용 - 복잡한 로직: 수동 Savepoint 관리
-  고려 - 에러 처리: 최상위 메서드에서 처리
+  실패 후에도 바깥 트랜잭션을 계속해야 하는 직접 DB 쿼리는 중첩
+  `getPuri("w").transaction(...)` Savepoint 안에서 실행하세요. 전체 작업을 원자적으로 처리해야
+  한다면 애플리케이션 에러를 같은 preset의 가장 바깥 `@transactional` 호출까지 전파해 모두
+  롤백하세요.
 </Info>
 
 ## @api와 함께 사용
@@ -662,8 +491,9 @@ async createUserComplex(data: UserSaveParams): Promise<number> {
 ## 주의사항
 
 <Warning>
-  **반드시 지켜야 할 사항**: 1. 메서드는 `async` 함수여야 함 2. `this.getPuri("r"/"w")`로 DB 접근 3. 에러는
-  throw로 전파 (자동 롤백) 4. 중첩 트랜잭션은 같은 컨텍스트 공유
+  **반드시 지켜야 할 사항**: 1. 메서드는 `async` 함수여야 함 2. `this.getPuri("r"/"w")`로 DB 접근 3.
+  애플리케이션 에러는 throw로 전파 (자동 롤백) 4. 같은 preset의 중첩 호출은 같은 DB 트랜잭션에
+  참여하며 가장 바깥 호출이 커밋/롤백
 </Warning>
 
 ### 흔한 실수
@@ -673,17 +503,17 @@ class UserModel extends BaseModelClass {
   // ❌ 잘못된 사용
   @transactional()
   async wrongUsage1(data: UserSaveParams): Promise<number> {
-    // getPuri를 다른 변수에 저장하지 말 것
-    const db = this.getPuri("w");
+    const wdb = this.getPuri("w");
 
-    // 에러를 catch로 숨기면 롤백 안 됨
+    wdb.ubRegister("users", data);
+    const [id] = await wdb.ubUpsert("users");
+
+    // 성공한 DB 작업 뒤의 애플리케이션 에러를 숨기면 해당 작업이 커밋될 수 있음
     try {
-      db.ubRegister("users", data);
-      const [id] = await db.ubUpsert("users");
-      return id;
+      throw new Error("Application validation failed");
     } catch (error) {
       console.error(error);
-      return 0; // ❌ 에러를 숨김 → 롤백 안 됨
+      return id;
     }
   }
 

--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/api/decorators.ts
+++ b/modules/sonamu/src/api/decorators.ts
@@ -396,9 +396,7 @@ export function transactional(options: TransactionalOptions = {}) {
         method: methodName,
       });
 
-      const existingContext = DB.transactionStorage.getStore();
-
-      // AsyncLocalStorage 컨텍스트 없거나 해당 preset의 트랜잭션이 없으면 새로 시작
+      // 해당 preset의 트랜잭션이 없으면 새 트랜잭션과 scope를 함께 시작한다.
       const startTransaction = async () => {
         const puri = this.getPuri(dbPreset);
 
@@ -406,33 +404,24 @@ export function transactional(options: TransactionalOptions = {}) {
           async (trx) => {
             this.logger.debug("new transaction context: {dbPreset}", { dbPreset });
             const trxWrapper = new PuriTransactionWrapper(trx, new UpsertBuilder());
-            // TransactionContext에 트랜잭션 저장
-            DB.getTransactionContext().setTransaction(dbPreset, trxWrapper);
 
-            try {
-              return await originalMethod.apply(this, args);
-            } finally {
-              // 트랜잭션 제거
-              this.logger.debug("delete transaction context: {dbPreset}", { dbPreset });
-              DB.getTransactionContext().deleteTransaction(dbPreset);
-            }
+            return DB.runWithTransactionScope(dbPreset, trxWrapper, () =>
+              originalMethod.apply(this, args),
+            );
           },
           { isolationLevel: isolation, readOnly },
         );
       };
 
-      // AsyncLocalStorage 컨텍스트가 없으면 새로 생성
-      if (!existingContext) {
-        return DB.runWithTransaction(startTransaction);
-      }
-
-      // 이미 AsyncLocalStorage 컨텍스트 안에 있는지 확인 후 해당 preset의 트랜잭션이 이미 있으면 재사용
-      if (existingContext?.getTransaction(dbPreset)) {
+      const existingTransaction = DB.transactionStorage.getStore()?.getTransaction(dbPreset);
+      if (existingTransaction) {
         this.logger.debug("reuse transaction context: {dbPreset}", { dbPreset });
-        return originalMethod.apply(this, args);
+        // 다른 preset이 안쪽에 있어도 이 메서드가 재사용한 트랜잭션을 현재 scope로 표시한다.
+        return DB.runWithTransactionScope(dbPreset, existingTransaction, () =>
+          originalMethod.apply(this, args),
+        );
       }
 
-      // 컨텍스트는 있지만 이 preset의 트랜잭션은 없는 경우 (같은 컨텍스트 내에서 실행)
       return startTransaction();
     };
 

--- a/modules/sonamu/src/database/__tests__/transaction-scope.test.ts
+++ b/modules/sonamu/src/database/__tests__/transaction-scope.test.ts
@@ -1,0 +1,227 @@
+import { type Knex } from "knex";
+import { describe, expect, it } from "vitest";
+
+import { type DBPreset, DBClass } from "../db";
+import { PuriTransactionWrapper } from "../puri-wrapper";
+import { UpsertBuilder } from "../upsert-builder";
+
+type TransactionScopeDB = DBClass & {
+  runWithTransactionScope?<T>(
+    preset: DBPreset,
+    transaction: PuriTransactionWrapper,
+    callback: () => Promise<T>,
+  ): Promise<T>;
+};
+
+function createTransactionWrapper(): PuriTransactionWrapper {
+  return new PuriTransactionWrapper({} as Knex.Transaction, new UpsertBuilder());
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function expectScopeRunner(db: TransactionScopeDB) {
+  expect(db.runWithTransactionScope).toBeTypeOf("function");
+  return db.runWithTransactionScope;
+}
+
+describe("DB.runWithTransactionScope", () => {
+  it("저장소가 없어도 루트 scope를 설치하고 콜백 결과를 반환한 뒤 정리한다", async () => {
+    const db = new DBClass() as TransactionScopeDB;
+    const transaction = createTransactionWrapper();
+    const runScope = expectScopeRunner(db);
+    if (!runScope) return;
+
+    let callbackContext: ReturnType<DBClass["getTransactionContext"]> | undefined;
+    const result = await runScope.call(db, "w", transaction, async () => {
+      callbackContext = db.getTransactionContext();
+      expect(db.transactionStorage.getStore()).toBe(callbackContext);
+      expect(callbackContext.getActiveTransaction()).toBe(transaction);
+      expect(callbackContext.getTransaction("w")).toBe(transaction);
+      return "완료";
+    });
+
+    expect(result).toBe("완료");
+    expect(callbackContext?.getActiveTransaction()).toBeUndefined();
+    expect(callbackContext?.getTransaction("w")).toBeUndefined();
+    expect(db.transactionStorage.getStore()).toBeUndefined();
+  });
+
+  it("scope 안에서 생성된 detached descendant가 완료된 자식 트랜잭션을 다시 사용하지 않는다", async () => {
+    const db = new DBClass() as TransactionScopeDB;
+    const parentTransaction = createTransactionWrapper();
+    const childTransaction = createTransactionWrapper();
+    const descendantReady = createDeferred();
+    const resumeDescendant = createDeferred();
+    const runScope = expectScopeRunner(db);
+    if (!runScope) return;
+
+    let parentContext: ReturnType<DBClass["getTransactionContext"]> | undefined;
+    let childContext: ReturnType<DBClass["getTransactionContext"]> | undefined;
+
+    await runScope.call(db, "r", parentTransaction, async () => {
+      parentContext = db.getTransactionContext();
+
+      let descendantPromise:
+        | Promise<{
+            context: ReturnType<DBClass["getTransactionContext"]>;
+            active: PuriTransactionWrapper | undefined;
+            write: PuriTransactionWrapper | undefined;
+            read: PuriTransactionWrapper | undefined;
+          }>
+        | undefined;
+
+      childContext = await runScope.call(db, "w", childTransaction, async () => {
+        const scopedContext = db.getTransactionContext();
+        descendantPromise = (async () => {
+          descendantReady.resolve();
+          await resumeDescendant.promise;
+          const context = db.getTransactionContext();
+          return {
+            context,
+            active: context.getActiveTransaction(),
+            write: context.getTransaction("w"),
+            read: context.getTransaction("r"),
+          };
+        })();
+
+        await descendantReady.promise;
+        return scopedContext;
+      });
+
+      expect(db.getTransactionContext()).toBe(parentContext);
+      expect(childContext.getActiveTransaction()).toBe(parentTransaction);
+      expect(childContext.getTransaction("w")).toBeUndefined();
+      expect(childContext.getTransaction("r")).toBe(parentTransaction);
+
+      resumeDescendant.resolve();
+      if (!descendantPromise) {
+        throw new Error("detached descendant가 생성되지 않았습니다");
+      }
+      const descendantResult = await descendantPromise;
+
+      expect(descendantResult.context).toBe(childContext);
+      expect(descendantResult.active).toBe(parentTransaction);
+      expect(descendantResult.write).toBeUndefined();
+      expect(descendantResult.read).toBe(parentTransaction);
+    });
+
+    expect(parentContext?.getActiveTransaction()).toBeUndefined();
+    expect(parentContext?.getTransaction("r")).toBeUndefined();
+    expect(childContext?.getActiveTransaction()).toBeUndefined();
+    expect(childContext?.getTransaction("r")).toBeUndefined();
+    expect(db.transactionStorage.getStore()).toBeUndefined();
+  });
+
+  it("같거나 다른 preset의 중첩 범위를 복원하고 같은 오류를 다시 던진다", async () => {
+    const db = new DBClass() as TransactionScopeDB;
+    const outer = createTransactionWrapper();
+    const samePresetInner = createTransactionWrapper();
+    const differentPresetInner = createTransactionWrapper();
+    const expectedError = new Error("의도한 scope 오류");
+    const runScope = expectScopeRunner(db);
+    if (!runScope) return;
+
+    await runScope.call(db, "w", outer, async () => {
+      const outerContext = db.getTransactionContext();
+      expect(outerContext.getActiveTransaction()).toBe(outer);
+
+      await runScope.call(db, "w", samePresetInner, async () => {
+        expect(db.getTransactionContext().getActiveTransaction()).toBe(samePresetInner);
+        expect(db.getTransactionContext().getTransaction("w")).toBe(samePresetInner);
+      });
+      expect(db.getTransactionContext()).toBe(outerContext);
+      expect(outerContext.getActiveTransaction()).toBe(outer);
+
+      await expect(
+        runScope.call(db, "fixture", differentPresetInner, async () => {
+          const innerContext = db.getTransactionContext();
+          expect(innerContext.getActiveTransaction()).toBe(differentPresetInner);
+          expect(innerContext.getTransaction("w")).toBe(outer);
+          expect(innerContext.getTransaction("fixture")).toBe(differentPresetInner);
+          throw expectedError;
+        }),
+      ).rejects.toBe(expectedError);
+
+      expect(db.getTransactionContext()).toBe(outerContext);
+      expect(outerContext.getActiveTransaction()).toBe(outer);
+      expect(outerContext.getTransaction("fixture")).toBeUndefined();
+    });
+
+    expect(db.transactionStorage.getStore()).toBeUndefined();
+  });
+
+  it("겹치는 sibling 범위가 완료 순서와 무관하게 서로의 활성 트랜잭션을 보지 않는다", async () => {
+    const db = new DBClass() as TransactionScopeDB;
+    const parentTransaction = createTransactionWrapper();
+    const firstTransaction = createTransactionWrapper();
+    const secondTransaction = createTransactionWrapper();
+    const firstReady = createDeferred();
+    const secondReady = createDeferred();
+    const firstExited = createDeferred();
+    const runScope = expectScopeRunner(db);
+    if (!runScope) return;
+
+    let firstContext: ReturnType<DBClass["getTransactionContext"]> | undefined;
+    let secondContext: ReturnType<DBClass["getTransactionContext"]> | undefined;
+
+    await runScope.call(db, "r", parentTransaction, async () => {
+      const parentContext = db.getTransactionContext();
+      const firstPromise = runScope.call(db, "w", firstTransaction, async () => {
+        firstReady.resolve();
+        await secondReady.promise;
+        return {
+          context: db.getTransactionContext(),
+          active: db.getTransactionContext().getActiveTransaction(),
+          write: db.getTransactionContext().getTransaction("w"),
+          inheritedRead: db.getTransactionContext().getTransaction("r"),
+        };
+      });
+
+      await firstReady.promise;
+      const secondPromise = runScope.call(db, "w", secondTransaction, async () => {
+        secondReady.resolve();
+        await firstExited.promise;
+        return {
+          context: db.getTransactionContext(),
+          active: db.getTransactionContext().getActiveTransaction(),
+          write: db.getTransactionContext().getTransaction("w"),
+          inheritedRead: db.getTransactionContext().getTransaction("r"),
+        };
+      });
+
+      const firstResult = await firstPromise;
+      firstExited.resolve();
+      const secondResult = await secondPromise;
+      firstContext = firstResult.context;
+      secondContext = secondResult.context;
+
+      expect(firstResult.context).not.toBe(secondResult.context);
+      expect(firstResult.active).toBe(firstTransaction);
+      expect(firstResult.write).toBe(firstTransaction);
+      expect(firstResult.inheritedRead).toBe(parentTransaction);
+      expect(secondResult.active).toBe(secondTransaction);
+      expect(secondResult.write).toBe(secondTransaction);
+      expect(secondResult.inheritedRead).toBe(parentTransaction);
+      expect(firstResult.context.getActiveTransaction()).toBe(parentTransaction);
+      expect(secondResult.context.getActiveTransaction()).toBe(parentTransaction);
+      expect(db.getTransactionContext()).toBe(parentContext);
+      expect(parentContext.getActiveTransaction()).toBe(parentTransaction);
+    });
+
+    expect(firstContext?.getActiveTransaction()).toBeUndefined();
+    expect(secondContext?.getActiveTransaction()).toBeUndefined();
+    expect(db.transactionStorage.getStore()).toBeUndefined();
+  });
+
+  it("기존 bootstrap helper를 런타임 API로 노출하지 않는다", () => {
+    const db = new DBClass();
+
+    expect(db).not.toHaveProperty("runWithTransaction");
+  });
+});

--- a/modules/sonamu/src/database/base-model.ts
+++ b/modules/sonamu/src/database/base-model.ts
@@ -67,6 +67,15 @@ export class BaseModelClass<
     return new PuriWrapper(db, new UpsertBuilder());
   }
 
+  private getSubsetQueryPuri(): PuriWrapper {
+    const activeTransaction = DB.getTransactionContext().getActiveTransaction();
+    if (activeTransaction) {
+      return activeTransaction;
+    }
+
+    return new PuriWrapper(this.getDB("r"), new UpsertBuilder());
+  }
+
   async destroy() {
     return DB.destroy();
   }
@@ -120,7 +129,7 @@ export class BaseModelClass<
       throw new Error("subsetQueries is not defined");
     }
 
-    const puriWrapper = new PuriWrapper(this.getDB("r"), new UpsertBuilder());
+    const puriWrapper = this.getSubsetQueryPuri();
     const qb = this.subsetQueries[subset]?.(puriWrapper);
 
     // NonAllowedAsSingleTable: 단일 테이블 컬럼 접근 방지용 마커
@@ -201,6 +210,8 @@ export class BaseModelClass<
     }
 
     const { num, page } = queryParams;
+    // 모든 로더가 root query와 같은 연결을 사용하도록 실행 시점의 knex에서 한 번만 파생한다.
+    const puriWrapper = new PuriWrapper(qb.knex, new UpsertBuilder());
 
     // COUNT 쿼리 실행 (queryMode: list일 때는 0 리턴)
     const total = await this.executeCountQuery(qb, queryParams, debug, optimizeCountQuery);
@@ -210,7 +221,15 @@ export class BaseModelClass<
     }
 
     // LIST 쿼리 실행
-    const computedRows = await this.executeListQuery(subset, qb, queryParams, num, page, debug);
+    const computedRows = await this.executeListQuery(
+      subset,
+      qb,
+      queryParams,
+      num,
+      page,
+      debug,
+      puriWrapper,
+    );
 
     // Enhancer 적용
     const enhancer = (params as any).enhancers?.[subset];
@@ -457,6 +476,7 @@ export class BaseModelClass<
     num: number,
     page: number,
     debug: boolean,
+    puriWrapper: PuriWrapper,
   ): Promise<any[]> {
     if (params.queryMode === "count") {
       return [];
@@ -478,7 +498,7 @@ export class BaseModelClass<
     // 로더 처리
     const loaders = (this.loaderQueries as any)[subset];
     if (loaders && Array.isArray(loaders)) {
-      unloadedRows = await this.processLoaders(unloadedRows, loaders, debug);
+      unloadedRows = await this.processLoaders(unloadedRows, loaders, debug, puriWrapper);
     }
 
     return this.hydrate(unloadedRows);
@@ -487,12 +507,17 @@ export class BaseModelClass<
   /**
    * 재귀적 로더 처리
    */
-  private async processLoaders(rows: any[], loaders: any[], debug: boolean): Promise<any[]> {
+  private async processLoaders(
+    rows: any[],
+    loaders: any[],
+    debug: boolean,
+    puriWrapper: PuriWrapper,
+  ): Promise<any[]> {
     for (const resolveLoader of loaders) {
       const { as, refId, qb: resolveLoaderQbFn, loaders: nestedLoaders } = resolveLoader;
 
       const resolveLoaderQb = resolveLoaderQbFn(
-        new PuriWrapper(this.getDB("r"), new UpsertBuilder()),
+        puriWrapper,
         rows.map((row) => row[refId]),
       );
 
@@ -504,7 +529,7 @@ export class BaseModelClass<
 
       // 중첩 loaders가 있으면 재귀 처리
       if (nestedLoaders && nestedLoaders.length > 0) {
-        loadedRows = await this.processLoaders(loadedRows, nestedLoaders, debug);
+        loadedRows = await this.processLoaders(loadedRows, nestedLoaders, debug, puriWrapper);
       }
 
       const subRowGroups = group(loadedRows, (row) => row.refId);

--- a/modules/sonamu/src/database/db.ts
+++ b/modules/sonamu/src/database/db.ts
@@ -6,6 +6,7 @@ import { type Knex } from "knex";
 import { type DatabaseConfig, type SonamuConfig } from "../api/config";
 import { getSonamuEnvironment, type EnvironmentSnapshots, type SonamuEnvironment } from "../env";
 import { createKnexInstance } from "./knex";
+import { type PuriTransactionWrapper } from "./puri-wrapper";
 import { TransactionContext } from "./transaction-context";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -155,8 +156,22 @@ export class DBClass {
 
   public transactionStorage = new AsyncLocalStorage<TransactionContext>();
 
-  public runWithTransaction<T>(callback: () => Promise<T>): Promise<T> {
-    return this.transactionStorage.run(new TransactionContext(), callback);
+  public runWithTransactionScope<T>(
+    preset: DBPreset,
+    transaction: PuriTransactionWrapper,
+    callback: () => Promise<T>,
+  ): Promise<T> {
+    const parentContext = this.transactionStorage.getStore();
+    const transactionContext = new TransactionContext(parentContext, { preset, transaction });
+
+    return this.transactionStorage.run(transactionContext, async () => {
+      try {
+        return await callback();
+      } finally {
+        // detached descendant가 완료된 트랜잭션을 다시 사용하지 않도록 local scope를 비운다.
+        transactionContext.clearLocal();
+      }
+    });
   }
 
   setConfig(dbConfig: SonamuDBConfig): void {

--- a/modules/sonamu/src/database/puri-wrapper.ts
+++ b/modules/sonamu/src/database/puri-wrapper.ts
@@ -99,11 +99,8 @@ export class PuriWrapper<TSchema extends DatabaseSchemaExtend = DatabaseSchemaEx
   ): Promise<T> {
     const { isolation, readOnly, dbPreset = "w" } = options;
 
-    // @transactional 데코레이터와 동일한 로직: 이미 트랜잭션 컨텍스트가 있는지 확인
     const { DB } = await import("./db");
-    const existingContext = DB.transactionStorage.getStore();
 
-    // AsyncLocalStorage 컨텍스트가 없거나 해당 preset의 트랜잭션이 없으면 새로 시작
     const startTransaction = async (
       knex: Knex | Knex.Transaction,
       upsertBuilder: UpsertBuilder,
@@ -112,33 +109,19 @@ export class PuriWrapper<TSchema extends DatabaseSchemaExtend = DatabaseSchemaEx
         async (trx) => {
           const trxWrapper = new PuriTransactionWrapper(trx, upsertBuilder);
 
-          // TransactionContext에 트랜잭션 저장
-          DB.getTransactionContext().setTransaction(dbPreset, trxWrapper);
-
-          try {
-            return await callback(trxWrapper);
-          } finally {
-            // 트랜잭션 제거
-            DB.getTransactionContext().deleteTransaction(dbPreset);
-          }
+          return DB.runWithTransactionScope(dbPreset, trxWrapper, () => callback(trxWrapper));
         },
         { isolationLevel: isolation, readOnly },
       );
     };
 
-    // AsyncLocalStorage 컨텍스트가 없으면 새로 생성
-    if (!existingContext) {
-      return DB.runWithTransaction(() => startTransaction(this.knex, this.upsertBuilder));
+    const existingTrx = DB.transactionStorage.getStore()?.getTransaction(dbPreset);
+    if (existingTrx) {
+      // 같은 preset의 중첩 트랜잭션은 기존 연결에서 SAVEPOINT로 시작한다.
+      return startTransaction(existingTrx.trx, existingTrx.upsertBuilder);
     }
 
-    // 해당 preset의 트랜잭션이 이미 있으면 SAVEPOINT로 중첩 트랜잭션 생성
-    const existingTrx = existingContext.getTransaction(dbPreset);
-    if (existingTrx) {
-      return startTransaction(existingTrx.trx, existingTrx.upsertBuilder);
-    } else {
-      // 컨텍스트는 있지만 이 preset의 트랜잭션은 없는 경우 (같은 컨텍스트 내에서 실행)
-      return startTransaction(this.knex, this.upsertBuilder);
-    }
+    return startTransaction(this.knex, this.upsertBuilder);
   }
 
   ubRegister<TTable extends TableName<TSchema>>(

--- a/modules/sonamu/src/database/transaction-context.ts
+++ b/modules/sonamu/src/database/transaction-context.ts
@@ -2,17 +2,25 @@ import { type DBPreset } from "./db";
 import { type PuriTransactionWrapper } from "./puri-wrapper";
 
 export class TransactionContext {
-  private transactions: Map<DBPreset, PuriTransactionWrapper> = new Map();
+  constructor(
+    private readonly parent?: TransactionContext,
+    private local?: {
+      preset: DBPreset;
+      transaction: PuriTransactionWrapper;
+    },
+  ) {}
 
   getTransaction(preset: DBPreset): PuriTransactionWrapper | undefined {
-    return this.transactions.get(preset);
+    return this.local?.preset === preset
+      ? this.local.transaction
+      : this.parent?.getTransaction(preset);
   }
 
-  setTransaction(preset: DBPreset, trx: PuriTransactionWrapper): void {
-    this.transactions.set(preset, trx);
+  getActiveTransaction(): PuriTransactionWrapper | undefined {
+    return this.local?.transaction ?? this.parent?.getActiveTransaction();
   }
 
-  deleteTransaction(preset: DBPreset): void {
-    this.transactions.delete(preset);
+  clearLocal(): void {
+    this.local = undefined;
   }
 }


### PR DESCRIPTION
## 배경

`@transactional()` 메서드 안에서 `findMany`를 호출하면 현재 트랜잭션이 아닌 별도 read 연결을 사용함
→ 같은 트랜잭션에서 수정한 미커밋 데이터를 조회하지 못해, 트랜잭션 내에서 수정 전후 상태 비교가 동작하지 않음

* e.g. row를 `FOR UPDATE`로 잠근 뒤 데이터를 변경하고 `findMany`를 수행하면 변경 전의 값이 조회됨

## 목표

* findMany 내의 count/list/loader 등 쿼리가 트랜잭션 연결을 사용하도록 변경
* 기존 트랜잭션 동작이 변경되어서는 안됨

## 작업 내역

* 기존 `TransactionContext`의 preset별 Map 구조를 부모-자식 scope 체인 구조로 변경
  * 각 스코프가 자신의 preset과 트랜잭션을 보유
  * preset별 트랜잭션 조회와 가장 가까운 활성 트랜잭션 조회 분리
  * 중첩 scope 종료 시 부모 scope로 복귀
* `DB.runWithTransaction()`을 제거하고 `DB.runWithTransactionScope()` 도입
  * 트랜잭션 wrapper의 라이프사이클 관리 책임을 모음
  * scope 생성, 상속, 성공/실패 로직을 관리
* 서브셋 쿼리의 puri wrapper 생성 구조 변경
  * 변경 전: 항상 read preset으로 새로운 puri wrapper 생성
  * 변경 후: 활성 트랜잭션이 있으면 그거 사용, 없을 때만 read로 생성
* loader별 wrapper 생성 구조 제거
  * 기존 서브셋 로더는 매번 새로운 puri wrapper를 생성했었음. 최초 한 번만 생성하고, 재사용하는 방식으로 변경
* 문서 내용 정리
