### PR TITLE
[sonamu] fix(SON-522): app mutation hook의 namespace 참조 방식 개선

### DIFF
--- a/examples/miomock/api/sonamu.lock
+++ b/examples/miomock/api/sonamu.lock
@@ -325,7 +325,7 @@
   },
   {
     "path": "web/src/services/services.generated.ts",
-    "checksum": "55f9849c261ad4ef41739f6b206d1e3ed2242b0b"
+    "checksum": "e1edd2098242b9f3a4d2579f3fadb60dcd95db19"
   },
   {
     "path": "web/src/services/session/session.types.ts",

--- a/examples/miomock/web/src/services/services.generated.ts
+++ b/examples/miomock/web/src/services/services.generated.ts
@@ -185,7 +185,7 @@ export namespace UserService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: UserSaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: UserSaveParams[] }) => UserService.save(params.spa),
     });
 
   export async function del(ids: string[]): Promise<number> {
@@ -198,7 +198,7 @@ export namespace UserService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: string[] }) => del(params.ids),
+      mutationFn: (params: { ids: string[] }) => UserService.del(params.ids),
     });
 
   export async function getMyIP(): Promise<{ ip: string }> {
@@ -373,7 +373,7 @@ export namespace TagService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: TagSaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: TagSaveParams[] }) => TagService.save(params.spa),
     });
 
   export async function del(ids: number[]): Promise<number> {
@@ -386,7 +386,7 @@ export namespace TagService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: number[] }) => del(params.ids),
+      mutationFn: (params: { ids: number[] }) => TagService.del(params.ids),
     });
 
   export async function cached(): Promise<TagSubsetMapping["A"]> {
@@ -557,7 +557,7 @@ export namespace SyncFixtureService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: SyncFixtureSaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: SyncFixtureSaveParams[] }) => SyncFixtureService.save(params.spa),
     });
 
   export async function del(ids: number[]): Promise<number> {
@@ -570,7 +570,7 @@ export namespace SyncFixtureService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: number[] }) => del(params.ids),
+      mutationFn: (params: { ids: number[] }) => SyncFixtureService.del(params.ids),
     });
 }
 
@@ -678,7 +678,7 @@ export namespace ProjectService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: ProjectSaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: ProjectSaveParams[] }) => ProjectService.save(params.spa),
     });
 
   export async function del(ids: number[]): Promise<number> {
@@ -691,7 +691,7 @@ export namespace ProjectService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: number[] }) => del(params.ids),
+      mutationFn: (params: { ids: number[] }) => ProjectService.del(params.ids),
     });
 
   export function useAsk(
@@ -863,7 +863,7 @@ export namespace MilestoneService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: MilestoneSaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: MilestoneSaveParams[] }) => MilestoneService.save(params.spa),
     });
 
   export async function del(ids: number[]): Promise<number> {
@@ -876,7 +876,7 @@ export namespace MilestoneService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: number[] }) => del(params.ids),
+      mutationFn: (params: { ids: number[] }) => MilestoneService.del(params.ids),
     });
 
   export async function complete(id: number): Promise<MilestoneSubsetMapping["A"]> {
@@ -889,7 +889,7 @@ export namespace MilestoneService {
 
   export const useCompleteMutation = () =>
     useMutation({
-      mutationFn: (params: { id: number }) => complete(params.id),
+      mutationFn: (params: { id: number }) => MilestoneService.complete(params.id),
     });
 
   export async function uncomplete(id: number): Promise<MilestoneSubsetMapping["A"]> {
@@ -902,7 +902,7 @@ export namespace MilestoneService {
 
   export const useUncompleteMutation = () =>
     useMutation({
-      mutationFn: (params: { id: number }) => uncomplete(params.id),
+      mutationFn: (params: { id: number }) => MilestoneService.uncomplete(params.id),
     });
 }
 
@@ -1007,7 +1007,7 @@ export namespace FileService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: FileSaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: FileSaveParams[] }) => FileService.save(params.spa),
     });
 
   export async function del(ids: number[]): Promise<number> {
@@ -1020,7 +1020,7 @@ export namespace FileService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: number[] }) => del(params.ids),
+      mutationFn: (params: { ids: number[] }) => FileService.del(params.ids),
     });
 
   export async function upload(
@@ -1046,7 +1046,7 @@ export namespace FileService {
     },
   ) =>
     useMutation({
-      mutationFn: (params: { files: File[] }) => upload(params.files),
+      mutationFn: (params: { files: File[] }) => FileService.upload(params.files),
       retry: false,
       ...options,
     });
@@ -1080,7 +1080,7 @@ export namespace FileService {
   ) =>
     useMutation({
       mutationFn: (params: { params: { category: string }; files: File[] }) =>
-        inlineUpload(params.params, params.files),
+        FileService.inlineUpload(params.params, params.files),
       retry: false,
       ...options,
     });
@@ -1117,7 +1117,7 @@ export namespace FileService {
   ) =>
     useMutation({
       mutationFn: (params: { params: string; files: File[] }) =>
-        inlineUploadFlat(params.params, params.files),
+        FileService.inlineUploadFlat(params.params, params.files),
       retry: false,
       ...options,
     });
@@ -1157,7 +1157,7 @@ export namespace FileService {
   ) =>
     useMutation({
       mutationFn: (params: { params: { name: string }; files: File[] }) =>
-        testBufferUpload(params.params, params.files),
+        FileService.testBufferUpload(params.params, params.files),
       retry: false,
       ...options,
     });
@@ -1197,7 +1197,7 @@ export namespace FileService {
   ) =>
     useMutation({
       mutationFn: (params: { params: { name: string }; files: File[] }) =>
-        testStreamUpload(params.params, params.files),
+        FileService.testStreamUpload(params.params, params.files),
       retry: false,
       ...options,
     });
@@ -1310,7 +1310,7 @@ export namespace EmployeeService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: EmployeeSaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: EmployeeSaveParams[] }) => EmployeeService.save(params.spa),
     });
 
   export async function del(ids: number[]): Promise<number> {
@@ -1323,7 +1323,7 @@ export namespace EmployeeService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: number[] }) => del(params.ids),
+      mutationFn: (params: { ids: number[] }) => EmployeeService.del(params.ids),
     });
 }
 
@@ -1463,7 +1463,7 @@ export namespace DocumentService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: DocumentSaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: DocumentSaveParams[] }) => DocumentService.save(params.spa),
     });
 
   export async function del(ids: number[]): Promise<number> {
@@ -1476,7 +1476,7 @@ export namespace DocumentService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: number[] }) => del(params.ids),
+      mutationFn: (params: { ids: number[] }) => DocumentService.del(params.ids),
     });
 }
 
@@ -1590,7 +1590,7 @@ export namespace DepartmentService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: DepartmentSaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: DepartmentSaveParams[] }) => DepartmentService.save(params.spa),
     });
 
   export async function del(ids: number[]): Promise<number> {
@@ -1603,7 +1603,7 @@ export namespace DepartmentService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: number[] }) => del(params.ids),
+      mutationFn: (params: { ids: number[] }) => DepartmentService.del(params.ids),
     });
 }
 
@@ -1774,7 +1774,7 @@ export namespace CompanyService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: CompanySaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: CompanySaveParams[] }) => CompanyService.save(params.spa),
     });
 
   export async function del(ids: number[]): Promise<number> {
@@ -1787,7 +1787,7 @@ export namespace CompanyService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: number[] }) => del(params.ids),
+      mutationFn: (params: { ids: number[] }) => CompanyService.del(params.ids),
     });
 }
 
@@ -2014,7 +2014,7 @@ export namespace AuditEventService {
 
   export const useSaveMutation = () =>
     useMutation({
-      mutationFn: (params: { spa: AuditEventSaveParams[] }) => save(params.spa),
+      mutationFn: (params: { spa: AuditEventSaveParams[] }) => AuditEventService.save(params.spa),
     });
 
   export async function del(ids: number[]): Promise<number> {
@@ -2027,7 +2027,7 @@ export namespace AuditEventService {
 
   export const useDelMutation = () =>
     useMutation({
-      mutationFn: (params: { ids: number[] }) => del(params.ids),
+      mutationFn: (params: { ids: number[] }) => AuditEventService.del(params.ids),
     });
 }
 

--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/template/__tests__/services.template.mutation.test.ts
+++ b/modules/sonamu/src/template/__tests__/services.template.mutation.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { Sonamu } from "../../api";
+import { type ExtendedApi } from "../../api/decorators";
+import { Template__services } from "../implementations/services.template";
+
+describe("Template__services mutation hooks", () => {
+  let originalConfig: unknown;
+  let originalSyncer: unknown;
+
+  beforeEach(() => {
+    originalConfig = Reflect.get(Sonamu, "_config");
+    originalSyncer = Reflect.get(Sonamu, "_syncer");
+    Reflect.set(Sonamu, "_config", {
+      api: {
+        route: {
+          prefix: "/api",
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    Reflect.set(Sonamu, "_config", originalConfig);
+    Reflect.set(Sonamu, "_syncer", originalSyncer);
+  });
+
+  const renderServices = (apis: ExtendedApi[]) => {
+    Reflect.set(Sonamu, "_syncer", { apis });
+    return new Template__services().render({}).body;
+  };
+
+  it("파라미터가 있는 일반 mutation에서 namespace와 인자 순서를 유지한다", () => {
+    const body = renderServices([
+      {
+        modelName: "CaseModel",
+        methodName: "leave",
+        path: "/case/leave",
+        options: {
+          httpMethod: "POST",
+          clients: ["tanstack-mutation"],
+        },
+        typeParameters: [],
+        parameters: [
+          { name: "caseId", type: "number", optional: false },
+          { name: "notify", type: "boolean", optional: false },
+        ],
+        returnType: {
+          t: "ref",
+          id: "Promise",
+          args: ["boolean"],
+        },
+      },
+    ]);
+
+    expect(body).toContain(`export const useLeaveMutation = () => useMutation({
+  mutationFn: (params: { caseId: number, notify: boolean }) => CaseService.leave(params.caseId, params.notify)
+});`);
+    expect(body).not.toContain(
+      "mutationFn: (params: { caseId: number, notify: boolean }) => leave(params.caseId, params.notify)",
+    );
+  });
+
+  it("파라미터가 없는 일반 mutation에서 params: void 타입을 유지한다", () => {
+    const body = renderServices([
+      {
+        modelName: "CaseModel",
+        methodName: "refresh",
+        path: "/case/refresh",
+        options: {
+          httpMethod: "POST",
+          clients: ["tanstack-mutation"],
+        },
+        typeParameters: [],
+        parameters: [],
+        returnType: {
+          t: "ref",
+          id: "Promise",
+          args: ["void"],
+        },
+      },
+    ]);
+
+    expect(body).toContain(`export const useRefreshMutation = () => useMutation({
+  mutationFn: (params: void) => CaseService.refresh()
+});`);
+    expect(body).not.toContain("mutationFn: (params: void) => refresh()");
+  });
+
+  it("파일만 받는 multipart mutation에서 namespace와 mutation 옵션을 유지한다", () => {
+    const body = renderServices([
+      {
+        modelName: "VoiceFrame",
+        methodName: "uploadRecording",
+        path: "/voice/uploadRecording",
+        options: {
+          httpMethod: "POST",
+          clients: ["axios-multipart", "tanstack-mutation-multipart"],
+        },
+        typeParameters: [],
+        parameters: [],
+        returnType: {
+          t: "ref",
+          id: "Promise",
+          args: ["string"],
+        },
+      },
+    ]);
+
+    expect(body).toContain(`export const useUploadRecordingMutation = (
+  options?: UseMutationOptions<string, Error, { files: File[] }> & {
+    onUploadProgress?: (e: AxiosProgressEvent) => void;
+  }
+) => useMutation({
+  mutationFn: (params: { files: File[] }) => VoiceService.uploadRecording(params.files),
+  retry: false,
+  ...options,
+});`);
+    expect(body).not.toContain(
+      "mutationFn: (params: { files: File[] }) => uploadRecording(params.files)",
+    );
+  });
+
+  it("API 파라미터와 파일을 받는 multipart mutation에서 namespace와 인자 순서를 유지한다", () => {
+    const body = renderServices([
+      {
+        modelName: "VoiceFrame",
+        methodName: "transcript",
+        path: "/voice/transcript",
+        options: {
+          httpMethod: "POST",
+          clients: ["axios-multipart", "tanstack-mutation-multipart"],
+        },
+        typeParameters: [],
+        parameters: [
+          {
+            name: "params",
+            type: {
+              t: "object",
+              props: [
+                { name: "language", type: "string", optional: false },
+                { name: "speakerCount", type: "number", optional: false },
+              ],
+            },
+            optional: false,
+          },
+        ],
+        returnType: {
+          t: "ref",
+          id: "Promise",
+          args: ["number"],
+        },
+      },
+    ]);
+
+    expect(body).toContain(`export const useTranscriptMutation = (
+  options?: UseMutationOptions<number, Error, { params: { language: string, speakerCount: number }, files: File[] }> & {
+    onUploadProgress?: (e: AxiosProgressEvent) => void;
+  }
+) => useMutation({
+  mutationFn: (params: { params: { language: string, speakerCount: number }, files: File[] }) => VoiceService.transcript(params.params, params.files),
+  retry: false,
+  ...options,
+});`);
+    expect(body).not.toContain(
+      "mutationFn: (params: { params: { language: string, speakerCount: number }, files: File[] }) => transcript(params.params, params.files)",
+    );
+  });
+});

--- a/modules/sonamu/src/template/implementations/services.template.ts
+++ b/modules/sonamu/src/template/implementations/services.template.ts
@@ -353,7 +353,7 @@ export const ${infiniteHookName} = ${typeParamsDef}(${paramsDef}${
           functions.push(
             `
 export const use${hookName}Mutation = ${typeParamsDef}() => useMutation({
-  mutationFn: (params: ${mutationParamType}) => ${methodName}(${mutationParamNames})
+  mutationFn: (params: ${mutationParamType}) => ${modelName}Service.${methodName}(${mutationParamNames})
 });
           `.trim(),
           );
@@ -378,8 +378,8 @@ export const use${hookName}Mutation = ${typeParamsDef}() => useMutation({
           // mutationFn 호출 파라미터
           const mutationFnCall =
             paramsWithoutContext.length > 0
-              ? `${methodName}(params.params, params.files)`
-              : `${methodName}(params.files)`;
+              ? `${modelName}Service.${methodName}(params.params, params.files)`
+              : `${modelName}Service.${methodName}(params.files)`;
 
           functions.push(
             `


### PR DESCRIPTION
> [!NOTE]
> 한 줄 요약: React Compiler를 사용하는 환경에서 `services.generated.ts`의 mutation hook 사용 불가 이슈 해결


## 배경 및 문제 상황

Sonamu가 생성하는 mutation hook은 namespace 내부 API 메서드를 bare identifier로 참조하고 있음.

```ts
export namespace CaseMemberService {
  export async function leave(caseId: string) {
    // API 요청
  }

  export const useLeaveMutation = () =>
    useMutation({
      mutationFn: (params) => leave(params.caseId),
    });
}
```

React Compiler를 사용하지 않는 환경에서는 callback이 namespace 내부에서 실행되므로 정상 동작함. 그러나 React Compiler가 `mutationFn`을 namespace 밖으로 hoist하면 다음과 같은 형태가 됨.

```ts
function _temp(params) {
  return leave(params.caseId);
}
```

TypeScript namespace는 JavaScript에서 IIFE로 변환되므로 `leave`는 namespace 외부에서 직접 참조할 수 없음. 이 상태에서 callback이 실행되면 Hermes에서 아래 오류가 발생하고 API 요청도 전송되지 않음.

```text
ReferenceError: Property 'leave' doesn't exist
```

일반 mutation과 multipart mutation이 모두 같은 방식으로 메서드를 참조하고 있어 두 생성 경로가 동일하게 영향받음.

## 발생 시점

* 2025-12-23: 일반 `tanstack-mutation` 생성 방식 도입 (`743783b3`)
* 2026-01-08: `tanstack-mutation-multipart` 지원 도입 (`742950c6`)
* 2026-01-12: 현재 multipart mutation 파라미터 호출 구조 적용 (`6f9a4c2a`)
* 2026-06-08: MedPath App이 Expo SDK 56 적용과 함께 React Compiler 활성화 (`e8ab5985`)
* 2026-08-03: [MED-629] 증례 나가기 기능의 `useLeaveMutation().mutateAsync()` 실행 시 오류를 명확히 확인

## 수정 방식

mutation callback이 실행되는 위치와 무관하게 API 메서드를 찾을 수 있도록 namespace-qualified 호출을 생성함.

```ts
mutationFn: (params) =>
  CaseMemberService.leave(params.caseId)
```

다음 두 생성 경로를 함께 수정함.

* `tanstack-mutation`
* `tanstack-mutation-multipart`

변경 대상은 생성된 callback 내부의 메서드 참조 방식뿐임. 기존 hook 이름, 파라미터 타입, 인자 순서, 반환 타입, upload 옵션 및 API 요청 방식은 유지되므로 호출부 변경은 필요하지 않음. React Compiler를 사용하지 않는 환경에서도 기존과 동일하게 동작함.
